### PR TITLE
Add slash commands for workflow automation

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -1,0 +1,96 @@
+# Commit Changes
+
+Review uncommitted changes, organize them into atomic commits on an appropriate branch, and push.
+
+## Arguments
+
+$ARGUMENTS — optional: branch name or short description of the change. If not provided, infer from the changes.
+
+## Instructions
+
+### 1. Assess current state
+
+Run in parallel:
+```bash
+git status
+git diff
+git diff --cached
+git log --oneline -10
+git branch --show-current
+```
+
+Also check if the current branch has unmerged commits (i.e., is not `main`):
+```bash
+git log main..HEAD --oneline
+```
+
+### 2. Determine the branch
+
+- **If already on a non-main branch with unmerged commits**: check if the uncommitted changes are related to the branch's purpose. If yes, use this branch. If the changes are unrelated (different feature/fix), stash them, switch to main, and create a new branch.
+- **If on main or on a clean feature branch with no relation to the changes**: create a new branch. Use a descriptive kebab-case name (e.g., `fix-auth-token-refresh`, `add-region-export`). If $ARGUMENTS provides a name or hint, use that.
+
+### 3. Filter out junk
+
+Review every changed file. **Do NOT stage** any of the following:
+- `.env`, `.env.*` files or anything with secrets/credentials
+- Files with hardcoded local paths, hostnames, ports specific to your machine
+- IDE/editor config (`.idea/`, `.vscode/settings.json`, etc.) unless they're already tracked
+- OS files (`.DS_Store`, `Thumbs.db`)
+- Build artifacts, `node_modules/`, `dist/`, `.cache/`
+- Log files, temporary files, debug output
+- Any file that contains private data (API keys, tokens, personal info)
+
+If you find suspicious files, **skip them** and mention it in the summary.
+
+### 4. Group changes into atomic commits
+
+Analyze the staged-worthy changes and group them by purpose. Each commit should contain **only** changes that belong together:
+
+- A bug fix is one commit — don't mix in unrelated refactoring
+- A new feature is one commit (or a small series if it has distinct layers: schema, backend, frontend)
+- Documentation updates related to a code change go in the **same commit** as the code
+- Unrelated documentation fixes get their own commit
+- Config changes get their own commit unless directly tied to a feature
+
+**Do NOT create a commit that mixes unrelated changes.** If changes span multiple unrelated topics, they need separate commits (and potentially separate branches — see step 2).
+
+### 5. Create commits
+
+For each atomic group, stage the specific files and commit:
+
+```bash
+git add <file1> <file2> ...
+git commit -s -m "$(cat <<'EOF'
+<title: imperative, under 72 chars>
+
+<body: explain what changed and why, wrap at 72 chars>
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+Rules for commit messages:
+- **Title**: imperative mood ("Add X", "Fix Y", "Update Z"), max 72 characters
+- **Body**: explain _what_ changed and _why_ (not just _how_). Provide enough context that someone reading `git log` understands the motivation
+- **Related issues**: if the change addresses or relates to a GitHub issue, include `Closes #N` or `Relates to #N` in the commit body (before the trailers). Search open issues with `gh issue list` if unsure whether a relevant issue exists
+- **Always** use `-s` (sign-off: Developer Certificate of Origin)
+- **Always** include the `Co-Authored-By` trailer
+
+### 6. Push
+
+After all commits are created:
+```bash
+git push -u origin <branch-name>
+```
+
+If the branch is new, this sets up tracking. If pushing to an existing branch, a regular `git push` suffices.
+
+### 7. Summary
+
+Report:
+- Branch name
+- Number of commits created (with short titles)
+- Any files that were **skipped** (junk, secrets, host-specific) and why
+- Any uncommitted changes that remain (files you chose not to commit)
+- Remind the user if there are leftover changes that might need a separate branch

