### PR TITLE
Fix review-dependabot command to use rebase merge

### DIFF
--- a/.claude/commands/review-dependabot.md
+++ b/.claude/commands/review-dependabot.md
@@ -155,7 +155,7 @@ After the review:
 
 If the user wants to merge:
 ```bash
-gh pr merge <number> --squash
+gh pr merge <number> --rebase
 ```
 
-Use `--squash` for clean history. Merge one at a time and report success/failure for each.
+Use `--rebase` for fast-forward merge (no merge commits). Merge one at a time and report success/failure for each.


### PR DESCRIPTION
## Description
Update the `/review-dependabot` slash command to use `--rebase` instead of `--squash` for merging, matching the repository's fast-forward-only merge policy.

Also includes the `pr-create` command update to add a rebase step and handle edge cases (dirty working tree, empty branches after rebase, stale tracking refs).

## Related Issues
None

## How Was This Tested?
N/A — configuration/documentation change

## Checklist
- [x] Commit messages follow the standard template.
- [x] All commits are signed.
- [x] Related issues are mentioned in the description above.
- [x] Linter checks have been passed.

## Additional Comments (if any):
Follow-up to merged PR #239. The original PR had `--squash` which is not allowed on this repo.