### PR TITLE
Update fetchSubregions to return empty array on no results

### DIFF
--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -34,8 +34,7 @@ export const fetchSubregions = async (regionId, hierarchyId) => {
   try {
     const response = await api.get(`/api/regions/${regionId}/subregions`, { params: { hierarchyId } });
     if (response.status === 204) {
-      // TODO return empty array instead of null, Issue #189
-      return null;
+      return [];
     }
     return response.data;
   } catch (error) {

--- a/frontend/src/components/RegionMap.jsx
+++ b/frontend/src/components/RegionMap.jsx
@@ -64,9 +64,6 @@ function MapComponent() {
       // If region has subregions, fetch the subregions
       if (selectedRegion.hasSubregions) {
         const subregions = await fetchSubregions(selectedRegion.id, selectedHierarchy.hierarchyId);
-        if (subregions === null) {
-          return [];
-        }
         return subregions;
       }
       // If region does not have subregions, fetch the siblings


### PR DESCRIPTION
## Description
This PR updates the `fetchSubregions` function within the frontend's `api` module to return an empty array instead of `null` when there are no subregions available. This change ensures consistency across the application by conforming to the expected return type for collection results and prevents potential errors or inconsistencies in type handling downstream.

## Related Issues
Closes: #189

## How Was This Tested?
- Manual testing was conducted to ensure that an empty array is returned when a region has no subregions.

## Checklist
Before submitting your PR, please review the following:
- [x] Commit messages follow the standard template.
- [x] All commits are signed.
- [x] Related issues are mentioned in the description above.
- [x] I have followed the project's directory structure.
- [x] Linter checks have been passed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the handling of areas without subregions in the map feature, ensuring a smoother user experience when navigating regional data.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->