--- a/.claude/commands/feature.md
+++ b/.claude/commands/feature.md
@@ -1,0 +1,86 @@
+# Work on a Feature
+
+Work on a feature or enhancement from a GitHub issue. Features require proper planning before implementation — this command reads the issue, explores the codebase, and produces a plan for approval.
+
+## Arguments
+
+$ARGUMENTS — required: GitHub issue number.
+
+## Instructions
+
+### 1. Load the issue
+
+```bash
+gh issue view $ARGUMENTS --json number,title,body,labels,comments
+```
+
+If the issue doesn't exist or isn't open, tell the user and stop.
+
+### 2. Understand the requirements
+
+- Read the issue title, description, and all comments carefully
+- Extract specific requirements and acceptance criteria
+- Note any subtasks or checkboxes in the issue body
+- Identify which parts of the system are affected (frontend, backend, database, etc.)
+
+### 3. Create a branch
+
+```bash
+git checkout main
+git pull
+git checkout -b feature/$ARGUMENTS-<short-slug>
+```
+
+Use a short slug derived from the issue title (e.g., `feature/200-dark-mode`).
+
+### 4. Enter plan mode
+
+This is a feature — it requires proper planning. Enter plan mode to:
+
+- Explore the relevant parts of the codebase
+- Understand existing patterns and architecture
+- Check `docs/tech/planning/` for any existing plans related to this feature
+- Check `docs/vision/vision.md` for relevant user stories
+- Check `frontend/src/components/shared/` for reusable components
+- Design the implementation approach
+- Identify files to create/modify
+- Consider edge cases and security implications
+
+Present the plan to the user for approval before writing any code.
+
+### 5. After plan approval — implement
+
+Once the user approves the plan:
+
+- Implement the feature following the approved plan
+- Follow existing code patterns (check similar features for reference)
+- Reuse existing utilities and shared components
+- Add proper input validation (Zod schemas for new endpoints)
+- Add auth middleware where needed
+
+### 6. Verify
+
+Run the project checks:
+
+```bash
+npm run check
+```
+
+Fix any lint or type errors.
+
+### 7. Update documentation
+
+Features always require doc updates:
+
+- **`docs/tech/`** — create or update technical documentation for the feature
+- **`docs/vision/vision.md`** — update if the feature is user-facing
+- **`docs/tech/planning/`** — if there was an existing plan, trim it to only remaining ideas
+- **`docs/security/`** — update if the feature touches auth, new endpoints, or input surfaces
+
+### 8. Commit and summarize
+
+Commit the changes (follow the git commit protocol from system instructions).
+
+Then summarize what was built and suggest:
+- **To create a PR**: use `gh pr create` — the PR description should reference the issue with `Closes #$ARGUMENTS` or `Part of #$ARGUMENTS` (if partial)
+- **To continue work**: list any remaining items from the issue that weren't addressed

--- a/.claude/commands/fix.md
+++ b/.claude/commands/fix.md
@@ -1,0 +1,82 @@
+# Fix a Bug
+
+Work on a bug fix from a GitHub issue. This is a streamlined workflow for bugs — read the issue, understand the problem, find the code, fix it, and verify.
+
+## Arguments
+
+$ARGUMENTS — required: GitHub issue number.
+
+## Instructions
+
+### 1. Load the issue
+
+```bash
+gh issue view $ARGUMENTS --json number,title,body,labels,comments
+```
+
+If the issue doesn't exist or isn't open, tell the user and stop.
+
+### 2. Understand the problem
+
+- Read the issue title, description, and any comments
+- Extract the specific bug behavior described
+- Identify reproduction steps if provided
+- Note any files or areas of code mentioned
+
+### 3. Create a branch
+
+```bash
+git checkout main
+git pull
+git checkout -b fix/$ARGUMENTS-<short-slug>
+```
+
+Use a short slug derived from the issue title (e.g., `fix/42-login-crash`).
+
+### 4. Investigate
+
+- Search the codebase for the relevant code based on the issue description
+- Read the files involved to understand the current behavior
+- Identify the root cause of the bug
+- Check related tests if they exist
+
+### 5. Explain your findings
+
+Before making any changes, briefly explain:
+- What the bug is
+- Where in the code it occurs (file:line references)
+- What the root cause is
+- What the fix will be
+
+Ask the user to confirm before proceeding with the fix.
+
+### 6. Implement the fix
+
+- Make the minimal change needed to fix the bug
+- Follow existing code patterns and style
+- Do NOT refactor surrounding code or add unrelated improvements
+- Update any relevant tests
+
+### 7. Verify
+
+Run the project checks:
+
+```bash
+npm run check
+```
+
+Fix any lint or type errors introduced by the change.
+
+### 8. Update docs if needed
+
+If the fix changes user-facing behavior:
+- Update `docs/vision/vision.md`
+- Update relevant `docs/tech/` files
+
+### 9. Commit and summarize
+
+Commit the fix (follow the git commit protocol from system instructions).
+
+Then summarize what was done and suggest:
+- **To create a PR**: run `/commit` or use `gh pr create`
+- **To close the issue**: the PR description should include `Fixes #$ARGUMENTS`

