### PR TITLE
Add comprehensive rate limiting to all API endpoint tiers

### DIFF
--- a/backend/src/middleware/rateLimiter.ts
+++ b/backend/src/middleware/rateLimiter.ts
@@ -1,0 +1,110 @@
+/**
+ * Shared Rate Limiters
+ *
+ * ALL rate limiters are defined here for consistency.
+ * See docs/tech/rate-limiting.md for the full strategy.
+ *
+ * Tiers:
+ * 1. Auth-specific: strict limits on login, register, refresh, etc.
+ * 2. Search: moderate limits on search/geocode endpoints (30 req/min)
+ * 3. Public read: generous limits for UI-serving read endpoints (60 req/min)
+ * 4. Authenticated user: per-IP limits for logged-in user actions (60 req/min)
+ * 5. Admin/curator: exempt — protected by requireAuth + requireAdmin/requireCurator
+ */
+import rateLimit from 'express-rate-limit';
+
+// =============================================================================
+// Auth Rate Limiters (strict)
+// =============================================================================
+
+export const loginLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 10, // 10 attempts per window
+  standardHeaders: 'draft-7',
+  legacyHeaders: false,
+  message: { error: 'Too many login attempts, please try again later' },
+});
+
+export const registerLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000, // 1 hour
+  max: 5, // 5 registrations per hour per IP
+  standardHeaders: 'draft-7',
+  legacyHeaders: false,
+  message: { error: 'Too many registration attempts, please try again later' },
+});
+
+export const refreshLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 30, // 30 refreshes per minute
+  standardHeaders: 'draft-7',
+  legacyHeaders: false,
+  message: { error: 'Too many requests, please try again later' },
+});
+
+export const verifyEmailLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 10, // 10 attempts per minute per IP
+  standardHeaders: 'draft-7',
+  legacyHeaders: false,
+  message: { error: 'Too many requests, please try again later' },
+});
+
+export const exchangeCodeLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 10, // 10 attempts per minute per IP
+  standardHeaders: 'draft-7',
+  legacyHeaders: false,
+  message: { error: 'Too many requests, please try again later' },
+});
+
+export const resendLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000, // 1 hour
+  max: 3, // 3 resend attempts per hour per IP
+  standardHeaders: 'draft-7',
+  legacyHeaders: false,
+  message: { error: 'Too many requests, please try again later' },
+});
+
+// =============================================================================
+// Search Rate Limiter
+// =============================================================================
+
+export const searchLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 30, // 30 searches per minute per IP
+  standardHeaders: 'draft-7',
+  legacyHeaders: false,
+  message: { error: 'Too many search requests, please try again later' },
+});
+
+// =============================================================================
+// Public Read Rate Limiter
+// =============================================================================
+
+/**
+ * Public read endpoints (world views, regions, experiences, etc.)
+ * Generous limit since these serve the main UI for all visitors.
+ */
+export const publicReadLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 60, // 60 requests per minute per IP
+  standardHeaders: 'draft-7',
+  legacyHeaders: false,
+  message: { error: 'Too many requests, please try again later' },
+});
+
+// =============================================================================
+// Authenticated User Rate Limiter
+// =============================================================================
+
+/**
+ * Authenticated user actions (visited regions, experiences, treasures, etc.)
+ * Per-IP limiting for logged-in users.
+ */
+export const authenticatedLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 60, // 60 requests per minute per IP
+  standardHeaders: 'draft-7',
+  legacyHeaders: false,
+  message: { error: 'Too many requests, please try again later' },
+});

--- a/backend/src/routes/geocodeRoutes.ts
+++ b/backend/src/routes/geocodeRoutes.ts
@@ -4,22 +4,14 @@
  */
 
 import { Router } from 'express';
-import rateLimit from 'express-rate-limit';
 import { searchPlaces, suggestImage } from '../controllers/geocodeController.js';
 import { geocodeWithAI } from '../controllers/aiController.js';
 import { requireAuth, requireCurator } from '../middleware/auth.js';
