### PR TITLE
deploy: Update Makefile to dynamically select Docker Compose command …

### DIFF
--- a/deployment/Makefile
+++ b/deployment/Makefile
@@ -10,8 +10,8 @@ PROJECT_NAME = tyr
 # Default environment file
 ENV_FILE = .env.development
 
-# Docker Compose command with default environment file
-DC = docker-compose --env-file $(ENV_FILE)
+# Determine the Docker Compose command based on the Docker version
+export DC := $(shell command -v docker >/dev/null && docker --version | awk '{print $$3}' | cut -d'.' -f1,2 | sed 's/,//g' | (read v; if [ $$(echo "$$v >= 20.10" | bc -l) -eq 1 ]; then echo "docker compose --env-file $(ENV_FILE)"; else echo "docker-compose --env-file $(ENV_FILE)"; command -v docker-compose >/dev/null || { echo "Error: Docker Compose is not installed." >&2; exit 1; }; fi))
 
 # Required environment variables
 REQUIRED_ENV_VARS = DB_NAME DB_USER DB_PASSWORD GADM_FILE POSTGIS_VERSION


### PR DESCRIPTION
## Description
This Pull Request introduces an update to the deployment Makefile to automatically determine the correct Docker Compose command format based on the installed Docker version. It addresses the issue of compatibility with different Docker versions by programmatically checking the Docker version and setting the Docker Compose command (`docker compose` for Docker versions 20.10 and above, and `docker-compose` for older versions) accordingly. This enhancement simplifies the development and deployment process by eliminating the need for manual configuration adjustments based on the Docker version.


## How Was This Tested?
The changes were tested on multiple environments with different versions of Docker installed to ensure the correct Docker Compose command is selected and used in the Makefile.

## Checklist
Before submitting your PR, please review the following:
- [x] Commit messages follow the standard template.
- [x] All commits are signed.
- [x] Related issues are mentioned in the description above.
- [x] I have followed the project's directory structure.
- [ ] Linter checks have been passed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
    - Enhanced deployment process compatibility by dynamically adjusting for different Docker versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->