--- a/.claude/commands/issue-create.md
+++ b/.claude/commands/issue-create.md
@@ -1,0 +1,92 @@
+# Create GitHub Issue
+
+Create a new GitHub issue from a text description. Automatically determines whether it's a bug or a feature and applies appropriate labels.
+
+## Arguments
+
+$ARGUMENTS — required: a description of the issue or feature request, in plain language.
+
+## Instructions
+
+### 1. Parse the description
+
+Read the text in $ARGUMENTS. It may be informal, contain typos, or be brief — that's fine.
+
+Determine the type:
+- **Bug** if it describes something broken, wrong, or not working as expected
+- **Feature** if it describes something new to build, add, or improve
+- **Refactoring** if it describes restructuring existing code without changing behavior
+
+### 2. Draft the issue
+
+Create a well-structured GitHub issue from the description:
+
+**Title**: A clear, concise title (imperative form for features: "Add X", "Support Y"; descriptive for bugs: "X fails when Y", "Broken Z on page W")
+
+**Body**: Structure the body based on type:
+
+For **bugs**:
+```markdown
+## Description
+{Clear description of the bug, expanded from the user's text}
+
+## Steps to Reproduce
+{If the user mentioned steps, list them. Otherwise write "To be determined."}
+
+## Expected Behavior
+{What should happen}
+
+## Actual Behavior
+{What happens instead}
+```
+
+For **features**:
+```markdown
+## Description
+{Clear description of what should be built, expanded from the user's text}
+
+## Requirements
+{Extract specific requirements as a checklist. If the description is vague, create reasonable requirements and note they need review.}
+
+- [ ] Requirement 1
+- [ ] Requirement 2
+```
+
+For **refactoring**:
+```markdown
+## Description
+{Clear description of what should be restructured and why}
+
+## Scope
+- [ ] Item 1
+- [ ] Item 2
+```
+
+**Labels**: Pick from existing labels:
+- Type: `bug`, `enhancement`, or `refactoring`
+- Area (if obvious): `front`, `back`, `API`, `deploy`
+
+### 3. Show the draft to the user
+
+Display the full issue (title, body, labels) and **ask for confirmation** before creating it. The user may want to adjust the wording.
+
+### 4. Create the issue
+
+After the user confirms:
+
+```bash
+gh issue create --title "<title>" --body "<body>" --label "<label1>,<label2>"
+```
+
+Use a HEREDOC for the body to handle multi-line content and special characters:
+
+```bash
+gh issue create --title "<title>" --label "<labels>" --body "$(cat <<'EOF'
+<body content>
+EOF
+)"
+```
+
+### 5. Report
+
+Show the created issue number and URL.