+import { searchLimiter } from '../middleware/rateLimiter.js';
 import { validate } from '../middleware/errorHandler.js';
 import { geocodeSearchQuerySchema, suggestImageQuerySchema, aiGeocodeBodySchema } from '../types/index.js';
 
 const router = Router();
-
-const searchLimiter = rateLimit({
-  windowMs: 60 * 1000, // 1 minute
-  max: 30, // 30 searches per minute per IP
-  standardHeaders: 'draft-7',
-  legacyHeaders: false,
-  message: { error: 'Too many search requests, please try again later' },
-});
 
 // Search places by name (public)
 router.get('/search', searchLimiter, validate(geocodeSearchQuerySchema, 'query'), searchPlaces);

--- a/backend/src/routes/userRoutes.ts
+++ b/backend/src/routes/userRoutes.ts
@@ -1,6 +1,7 @@
 import { Router, Response } from 'express';
 import { pool } from '../db/index.js';
 import { requireAuth, type AuthenticatedRequest } from '../middleware/auth.js';
+import { authenticatedLimiter } from '../middleware/rateLimiter.js';
 import { validate } from '../middleware/errorHandler.js';
 import {
   regionIdParamSchema,
@@ -38,6 +39,9 @@ import {
 } from '../controllers/experience/index.js';
 
 const router = Router();
+
+// Rate limit all user endpoints (60 req/min per IP)
+router.use(authenticatedLimiter);
 
 /**
  * GET /api/users/me

--- a/backend/src/routes/worldViewRoutes.ts
+++ b/backend/src/routes/worldViewRoutes.ts
@@ -39,6 +39,7 @@ import {
   getSavedHullParams,
 } from '../controllers/worldView/index.js';
 import { requireAuth, requireAdmin, optionalAuth } from '../middleware/auth.js';
+import { publicReadLimiter } from '../middleware/rateLimiter.js';
 import { validate } from '../middleware/errorHandler.js';
 import {
   worldViewIdParamSchema,
@@ -71,7 +72,7 @@ const router = Router();
 // World View CRUD
 // =============================================================================
 // GET is public (optionalAuth), mutations require admin
-router.get('/', optionalAuth, getWorldViews);
+router.get('/', publicReadLimiter, optionalAuth, getWorldViews);
 router.post('/', requireAuth, requireAdmin, validate(createWorldViewBodySchema), createWorldView);
 router.put('/:worldViewId', validate(worldViewIdParamSchema, 'params'), requireAuth, requireAdmin, validate(updateWorldViewBodySchema), updateWorldView);
 router.delete('/:worldViewId', validate(worldViewIdParamSchema, 'params'), requireAuth, requireAdmin, deleteWorldView);
@@ -80,50 +81,50 @@ router.delete('/:worldViewId', validate(worldViewIdParamSchema, 'params'), requi
 // Regions within a World View (user-defined groupings)
 // =============================================================================
 // Read operations are public
-router.get('/:worldViewId/regions', validate(worldViewIdParamSchema, 'params'), optionalAuth, getRegions);
-router.get('/:worldViewId/regions/root', validate(worldViewIdParamSchema, 'params'), optionalAuth, getRootRegions);
-router.get('/:worldViewId/regions/search', validate(worldViewIdParamSchema, 'params'), validate(regionSearchQuerySchema, 'query'), optionalAuth, searchRegions);
-router.get('/:worldViewId/regions/leaf', validate(worldViewIdParamSchema, 'params'), optionalAuth, getLeafRegions);
+router.get('/:worldViewId/regions', publicReadLimiter, validate(worldViewIdParamSchema, 'params'), optionalAuth, getRegions);
+router.get('/:worldViewId/regions/root', publicReadLimiter, validate(worldViewIdParamSchema, 'params'), optionalAuth, getRootRegions);
+router.get('/:worldViewId/regions/search', publicReadLimiter, validate(worldViewIdParamSchema, 'params'), validate(regionSearchQuerySchema, 'query'), optionalAuth, searchRegions);
+router.get('/:worldViewId/regions/leaf', publicReadLimiter, validate(worldViewIdParamSchema, 'params'), optionalAuth, getLeafRegions);
 // Write operations require admin
 router.post('/:worldViewId/regions', validate(worldViewIdParamSchema, 'params'), requireAuth, requireAdmin, validate(createRegionBodySchema), createRegion);
 
 // Legacy routes (groups -> regions)
-router.get('/:worldViewId/groups', validate(worldViewIdParamSchema, 'params'), optionalAuth, getRegions);
-router.get('/:worldViewId/groups/root', validate(worldViewIdParamSchema, 'params'), optionalAuth, getRootRegions);
+router.get('/:worldViewId/groups', publicReadLimiter, validate(worldViewIdParamSchema, 'params'), optionalAuth, getRegions);
+router.get('/:worldViewId/groups/root', publicReadLimiter, validate(worldViewIdParamSchema, 'params'), optionalAuth, getRootRegions);
 router.post('/:worldViewId/groups', validate(worldViewIdParamSchema, 'params'), requireAuth, requireAdmin, validate(createRegionBodySchema), createRegion);
 
 // =============================================================================
 // World View geometry operations
 // =============================================================================
-router.get('/:worldViewId/regions/root/geometries', validate(worldViewIdParamSchema, 'params'), optionalAuth, getRootRegionGeometries);
-router.get('/:worldViewId/groups/root/geometries', validate(worldViewIdParamSchema, 'params'), optionalAuth, getRootRegionGeometries);  // Legacy
+router.get('/:worldViewId/regions/root/geometries', publicReadLimiter, validate(worldViewIdParamSchema, 'params'), optionalAuth, getRootRegionGeometries);
+router.get('/:worldViewId/groups/root/geometries', publicReadLimiter, validate(worldViewIdParamSchema, 'params'), optionalAuth, getRootRegionGeometries);  // Legacy
 router.post('/:worldViewId/compute-geometries', validate(worldViewIdParamSchema, 'params'), requireAuth, requireAdmin, computeWorldViewGeometries);
-router.get('/:worldViewId/compute-geometries/status', validate(worldViewIdParamSchema, 'params'), optionalAuth, getComputationStatus);
+router.get('/:worldViewId/compute-geometries/status', publicReadLimiter, validate(worldViewIdParamSchema, 'params'), optionalAuth, getComputationStatus);
 router.post('/:worldViewId/compute-geometries/cancel', validate(worldViewIdParamSchema, 'params'), requireAuth, requireAdmin, cancelComputation);
-router.post('/:worldViewId/division-usage', validate(worldViewIdParamSchema, 'params'), validate(divisionUsageBodySchema), optionalAuth, getDivisionUsageCounts);
+router.post('/:worldViewId/division-usage', publicReadLimiter, validate(worldViewIdParamSchema, 'params'), validate(divisionUsageBodySchema), optionalAuth, getDivisionUsageCounts);
 
 // Display geometry operations (for zoom-based rendering)
-router.get('/:worldViewId/display-geometry-status', validate(worldViewIdParamSchema, 'params'), optionalAuth, getDisplayGeometryStatus);
+router.get('/:worldViewId/display-geometry-status', publicReadLimiter, validate(worldViewIdParamSchema, 'params'), optionalAuth, getDisplayGeometryStatus);
 router.post('/:worldViewId/regenerate-display-geometries', validate(worldViewIdParamSchema, 'params'), validate(regenerateDisplayQuerySchema, 'query'), requireAuth, requireAdmin, regenerateDisplayGeometries);
 
 // =============================================================================
 // Individual Region operations
 // =============================================================================
-router.get('/regions/:regionId/ancestors', validate(regionIdParamSchema, 'params'), optionalAuth, getRegionAncestors);
-router.get('/regions/:regionId/subregions', validate(regionIdParamSchema, 'params'), optionalAuth, getSubregions);
+router.get('/regions/:regionId/ancestors', publicReadLimiter, validate(regionIdParamSchema, 'params'), optionalAuth, getRegionAncestors);
+router.get('/regions/:regionId/subregions', publicReadLimiter, validate(regionIdParamSchema, 'params'), optionalAuth, getSubregions);
 router.put('/regions/:regionId', validate(regionIdParamSchema, 'params'), requireAuth, requireAdmin, validate(updateRegionBodySchema), updateRegion);
 router.delete('/regions/:regionId', validate(regionIdParamSchema, 'params'), validate(deleteRegionQuerySchema, 'query'), requireAuth, requireAdmin, deleteRegion);
 
 // Legacy routes (groups -> regions)
-router.get('/groups/:groupId/subgroups', optionalAuth, getSubregions);
+router.get('/groups/:groupId/subgroups', publicReadLimiter, optionalAuth, getSubregions);
 router.put('/groups/:groupId', requireAuth, requireAdmin, validate(updateRegionBodySchema), updateRegion);
 router.delete('/groups/:groupId', validate(deleteRegionQuerySchema, 'query'), requireAuth, requireAdmin, deleteRegion);
 
 // =============================================================================
 // Region members (administrative divisions and subregions)
 // =============================================================================
-router.get('/regions/:regionId/members', validate(regionIdParamSchema, 'params'), optionalAuth, getRegionMembers);
-router.get('/regions/:regionId/members/geometries', validate(regionIdParamSchema, 'params'), optionalAuth, getRegionMemberGeometries);
+router.get('/regions/:regionId/members', publicReadLimiter, validate(regionIdParamSchema, 'params'), optionalAuth, getRegionMembers);
+router.get('/regions/:regionId/members/geometries', publicReadLimiter, validate(regionIdParamSchema, 'params'), optionalAuth, getRegionMemberGeometries);
 router.post('/regions/:regionId/members', validate(regionIdParamSchema, 'params'), requireAuth, requireAdmin, validate(addDivisionsToRegionBodySchema), addDivisionsToRegion);
 router.delete('/regions/:regionId/members', validate(regionIdParamSchema, 'params'), requireAuth, requireAdmin, validate(removeDivisionsFromRegionBodySchema), removeDivisionsFromRegion);
 router.post('/regions/:regionId/members/move', validate(regionIdParamSchema, 'params'), requireAuth, requireAdmin, validate(moveMemberBodySchema), moveMemberToRegion);
@@ -132,7 +133,7 @@ router.post('/regions/:parentRegionId/flatten/:subregionId', requireAuth, requir
 router.post('/regions/:regionId/expand', validate(regionIdParamSchema, 'params'), requireAuth, requireAdmin, validate(expandToSubregionsBodySchema), expandToSubregions);
 
 // Legacy routes for members (groups -> regions)
-router.get('/groups/:groupId/members', optionalAuth, getRegionMembers);
+router.get('/groups/:groupId/members', publicReadLimiter, optionalAuth, getRegionMembers);
 router.post('/groups/:groupId/members', requireAuth, requireAdmin, validate(addDivisionsToRegionBodySchema), addDivisionsToRegion);
 router.delete('/groups/:groupId/members', requireAuth, requireAdmin, validate(removeDivisionsFromRegionBodySchema), removeDivisionsFromRegion);
 router.post('/groups/:groupId/members/:regionId/add-children', requireAuth, requireAdmin, validate(addChildDivisionsBodySchema), addChildDivisionsAsSubregions);
@@ -142,22 +143,22 @@ router.post('/groups/:groupId/expand', requireAuth, requireAdmin, validate(expan
 // =============================================================================
 // Region geometry
 // =============================================================================
-router.get('/regions/:regionId/geometry', validate(regionIdParamSchema, 'params'), validate(regionGeometryDetailQuerySchema, 'query'), optionalAuth, getRegionGeometry);
+router.get('/regions/:regionId/geometry', publicReadLimiter, validate(regionIdParamSchema, 'params'), validate(regionGeometryDetailQuerySchema, 'query'), optionalAuth, getRegionGeometry);
 router.put('/regions/:regionId/geometry', validate(regionIdParamSchema, 'params'), requireAuth, requireAdmin, validate(updateGeometryBodySchema), updateRegionGeometry);
 router.post('/regions/:regionId/geometry/compute', validate(regionIdParamSchema, 'params'), validate(computeGeometryQuerySchema, 'query'), requireAuth, requireAdmin, computeSingleRegionGeometry);
 router.get('/regions/:regionId/geometry/compute-stream', validate(regionIdParamSchema, 'params'), validate(computeSSEQuerySchema, 'query'), requireAuth, requireAdmin, computeSingleRegionGeometrySSE);
 router.post('/regions/:regionId/geometry/reset', validate(regionIdParamSchema, 'params'), requireAuth, requireAdmin, resetRegionToGADM);
-router.get('/regions/:regionId/subregions/geometries', validate(regionIdParamSchema, 'params'), validate(subregionGeometriesQuerySchema, 'query'), optionalAuth, getSubregionGeometries);
+router.get('/regions/:regionId/subregions/geometries', publicReadLimiter, validate(regionIdParamSchema, 'params'), validate(subregionGeometriesQuerySchema, 'query'), optionalAuth, getSubregionGeometries);
 
 // Hull preview and save (with custom parameters)
 router.post('/regions/:regionId/hull/preview', validate(regionIdParamSchema, 'params'), requireAuth, requireAdmin, validate(hullPreviewBodySchema), previewHullGeometry);
 router.post('/regions/:regionId/hull/save', validate(regionIdParamSchema, 'params'), requireAuth, requireAdmin, validate(hullSaveBodySchema), saveHullGeometry);
-router.get('/regions/:regionId/hull/params', validate(regionIdParamSchema, 'params'), optionalAuth, getSavedHullParams);
+router.get('/regions/:regionId/hull/params', publicReadLimiter, validate(regionIdParamSchema, 'params'), optionalAuth, getSavedHullParams);
 
 // Legacy routes for geometry (groups -> regions)
-router.get('/groups/:groupId/geometry', validate(regionGeometryDetailQuerySchema, 'query'), optionalAuth, getRegionGeometry);
+router.get('/groups/:groupId/geometry', publicReadLimiter, validate(regionGeometryDetailQuerySchema, 'query'), optionalAuth, getRegionGeometry);
 router.put('/groups/:groupId/geometry', requireAuth, requireAdmin, validate(updateGeometryBodySchema), updateRegionGeometry);
 router.post('/groups/:groupId/geometry/compute', validate(computeGeometryQuerySchema, 'query'), requireAuth, requireAdmin, computeSingleRegionGeometry);
-router.get('/groups/:groupId/subgroups/geometries', validate(subregionGeometriesQuerySchema, 'query'), optionalAuth, getSubregionGeometries);
+router.get('/groups/:groupId/subgroups/geometries', publicReadLimiter, validate(subregionGeometriesQuerySchema, 'query'), optionalAuth, getSubregionGeometries);
 
 export default router;

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,7 @@ docs/
 | [hull-geometry.md](tech/hull-geometry.md) | Archipelago visualization, concave hull generation |
 | [gadm-mapping.md](tech/gadm-mapping.md) | GADM database structure and integration |
 | [STATE-MANAGEMENT.md](tech/STATE-MANAGEMENT.md) | Frontend state: React Query, localStorage, Zustand considerations |
+| [rate-limiting.md](tech/rate-limiting.md) | Rate limiting tiers, per-endpoint strategy, adding limiters to new routes |
 | [hacking.md](tech/hacking.md) | Practical engineering guide for local debugging and safe changes |
 
 ## Tech — Planning

--- a/docs/security/SECURITY.md
+++ b/docs/security/SECURITY.md
@@ -50,7 +50,7 @@ Level 3 requirements are tracked but optional for now.
 | ORM | Drizzle ORM + parameterized `pool.query()` |
 | Headers | Helmet (CSP, X-Frame-Options, etc.) |
 | CORS | Restricted to FRONTEND_URL origin |
-| Rate limiting | express-rate-limit on auth + search + geocode endpoints |
+| Rate limiting | express-rate-limit on all endpoint tiers (auth, search, public read, authenticated user). See [rate-limiting.md](../tech/rate-limiting.md) |
 | Email verification | nodemailer with console fallback; 24h tokens, anti-enumeration |
 | Password breach check | HIBP k-Anonymity API on register + password change |
 | SAST | Semgrep via Docker (`npm run security:scan`) — p/owasp-top-ten, p/nodejs, p/react, p/secrets rulesets |

--- a/docs/tech/rate-limiting.md
+++ b/docs/tech/rate-limiting.md
@@ -1,0 +1,89 @@
+# Rate Limiting Strategy
+
+All rate limiters are defined in `backend/src/middleware/rateLimiter.ts`. Route files import from this shared module — no inline rate limiter definitions.
+
+## Tiers
+
+### 1. Auth (strict)
+
+High-value targets for brute force and credential stuffing.
+
+| Limiter | Window | Max | Applied to |
+|---------|--------|-----|------------|
+| `loginLimiter` | 15 min | 10 | `POST /api/auth/login` |
+| `registerLimiter` | 1 hour | 5 | `POST /api/auth/register` |
+| `refreshLimiter` | 1 min | 30 | `POST /api/auth/refresh` |
+| `verifyEmailLimiter` | 1 min | 10 | `POST /api/auth/verify-email` |
+| `exchangeCodeLimiter` | 1 min | 10 | `POST /api/auth/exchange-code` |
+| `resendLimiter` | 1 hour | 3 | `POST /api/auth/resend-verification` |
+
+### 2. Search (moderate)
+
+Endpoints that hit external APIs or perform text search.
+
+| Limiter | Window | Max | Applied to |
+|---------|--------|-----|------------|
+| `searchLimiter` | 1 min | 30 | `GET /api/experiences/search`, `GET /api/geocode/search` |
+
+### 3. Public read (generous)
+
+Unauthenticated endpoints serving the main UI. Applied to all `optionalAuth` and fully public GET routes.
+
+| Limiter | Window | Max | Applied to |
+|---------|--------|-----|------------|
+| `publicReadLimiter` | 1 min | 60 | World view/region reads, experience browsing, categories, treasures, geometries |
+
+**Files using this limiter:**
+- `worldViewRoutes.ts` — all `optionalAuth` GET routes (regions, geometries, members, hull params)
+- `experienceRoutes.ts` — `GET /categories`, `GET /region-counts`, `GET /by-region/:id`, `GET /`, `GET /:id`, `GET /:id/locations`, `GET /:id/treasures`
+
+### 4. Authenticated user (generous)
+
+Per-IP limiting for logged-in user actions (tracking visits, viewed treasures).
+
+| Limiter | Window | Max | Applied to |
+|---------|--------|-----|------------|
+| `authenticatedLimiter` | 1 min | 60 | All `userRoutes.ts` endpoints (visited regions/experiences/locations, viewed treasures) |
+
+Applied via `router.use(authenticatedLimiter)` at the router level since all routes require auth.
+
+### 5. Admin/curator (exempt)
+
+Routes behind `requireAuth` + `requireAdmin` or `requireCurator` do **not** have rate limiting. Rationale:
+
+- These are inaccessible to unauthenticated users
+- Admin operations include long-running batch tasks (geometry computation, sync) where rate limiting could cause failures
+- The attack surface is negligible (requires compromised admin credentials)
+
+**Exempt files:** `adminRoutes.ts`, `divisionRoutes.ts` (mounted behind admin middleware), `viewRoutes.ts`, `aiRoutes.ts`, plus write operations in `worldViewRoutes.ts` and `experienceRoutes.ts` curation routes.
+
+## Adding rate limiting to new endpoints
+
+When adding a new route, choose the appropriate limiter:
+
+| Endpoint type | Limiter to use | Import from |
+|---------------|----------------|-------------|
+| Public read (no auth) | `publicReadLimiter` | `middleware/rateLimiter.ts` |
+| Public search / external API call | `searchLimiter` | `middleware/rateLimiter.ts` |
+| Authenticated user action | `authenticatedLimiter` | `middleware/rateLimiter.ts` |
+| Auth flow (login, register, etc.) | Create dedicated limiter | `middleware/rateLimiter.ts` |
+| Admin/curator only | None needed | — |
+
+**Important:** Always apply rate limiting middleware **before** the route handler in the middleware chain. For per-route application, place it as the first middleware argument:
+
+```typescript
+router.get('/example', publicReadLimiter, validate(schema, 'query'), optionalAuth, handler);
+```
+
+For router-wide application (when all routes in a file need the same limiter):
+
+```typescript
+router.use(authenticatedLimiter);
+```
+
+## Technical details
+
+- All limiters use `standardHeaders: 'draft-7'` (returns `RateLimit-*` headers per IETF draft)
+- Legacy `X-RateLimit-*` headers are disabled
+- Keying is IP-based (default `express-rate-limit` behavior via `req.ip`)
+- In-memory store (default); consider Redis store for multi-instance deployments


### PR DESCRIPTION
## Description

Consolidates all rate limiters into a single shared middleware module (`backend/src/middleware/rateLimiter.ts`) and extends rate limiting coverage to all previously unprotected API endpoints.

### Changes

**New shared middleware** — all rate limiter definitions moved from inline route files to `backend/src/middleware/rateLimiter.ts`:
- Auth limiters (login, register, refresh, verify-email, exchange-code, resend)
- Search limiter (experiences + geocode)
- **New:** `publicReadLimiter` (60 req/min per IP) for unauthenticated read endpoints
- **New:** `authenticatedLimiter` (60 req/min per IP) for logged-in user actions

**Route coverage:**
- `worldViewRoutes.ts` — all 23 public/optionalAuth routes now rate-limited
- `experienceRoutes.ts` — 7 public GET routes now rate-limited (categories, region-counts, by-region, list, detail, locations, treasures)
- `userRoutes.ts` — router-level rate limiting on all 19 authenticated endpoints
- Admin/curator routes explicitly exempt (behind `requireAuth` + `requireAdmin`/`requireCurator`)

**CodeQL alert triage:**
- 97 alerts dismissed as `won't_fix` (admin/curator-only routes)
- Remaining 90 alerts will auto-close on next CodeQL re-scan

**Documentation:**
- New `docs/tech/rate-limiting.md` — full strategy with tiers, per-endpoint tables, and guide for adding rate limiters to new endpoints
- Updated `docs/security/SECURITY.md` and `docs/README.md`

## Related Issues

Closes #247
Closes #248
Relates to #249

## How Was This Tested?

- `npm run check` passes (lint + typecheck)
- Rate limiter behavior unchanged for existing endpoints (auth, search, geocode) — only the import location moved
- New limiters use the same proven `express-rate-limit` library with identical configuration patterns

## Checklist

- [x] Commit messages follow conventional format with title + body
- [x] Commits are signed (`Signed-off-by`)
- [x] Related issues linked
- [x] Lint and typecheck pass (`npm run check`)
- [x] Documentation updated

## Additional Comments

The 90 remaining open CodeQL alerts (public read + authenticated user) should auto-close after this PR merges and CodeQL re-scans the `main` branch with the new rate limiters in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)