### PR TITLE
Implement distinct caching for node modules in front and back workflows.

### DIFF
--- a/.github/workflows/eslint-back.yml
+++ b/.github/workflows/eslint-back.yml
@@ -22,6 +22,14 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Cache node modules
+        uses: actions/cache@v3
+        with:
+          path: ./backend/node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('./backend/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-back-node-
+
       - name: Install dependencies
         run: npm install
         working-directory: ./backend

--- a/.github/workflows/eslint-front.yml
+++ b/.github/workflows/eslint-front.yml
@@ -23,6 +23,14 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Cache node modules
+        uses: actions/cache@v3
+        with:
+          path: ./frontend/node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('./frontend/package-lock.json') }}
+          restore-keys: |
+           ${{ runner.os }}-front-node-
+
       - name: Install dependencies
         run: npm install
         working-directory: ./frontend


### PR DESCRIPTION
This commit introduces separate caching mechanisms for the node modules in the frontend and backend workflows of our GitHub Actions. By caching the node_modules directory in both workflows, we aim to improve the efficiency and speed of our CI/CD process. The key for the cache in the backend workflow is based on the OS of the runner and the hash of 'backend/package-lock.json', while the frontend workflow uses the hash of 'frontend/package-lock.json'. This distinction ensures that each workflow utilizes its specific set of dependencies, avoiding potential conflicts or incorrect cache usage. The use of 'actions/cache@v3' facilitates this process, allowing for faster retrieval and installation of dependencies in subsequent workflow runs.