--- a/.claude/commands/issue-upload.md
+++ b/.claude/commands/issue-upload.md
@@ -1,0 +1,106 @@
+# Upload Issues from File
+
+Parse issues/features from a markdown file, create GitHub issues for each, and remove the uploaded items from the source file.
+
+## Arguments
+
+$ARGUMENTS — optional: path to the file. If not provided, show both known files and let the user pick:
+- `docs/inbox/found-issues.md` — bugs and issues found during development
+- `docs/inbox/new-features.md` — feature ideas and enhancement proposals
+
+## Instructions
+
+### 1. Read the source file
+
+If $ARGUMENTS is provided, read that file. Otherwise, list both files and ask the user which one to process (or both).
+
+Read the file contents.
+
+### 2. Parse items
+
+Items in these files follow this format:
+- Numbered lines: `1. Description of the issue or feature`
+- Some items may be struck through with `~~...~~` and/or marked **Done** — **skip these entirely**
+- Items may be informal, contain typos, or be brief
+
+Extract each non-done item as a separate issue to create.
+
+### 3. Classify each item
+
+For each item, determine:
+- **Type**: bug, enhancement, or refactoring (based on the description)
+- **Title**: A clear, concise title derived from the description
+- **Body**: Expand the description into a proper issue body (see format below)
+- **Labels**: Pick appropriate labels (`bug`/`enhancement`/`refactoring` + area labels like `front`, `back`, `API` if obvious)
+
+Issue body format for **features**:
+```markdown
+## Description
+{Expanded description}
+
+## Requirements
+- [ ] Requirement 1
+- [ ] Requirement 2
+```
+
+Issue body format for **bugs**:
+```markdown
+## Description
+{Expanded description}
+
+## Expected Behavior
+{What should happen}
+
+## Actual Behavior
+{What happens instead}
+```
+
+### 4. Present the batch for review
+
+Show ALL items in a numbered table before creating anything:
+
+```
+## Items to upload from {filename}
+
+| # | Type        | Title                              | Labels              |
+|---|-------------|------------------------------------|----------------------|
+| 1 | enhancement | Add full content curation for ...  | enhancement, front   |
+| 3 | enhancement | Sync navigation between Map and... | enhancement, front   |
+
+Skipped (done/struck-through): items 2
+
+Ready to create 2 issues?
+```
+
+**Ask the user to confirm.** They may want to skip some items, adjust titles, or change types.
+
+### 5. Create issues
+
+After confirmation, create each issue one at a time:
+
+```bash
+gh issue create --title "<title>" --label "<labels>" --body "$(cat <<'EOF'
+<body content>
+EOF
+)"
+```
+
+Report each created issue's number and URL as you go.
+
+### 6. Clean up the source file
+
+After all issues are created successfully:
+- **Remove** the uploaded items from the source file (delete those numbered lines)
+- **Keep** struck-through / done items as-is (they're historical record)
+- **Keep** any remaining items that were skipped by user choice
+- Re-number the remaining items if needed to keep the list clean
+- If the file becomes empty (or only has done items), leave the done items as a record
+
+Use the Edit tool to modify the file — do NOT rewrite the entire file if only removing a few lines.
+
+### 7. Summary
+
+Report:
+- How many issues were created (with numbers and URLs)
+- What was removed from the source file
+- What remains in the file (if anything)

--- a/.claude/commands/issues.md
+++ b/.claude/commands/issues.md
@@ -1,0 +1,57 @@
+# Browse GitHub Issues
+
+List open GitHub issues, categorized by type, to help pick what to work on next.
+
+## Arguments
+
+$ARGUMENTS — optional: filter options. Examples: `bug`, `enhancement`, `refactoring`, or a label name. If not provided, show all open issues.
+
+## Instructions
+
+### 1. Fetch issues
+
+```bash
+# If $ARGUMENTS contains a label, filter by it:
+gh issue list --state open --label "$ARGUMENTS" --limit 30 --json number,title,labels,assignees,createdAt,updatedAt
+
+# If no arguments, fetch all open issues:
+gh issue list --state open --limit 30 --json number,title,labels,assignees,createdAt,updatedAt
+```
+
+### 2. Categorize
+
+Group the issues into these categories based on their labels:
+
+- **Bugs** — issues with the `bug` label
+- **Features** — issues with the `enhancement` label
+- **Refactoring** — issues with the `refactoring` label
+- **Other** — everything else
+
+Within each category, sort by issue number (newest first).
+
+### 3. Display
+
+Output a clean summary table for each non-empty category:
+
+```
+## Bugs
+| #   | Title                          | Labels          | Age     |
+|-----|--------------------------------|-----------------|---------|
+| 123 | Login fails on mobile          | bug, front      | 3 days  |
+
+## Features
+| #   | Title                          | Labels          | Age     |
+|-----|--------------------------------|-----------------|---------|
+| 200 | Add dark mode                  | enhancement     | 2 weeks |
+
+## Refactoring
+...
+```
+
+### 4. Suggest next steps
+
+After the table, suggest:
+
+- **To fix a bug**: run `/fix <number>`
+- **To work on a feature**: run `/feature <number>`
+- **To see issue details**: run `gh issue view <number>`

--- a/.claude/commands/pr-create.md
+++ b/.claude/commands/pr-create.md
@@ -1,0 +1,142 @@
+# Create Pull Request
+
+Create a pull request for a branch, filling in the PR template based on the actual changes.
+
+## Arguments
+
+$ARGUMENTS — optional: branch name. If not provided, list branches with unmerged commits and ask which to create PRs for.
+
+## Instructions
+
+### 1. Determine which branches to process
+
+If $ARGUMENTS provides a branch name, use that branch.
+
+If no argument, analyze all local branches that don't have an open PR:
+
+```bash
+# List local branches with unmerged commits (excluding main)
+git branch --no-merged main --format='%(refname:short)'
+
+# List branches that already have open PRs
+gh pr list --state open --json headRefName --jq '.[].headRefName'
+```
+
+Filter to only local branches without an open PR. For each, gather a quick summary (commits, files changed) and present a table with your recommendation:
+
+```
+| # | Branch | Commits | Summary | Recommendation |
+|---|--------|---------|---------|----------------|
+| 1 | add-feature-x | 3 | New feature X | Create PR |
+| 2 | backup/old-stuff | 47 | Old backup branch | Skip (backup) |
+```
+
+Recommendations:
+- **Create PR** — focused branch with clear purpose
+- **Skip (backup)** — branch name suggests it's a backup (`backup/`, `-backup`, `old-`)
+- **Skip (stale)** — very old commits with no recent activity
+- **Review first** — large diff or unclear purpose, user should decide
+
+Ask the user to confirm which branches to create PRs for.
+
+### 2. Rebase branches on top of main
+
+Before creating PRs, ensure each branch is rebased with fast-forward on top of the latest main:
+
+```bash
+git fetch origin  # update ALL remote tracking refs (needed for --force-with-lease)
+git fetch origin main:main  # fast-forward local main
+```
+
+If the working tree is dirty, stash before switching branches:
+```bash
+git stash --include-untracked  # if needed
+```
+
+For each branch:
+```bash
+git checkout <branch>
+git rebase main
+git push --force-with-lease
+```
+
+After rebase, check if the branch still has commits ahead of main:
+```bash
+git log main..<branch> --oneline
+```
+
+If empty (all commits were already in main), **skip this branch** — report it as "already merged" and do not attempt to create a PR.
+
+If rebase has conflicts, stop and report them to the user — do not force through.
+
+After all rebases, restore the stash if one was created and return to the original branch.
+
+### 3. For each branch, analyze the changes
+
+Switch context to the branch (without checking it out) and gather info:
+
+```bash
+# Commits on this branch since diverging from main
+git log main..<branch> --oneline
+git log main..<branch> --format='%s%n%n%b---'
+
+# Full diff against main
+git diff main...<branch> --stat
+git diff main...<branch>
+```
+
+From this, determine:
+- **What changed**: summarize the purpose of the branch's commits
+- **Related issues**: look for issue references in commit messages (`#123`, `Closes #123`, etc.)
+- **Files changed**: list of modified/added/deleted files
+- **Type of change**: feature, bug fix, refactoring, docs, etc.
+
+### 4. Fill in the PR template
+
+Use the project's PR template (`.github/PULL_REQUEST_TEMPLATE.md`) and fill each section:
+
+#### Description
+Write a clear summary of what the branch does and why. Derive this from the commit messages and the actual diff — don't just repeat commit titles. Group related changes if there are multiple commits.
+
+#### Related Issues
+- If commit messages reference issues, include them with `Closes #N` or `Relates to #N`
+- Also search open issues for matches: `gh issue list --state open --json number,title` — look for issues related to the branch's changes by title/keyword
+- If no issues are referenced and none found, write "None"
+
+#### How Was This Tested?
+- If the branch includes test files, mention the tests added/modified
+- If it's a config/docs/tooling change that doesn't need tests, say "N/A — configuration/documentation change"
+- If it's code without tests, note "Manual testing" or flag that tests are needed
+
+#### Checklist
+Fill in the checklist based on actual state:
+- Check commit messages: are they well-formatted with title + body?
+- Check signatures: `git log main..<branch> --format='%G?'` or look for `Signed-off-by`
+- Check for related issues (already gathered above)
+- Lint status: run `npm run check` if code files changed, skip for docs-only changes
+
+#### Additional Comments
+Add any notable context: migration notes, deployment considerations, or things the reviewer should pay attention to. Leave empty if nothing special.
+
+### 5. Create the PR
+
+```bash
+gh pr create --base main --head <branch> --title "<title>" --body "$(cat <<'EOF'
+<filled template>
+EOF
+)"
+```
+
+PR title rules:
+- Under 70 characters
+- Imperative mood ("Add X", "Fix Y", not "Added X" or "Fixes Y")
+- Derived from the branch's overall purpose, not just the last commit
+
+### 6. Report results
+
+For each PR created, show:
+- PR number and URL
+- Title
+- Brief note on what was included
+
+If multiple PRs were created, show a summary table at the end.

--- a/.claude/commands/review-dependabot.md
+++ b/.claude/commands/review-dependabot.md
@@ -1,0 +1,161 @@
+# Review Dependabot PRs
+
+Analyze open Dependabot PRs, assess risk of each dependency update, and recommend whether to merge or flag concerns.
+
+## Arguments
+
+$ARGUMENTS — optional: PR number for a specific Dependabot PR. If not provided, review all open Dependabot PRs.
+
+## Instructions
+
+### 1. Find Dependabot PRs
+
+If a PR number was given in $ARGUMENTS:
+```bash
+gh pr view <number> --json number,title,url,body,state,author
+```
+Verify the author is `dependabot[bot]` or `dependabot`. If not, tell the user this isn't a Dependabot PR and stop.
+
+If no argument was given, list all open Dependabot PRs:
+```bash
+gh pr list --author "app/dependabot" --state open --json number,title,url,body,labels
+```
+If there are no open Dependabot PRs, tell the user and stop.
+
+### 2. For each PR, gather context
+
+For each Dependabot PR:
+
+#### a. Read the PR details
+```bash
+gh pr view <number> --json number,title,url,body,labels,files
+```
+
+Extract from the PR body:
+- **Package name** being updated
+- **Version change** (from → to)
+- **Whether it's a major, minor, or patch bump**
+- **Release notes / changelog** included in the PR body
+
+#### b. Check the diff
+```bash
+gh pr diff <number>
+```
+
+Look at what files changed (typically `package.json` and `package-lock.json`). Note if any other files changed — that's unusual for Dependabot and warrants attention.
+
+#### c. Check how the package is used in the codebase
+
+Search for imports/requires of the package:
+```bash
+# Use Grep tool to search for the package name in source files
+```
+
+Determine:
+- Is it a **direct dependency** or **dev dependency**?
+- Is it used in **backend**, **frontend**, or **both**?
+- How heavily is it used? (imported in 1 file vs. many)
+- Is it a **runtime** dependency (affects production) or **build/test** only?
+
+#### d. Check for breaking changes
+
+- Read the changelog/release notes in the PR body carefully
+- For **major version bumps**: always flag as needing attention — check for breaking changes, deprecated APIs, dropped Node.js version support
+- For **minor version bumps**: check for new peer dependency requirements or deprecation notices
+- For **patch version bumps**: usually safe, but verify it's genuinely a patch (security fix, bug fix)
+- Check if the update is a **security fix** (Dependabot labels or PR body will mention CVEs)
+
+#### e. Check CI status
+```bash
+gh pr checks <number>
+```
+
+Note whether CI passes, fails, or is pending.
+
+### 3. Deep-dive for concerning updates
+
+For any PR with a major version bump, CI failure, or breaking changes listed in the changelog, do a **real impact analysis**:
+
+#### a. Identify affected APIs
+
+Read the breaking changes section of the changelog. For each breaking change, determine the specific API surface that changed (renamed functions, removed options, changed signatures, new required config, dropped Node version support, etc.).
+
+#### b. Trace usage in our codebase
+
+For each affected API, use Grep and Read to find every place in our code that uses it. Read the surrounding code to understand:
+- Which specific function signatures, options, or patterns we rely on
+- Whether our usage hits the breaking change or not (many "breaking" changes only affect edge cases we don't use)
+- Whether any wrappers or abstractions insulate us from the change
+
+#### c. Determine real impact
+
+Classify the actual impact for our codebase:
+- **No real impact** — We don't use any of the changed/removed APIs. The major bump is safe for us despite the breaking changes on paper.
+- **Trivial fix** — We use an affected API but the migration is straightforward (rename, add an option, update a config key). Describe the exact changes needed, with file paths and line numbers.
+- **Moderate effort** — Multiple files need updates or behavior changes need testing. List every file and what needs to change.
+- **Significant rework** — Core patterns or architecture are affected. Explain what would need to be redesigned.
+
+#### d. For CI failures
+
+If CI fails on a Dependabot PR:
+- Read the CI output: `gh pr checks <number> --json name,state,description`
+- Determine if the failure is related to the dependency update or a flaky/unrelated test
+- If related, identify the root cause and what code changes would fix it
+
+### 4. Present the review
+
+Output a structured review:
+
+```
+## Dependabot PR Review
+
+### Safe to Merge
+| PR | Package | Change | Why safe |
+|----|---------|--------|----------|
+| #N | pkg-name | 1.2.3 → 1.2.4 | Patch bump, dev dependency, CI passes |
+
+### Likely Safe
+| PR | Package | Change | Notes |
+|----|---------|--------|-------|
+| #N | pkg-name | 1.2.0 → 1.3.0 | Minor bump, no breaking changes in changelog, used in 2 files |
+
+### Security Fixes (Merge ASAP)
+| PR | Package | Change | CVE |
+|----|---------|--------|-----|
+| #N | pkg-name | 1.2.3 → 1.2.4 | CVE-XXXX-XXXXX |
+
+### Needs Attention — Deep Dive
+For each PR that needed deeper analysis:
+
+#### PR #N: pkg-name 2.x → 3.x
+
+**Breaking changes in changelog:**
+- Change A: {description}
+- Change B: {description}
+
+**Impact on our codebase:**
+- Change A: **No real impact** — we don't use {affected API}
+- Change B: **Trivial fix** — `backend/src/services/foo.ts:42` calls `bar()` with old signature, needs to change to `bar(options)`
+
+**CI status:** Passes / Fails (reason: ...)
+
+**Verdict:** {Safe to merge as-is / Merge after applying fixes below / Hold off}
+
+**Required code changes (if any):**
+- `{file}:{line}` — change `{old}` to `{new}`
+```
+
+### 5. Recommend next steps
+
+After the review:
+- For "Safe to Merge", "Likely Safe", and "No real impact" PRs: ask if the user wants to merge them now
+- For "Security Fixes": strongly recommend merging ASAP
+- For PRs needing trivial fixes: offer to make the code changes and then merge
+- For significant rework: outline the effort and let the user decide
+
+If the user wants to merge:
+```bash
+gh pr merge <number> --squash
+```
+
+Use `--squash` for clean history. Merge one at a time and report success/failure for each.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,6 @@ Before submitting your PR, please review the following:
 - [ ] Commit messages follow the standard template.
 - [ ] All commits are signed.
 - [ ] Related issues are mentioned in the description above.
-- [ ] I have followed the project's directory structure.
 - [ ] Linter checks have been passed.
 
 ## Additional Comments (if any):


### PR DESCRIPTION
## Description
Add 8 new Claude Code slash commands to streamline common development workflows:

- `/commit` — organize uncommitted changes into atomic commits on appropriate branches
- `/pr-create` — create PRs with auto-filled template from branch analysis
- `/feature` — guided feature implementation workflow
- `/fix` — bug fix workflow
- `/issues` — browse and triage GitHub issues
- `/issue-create` — create a GitHub issue from a description
- `/issue-upload` — batch-upload issues from markdown inbox files
- `/review-dependabot` — analyze Dependabot PRs with deep impact assessment

Also removes the outdated "project directory structure" checklist item from the PR template.

## Related Issues
None

## How Was This Tested?
N/A — configuration/documentation change (slash command definitions and PR template)

## Checklist
- [x] Commit messages follow the standard template.
- [x] All commits are signed.
- [x] Related issues are mentioned in the description above.
- [x] Linter checks have been passed.

## Additional Comments (if any):
All commands live in `.claude/commands/` following existing patterns (security-audit, security-check, etc.).