### PR TITLE
Fix Build Issues: Downgrade eslint and Add GADM File Check Dependency

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,7 @@
   "description": "Backend for Track Your Regions",
   "devDependencies": {
     "dotenv-cli": "^7.3.0",
-    "eslint": "^9.0.0",
+    "eslint": "^8.2.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-plugin-markdownlint": "^0.6.0",
     "nodemon": "^3.0.1",

--- a/deployment/Makefile
+++ b/deployment/Makefile
@@ -86,7 +86,7 @@ reinit-db: check-gadm-file clean-volume init-db
 stop:
 	$(DC) stop
 
-build: check-env
+build: check-env check-gadm-file
 	$(DC) build
 
 run: check-env

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,7 +38,7 @@
     ]
   },
   "devDependencies": {
-    "eslint": "^9.0.0",
+    "eslint": "^8.2.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-plugin-markdownlint": "^0.6.0",
     "react-scripts": "^5.0.1"


### PR DESCRIPTION
## Description
This pull request addresses two key issues to ensure successful build and deployment processes:

1. **Downgrade eslint Version**:
   - Downgraded eslint from ^9.0.0 to ^8.2.0 in the `package.json` file.
   - This downgrade is necessary due to incompatibility with `eslint-config-airbnb`, which does not yet support eslint 9.

2. **Add GADM File Check Dependency**:
   - Added `check-gadm-file` as a dependency for the `build` target in the `Makefile`.
   - This ensures the GADM file is present before initiating the build process, which is necessary because the Docker Compose configuration relies on the GADM file as a volume for the container.

## How Was This Tested?
- Verified that the build process completes successfully with the downgraded eslint version.
- Confirmed that the `build` target in the `Makefile` now checks for the GADM file before proceeding, ensuring all dependencies are in place for a smooth build process.

## Checklist
Before submitting your PR, please review the following:
- [x] Commit messages follow the standard template.
- [x] All commits are signed.
- [ ] Related issues are mentioned in the description above.
- [x] I have followed the project's directory structure.
- [x] Linter checks have been passed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated `eslint` version to `^8.2.0` in both backend and frontend package files to maintain consistency.
  - Modified build process to include a check for `gadm` file, ensuring comprehensive validation during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->