### PR TITLE
Refactor Docker setup to allow optional init and external GADM file.

### DIFF
--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -29,10 +29,6 @@ RUN pip3 install -r /tmp/requirements.txt
 # Make the init script executable
 RUN chmod +x /docker-entrypoint-initdb.d/init-db.sh
 
-# Copy the GADM file to the container
-ARG GADM_FILE
-COPY $GADM_FILE /data/gadm/gadm.gpkg
-
 # Define a volume
 VOLUME /data/gadm
 

--- a/deployment/Makefile
+++ b/deployment/Makefile
@@ -36,10 +36,13 @@ build-db: check-env
 	# Check if the database is already built
 	@$(DC) images | grep db >/dev/null || $(DC) build db
 
-run-db:
-	$(DC) up -d db
+run-db: build-db
+	export RUN_INIT=true && $(DC) up -d db
 
-init-db: check-gadm-file build-db run-db
+just-run-db: build-db
+	export RUN_INIT=false && $(DC) up -d db
+
+init-db: check-gadm-file run-db
 	@echo "Database initialized and GPKG file imported."
 	# Check if the database is ready and has the required tables
 	@until $(DC) exec -T db pg_isready -U $(DB_USER) -d $(DB_NAME) > /dev/null 2>&1 && \
@@ -83,4 +86,4 @@ start-all: init-db build run migrate-db
 	@echo "Frontend is running on host port ${HOST_FRONTEND_PORT}"
 	@echo "All services are up and the database is initialized and migrated."
 
-.PHONY: build run init-db clean-container clean-image clean-all reinit-db clean-volume migrate start-all
+.PHONY: build run init-db clean-container clean-image clean-all reinit-db clean-volume migrate start-all just-run-db

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -5,17 +5,16 @@ services:
     container_name: tyr-db
     build:
       context: .
-      args:
-        GADM_FILE: ${GADM_FILE}
     environment:
       POSTGRES_DB: ${DB_NAME}
       POSTGRES_USER: ${DB_USER}
       POSTGRES_PASSWORD: ${DB_PASSWORD}
+      RUN_INIT: ${RUN_INIT}
     ports:
       - "${HOST_DB_PORT}:${DEFAULT_POSTGRES_PORT}"
     volumes:
       - postgres_data:/var/lib/postgresql/data
-      - gadm_data:/data/gadm
+      - ${GADM_FILE}:/data/gadm/gadm.gpkg
 
   backend:
     container_name: tyr-backend

--- a/deployment/init-db.sh
+++ b/deployment/init-db.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 set -e
 
+if [ "$RUN_INIT" != "true" ]; then
+    echo "Skipping init-db.sh"
+    exit 0
+fi
+
 echo "Creating database..."
 python3 -u /tmp/init-regions-table.py /data/gadm/gadm.gpkg
-
 echo "Done."
 


### PR DESCRIPTION

- Removed the copying of GADM file into the Docker image in Dockerfile, instead, the file will be mounted from the host into the container using a volume in docker-compose.yml.
- Introduced a new environment variable RUN_INIT to control the execution of the init-db script.
- Updated Makefile to set RUN_INIT environment variable when starting the db service, and added a new target just-run-db for starting the db service without running the init script.
- Updated init-db.sh to check the value of RUN_INIT before executing the script.

This setup allows for more flexibility in managing the database initialization and GADM file, reducing the Docker image size and startup time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated Dockerfile to remove unnecessary file copying.
	- Modified Makefile to improve database build and run process.
	- Added conditional check in init-db.sh for optional database initialization.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->