### PR TITLE
Standardize Geometry Representation in API Response and Backend Processing 

### DIFF
--- a/api/api.yaml
+++ b/api/api.yaml
@@ -115,14 +115,14 @@ paths:
             type: boolean
       responses:
         '200':
-          description: Geometry of the region
+          description: Geometry of the region, in GeoJSON format, always a MultiPolygon
           content:
             application/json:
               schema:
                 type: object
                 properties:
                   geometry:
-                    type: string
+                    $ref: '#/components/schemas/MultiPolygonGeometry'
         '204':
           description: Region has no geometry
         '400':
@@ -327,6 +327,58 @@ components:
           type: integer
         hasSubregions:
           type: boolean
+
+    CRS:
+      type: object
+      properties:
+        type:
+          type: string
+          enum: [ name ]
+          description: Type of CRS; here, 'name' refers to a named CRS.
+        properties:
+          type: object
+          properties:
+            name:
+              type: string
+              description: Name of the CRS used; typically an EPSG code.
+              example: "EPSG:4326"
+
+    Coordinate:
+      type: array
+      minItems: 2
+      maxItems: 2
+      items:
+        type: number
+        format: double
+      description: A longitude and latitude pair.
+
+    LinearRing:
+      type: array
+      items:
+        $ref: '#/components/schemas/Coordinate'
+      description: A closed LineString, with four or more positions. The first and last positions are equivalent (they represent the same point).
+
+    Polygon:
+      type: array
+      items:
+        $ref: '#/components/schemas/LinearRing'
+      description: An array of LinearRings where the first element is the outer boundary and any subsequent elements are inner boundaries (holes).
+
+    MultiPolygonGeometry:
+      type: object
+      properties:
+        type:
+          type: string
+          enum: [ MultiPolygon ]
+          description: Type of the geometry; for this API, always 'MultiPolygon'.
+        coordinates:
+          type: array
+          items:
+            $ref: '#/components/schemas/Polygon'
+          description: An array of Polygons that make up the MultiPolygon.
+        crs:
+          $ref: '#/components/schemas/CRS'
+        description: A GeoJSON object representing the geometry of the region as a MultiPolygon.
 
     Experience:
       type: object

--- a/backend/src/controllers/regionController.js
+++ b/backend/src/controllers/regionController.js
@@ -17,6 +17,18 @@ exports.getGeometry = async (req, res) => {
 
     let geometry = region.geom;
 
+    // Convert any geometry to MultiPolygon if it exists
+    if (geometry) {
+        geometry = await sequelize.query(
+            `SELECT ST_AsGeoJSON(ST_Multi(:geometry)) as geometry`, {
+                replacements: { geometry: geometry },
+                type: QueryTypes.SELECT
+            }
+        );
+
+        geometry = geometry.length > 0 ? geometry[0].geometry : null;
+    }
+
     if (!geometry) {
         if (!resolveEmpty) {
             return res.status(204).json({ message: 'Geometry not found' });


### PR DESCRIPTION
This PR introduces changes to both the API specification and the backend processing of region geometries. The goal is to standardize the geometry data as MultiPolygon in GeoJSON format, ensuring consistency and reliability in the data we expose to our API consumers.

Changes
API Specification Update
The Swagger API specification (api.yaml) has been enhanced to define the expected geometry format strictly as a MultiPolygon. Additional descriptions have been added for each level of the array to clarify the structure of the GeoJSON object and the CRS being used.
The 200 response now references the newly defined MultiPolygonGeometry schema, which details the nested array structures and the CRS object.

Backend Geometry Processing Update
The regionController.js has been updated to convert any retrieved geometry to a MultiPolygon format. This ensures that the data conforms to the updated API specification and that clients can reliably process the geometry data.
Utilizing the ST_Multi function from PostGIS, the backend now uniformly processes all geometries as MultiPolygon, regardless of their initial format in the database.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated API responses to include detailed GeoJSON formatted MultiPolygon geometries.
	- Introduced a new coordinate reference system representation.
- **Bug Fixes**
	- Enhanced the `getGeometry` function to handle cases where `geometry` is not found or is empty, improving error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->