### PR TITLE
Enhance Path Uniqueness Logic in Search Component

### DIFF
--- a/frontend/src/components/Search.jsx
+++ b/frontend/src/components/Search.jsx
@@ -11,38 +11,49 @@ function Search() {
   const { selectedRegion, setSelectedRegion, selectedHierarchyId } = useNavigation();
   const prevSelectedRegion = useRef();
 
+  // Returns an object of the form:
+  // { name: 'Region Name', segment: 'Region Segment (if name is not unique)', id: 'Region ID' }
   function formatNames(foundResults) {
-    const nameCount = new Map();
-    foundResults.forEach((item) => {
-      nameCount.set(item.name, (nameCount.get(item.name) || 0) + 1);
+    // Group paths by the last element (which is the same as region.name)
+    const pathsByLastName = {};
+    foundResults.forEach((region) => {
+      if (!pathsByLastName[region.name]) {
+        pathsByLastName[region.name] = [];
+      }
+      pathsByLastName[region.name].push(region.path);
     });
 
-    return foundResults.map((item) => {
-      if (nameCount.get(item.name) === 1) {
-        return ({
-          name: item.name,
-          segment: null,
-          id: item.id,
-        }); // Unique name, return as is
-      }
-      // Find the smallest unique path segment
-      const pathSegments = item.path.split(' > ');
-      let uniqueSegment = pathSegments[pathSegments.length - 1];
-
-      for (let i = pathSegments.length - 2; i >= 0; i -= 1) {
-        const testPath = pathSegments.slice(i).join(' > ');
-        const isUnique = foundResults.filter((r) => r.path.includes(testPath)).length === 1;
-        if (isUnique) {
-          uniqueSegment = pathSegments.slice(i).join(' > ');
+    // Find the common prefix of each group of paths
+    function findCommonPrefixByTokens(paths) {
+      const tokens = paths.map((path) => path.split(' > '));
+      const minLength = Math.min(...tokens.map((token) => token.length));
+      let prefix = '';
+      for (let i = 0; i < minLength; i += 1) {
+        const token = tokens[0][i];
+        if (tokens.every((t) => t[i] === token)) {
+          prefix += `${token} > `;
+        } else {
           break;
         }
       }
+      return prefix;
+    }
 
-      return ({
-        name: item.name,
-        segment: uniqueSegment,
-        id: item.id,
-      });
+    // Process each group to find the shortest unique suffix
+    return foundResults.map((region) => {
+      const paths = pathsByLastName[region.name];
+      if (paths.length === 1) {
+        // Only one path with this name, no need to shorten
+        return { name: region.name, segment: null, id: region.id };
+      }
+      // Find the shortest unique suffix for this path
+      const prefix = findCommonPrefixByTokens(paths);
+      // Replace " >" with ","
+      return {
+        name: region.name,
+        segment: region.path.slice(prefix.length).replace(/ > /g, ', ').trim(','),
+        id: region.id,
+      };
     });
   }
 


### PR DESCRIPTION
## Description
This PR introduces an enhancement to the `formatNames` function within the `Search` component. The updated logic is designed to handle cases where regions with identical names appear under different parent regions or within nested structures. The changes include grouping paths by the last element (region name), identifying the common prefix for each group of paths, and then determining the shortest unique suffix for each region. This approach ensures that each region is uniquely identifiable, aiding in clearer and more accurate search results.

## Related Issues
Closes: #172

## How Was This Tested?
The changes were tested by checking the search functionality with different inputs, ensuring that regions with the same name but different parent regions or nested paths are correctly and uniquely identified in the autocomplete suggestions.

## Checklist
Before submitting your PR, please review the following:
- [x] Commit messages follow the standard template.
- [x] All commits are signed.
- [x] Related issues are mentioned in the description above.
- [x] I have followed the project's directory structure.
- [x] Linter checks have been passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the grouping and processing logic for region names in the search component to enhance search result clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->