### PR TITLE
Map Centering Enhancement

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,8 @@
     "maplibre-gl": "^3.5.2",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "@turf/turf": "^6.5.0"
   },
   "overrides": {
     "glob": "10.3.10"

--- a/frontend/src/components/RegionMap.jsx
+++ b/frontend/src/components/RegionMap.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import maplibregl from 'maplibre-gl';
+import * as turf from '@turf/turf';
 import { useNavigation } from './NavigationContext';
 import { fetchRegionGeometry } from '../api';
 
@@ -30,14 +31,18 @@ function MapComponent() {
       return;
     }
 
+    const bounds = turf.bbox(polygonData);
+
+    // Create a MapLibre GL JS LngLatBounds object from the bounding box
+    const mapBounds = new maplibregl.LngLatBounds([bounds[0], bounds[1]], [bounds[2], bounds[3]]);
+
     map.current = new maplibregl.Map({
       container: mapContainer.current,
       style: 'https://demotiles.maplibre.org/style.json', // specify the base map style
-      center: [
-        polygonData.coordinates[0][0][0][0],
-        polygonData.coordinates[0][0][0][1],
-      ], // center the map on the first coordinate of the polygon
-      zoom: 9,
+      bounds: mapBounds,
+      fitBoundsOptions: {
+        padding: 50,
+      },
     });
 
     map.current.on('load', () => {


### PR DESCRIPTION
Implemented geocenter calculation using @turf/turf to center the map based on the bounding box of the polygon data. This enhancement replaces the previous method of centering on the first point of the region, improving the accuracy and visual representation of regions on the map.

Closes #56

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Implemented map zoom to fit the selected region's boundaries using the `turf` library for enhanced map interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->