### PR TITLE
Add Workflow for Stale PRs with Manual Trigger

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,24 @@
+name: Mark and Close Stale Pull Requests
+
+on:
+  schedule:
+    - cron: '41 2 * * *'  # Runs at 03:17 UTC every day.
+  workflow_dispatch:  # Allows manual triggering of the workflow
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/stale@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-stale: 7             # Number of days of inactivity before a PR is marked stale
+          days-before-close: 7             # Number of days after being marked stale before a PR is closed
+          stale-pr-message: 'This PR has been inactive for a week. It will be closed in another week if there is no further activity.'
+          stale-pr-label: 'stale'          # Label to apply to stale PRs
+          close-pr-message: 'Closing this stale PR due to inactivity.'
+          operations-per-run: 30           # Maximum number of operations per run


### PR DESCRIPTION
This commit introduces a GitHub Actions workflow to mark and close stale pull requests. The workflow is configured to:
- Mark PRs as stale after 7 days of inactivity.
- Close PRs 7 days after being marked as stale.
- Run automatically at 02:41 UTC every day.
- Allow manual triggering via the GitHub UI using the 'workflow_dispatch' event.

This change aims to streamline PR management and maintain an active, up-to-date list of pull requests in the repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a GitHub Actions workflow to automatically mark and close stale pull requests daily.

- **Chores**
  - Configured the stale action to label and manage inactive pull requests to maintain repository hygiene.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->