### PR TITLE
chore: silence pre-existing lint warnings to enable --max-warnings 0 gate

### DIFF
--- a/backend/src/services/wikivoyageExtract/__tests__/parser.test.ts
+++ b/backend/src/services/wikivoyageExtract/__tests__/parser.test.ts
@@ -15,6 +15,7 @@ import {
 const FIXTURES = path.join(__dirname, 'fixtures');
 
 function loadFixture(name: string): string {
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- test fixtures from fixed dir
   return fs.readFileSync(path.join(FIXTURES, name), 'utf-8');
 }
 

--- a/backend/src/services/wikivoyageExtract/cache.ts
+++ b/backend/src/services/wikivoyageExtract/cache.ts
@@ -6,6 +6,7 @@
  * Auto-saves every 200 writes.
  */
 
+/* eslint-disable security/detect-non-literal-fs-filename -- paths are internally constructed, not user-controlled */
 import fs from 'fs';
 import path from 'path';
 import type { CacheStore } from './types.js';

--- a/backend/src/services/wikivoyageExtract/index.ts
+++ b/backend/src/services/wikivoyageExtract/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable security/detect-non-literal-fs-filename -- cache dir paths are validated (no user input) */
 /**
  * Wikivoyage Extraction Service
  *

--- a/backend/src/services/wikivoyageExtract/parser.ts
+++ b/backend/src/services/wikivoyageExtract/parser.ts
@@ -6,6 +6,7 @@
  * re.findall → matchAll().
  */
 
+/* eslint-disable security/detect-non-literal-regexp, security/detect-unsafe-regex -- patterns built from static keyword arrays, not user input */
 import type { WikiSection, RegionEntry } from './types.js';
 
 const COMMONS_FILE_URL = 'https://commons.wikimedia.org/wiki/Special:FilePath/';

--- a/frontend/src/components/regionMap/useMapInteractions.ts
+++ b/frontend/src/components/regionMap/useMapInteractions.ts
@@ -379,7 +379,7 @@ export function useMapInteractions({
       }
     }
     return null;
-  }, [hoveredRegionId, metadataById, mapRef, mapLoaded, sourceLayerName, contextLayerCount]);
+  }, [hoveredRegionId, metadataById, mapRef, sourceLayerName, contextLayerCount]);
 
   const hoverPreviewImage = useMemo(() => {
     if (!hoverPreview) return null;


### PR DESCRIPTION
## Summary

Silence four pre-existing ESLint security-rule warnings in `backend/src/services/wikivoyageExtract/*` with documented file-level disables, and fix one legitimate `react-hooks/exhaustive-deps` warning in `useMapInteractions.ts`.

This unblocks `npm run check` (which runs lint with `--max-warnings 0`) so subsequent `rebuild/*` PRs can use it as a hard verification gate.

## Why these warnings are false positives

| File | Rule | Why safe |
|------|------|----------|
| `cache.ts` | `security/detect-non-literal-fs-filename` | `this.filePath`/`dir`/`tmpPath` constructed in class config; never user-controlled |
| `index.ts` | `security/detect-non-literal-fs-filename` | Uses `DEFAULT_CACHE_PATH` constant + derived paths only |
| `parser.ts` | `security/detect-non-literal-regexp`, `security/detect-unsafe-regex` | All `new RegExp(...)` built from `escapeRegex()` over **static keyword arrays** (`HARD_SKIP`, `SKIP_WORDS`, `WEAK_MAP_KEYWORDS`) — no user input |
| `parser.test.ts` | `security/detect-non-literal-fs-filename` | Test fixture loader: fixed `__dirname/fixtures` + hardcoded test names |

## Real fix

`frontend/src/components/regionMap/useMapInteractions.ts:382` — `mapLoaded` was in the `useMemo` deps array but never referenced inside the callback. Removed it (genuine bug, not a suppression).

## Verification

- ✅ `npm run check` (lint + typecheck) — clean, 0 warnings
- ✅ `npm run knip` — no unused
- ✅ `TEST_REPORT_LOCAL=1 npm test` — all backend + frontend tests pass
- ✅ `npm run security:all` — Semgrep 0 findings; npm audit shows 2 pre-existing moderate vulns (`ip-address` via `express-rate-limit`) **unrelated to this PR** — will be addressed in a separate PR

## Wave 1 of multi-PR delivery

This is the foundation PR. Subsequent PRs (`rebuild/01-04`, `rebuild/05`) rebase onto it and rely on the `npm run check` gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)