### PR TITLE
fix(deps): bump express-rate-limit to clear ip-address XSS (GHSA-v2v4-37r5-5v8g)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -16,7 +16,7 @@
         "drizzle-orm": "^0.45.2",
         "express": "^4.21.0",
         "express-async-errors": "^3.1.1",
-        "express-rate-limit": "^8.2.2",
+        "express-rate-limit": "^8.5.1",
         "helmet": "^8.0.0",
         "jsonwebtoken": "^9.0.3",
         "nodemailer": "^8.0.5",
@@ -4819,12 +4819,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.2.tgz",
-      "integrity": "sha512-Ybv7bqtOgA914MLwaHWVFXMpMYeR1MQu/D+z2MaLYteqBsTIp9sY3AU7mGNLMJv8eLg8uQMpE20I+L2Lv49nSg==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -5343,9 +5343,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/backend/package.json
+++ b/backend/package.json
@@ -26,7 +26,7 @@
     "drizzle-orm": "^0.45.2",
     "express": "^4.21.0",
     "express-async-errors": "^3.1.1",
-    "express-rate-limit": "^8.2.2",
+    "express-rate-limit": "^8.5.1",
     "helmet": "^8.0.0",
     "jsonwebtoken": "^9.0.3",
     "nodemailer": "^8.0.5",


### PR DESCRIPTION
## Summary

Bump \`express-rate-limit\` from ^8.2.2 → ^8.5.1 to clear a transitive vulnerability in \`ip-address\`.

## Vulnerability

- **Advisory**: [GHSA-v2v4-37r5-5v8g](https://github.com/advisories/GHSA-v2v4-37r5-5v8g)
- **Severity**: Moderate
- **Component**: \`ip-address\` <= 10.1.0
- **Vector**: XSS in Address6 HTML-emitting methods
- **Path**: \`express-rate-limit\` 8.0.1–8.5.0 → \`ip-address\` (vulnerable)
- **Fix**: \`express-rate-limit\` ^8.5.1 pulls a non-vulnerable \`ip-address\`

## Before / After

| | Before | After |
|---|---|---|
| backend npm audit | 2 moderate | 0 vulnerabilities |
| frontend npm audit | 0 | 0 |

## Why a dedicated PR (not waiting for Dependabot)

The CI Security Scan job is red on main due to this advisory, blocking the multi-PR \`rebuild/*\` delivery sequence. Landing this first re-greens main so the rebuild PRs (starting with PR #310) can pass their security gate.

## Verification

- ✅ \`npm run check\` — lint + typecheck clean
- ✅ \`npm run knip\` — no unused
- ✅ \`TEST_REPORT_LOCAL=1 npm test\` — all backend + frontend tests pass
- ✅ \`npm run security:all\` — Semgrep 0 findings, npm audit 0 vulnerabilities (both packages)

## Diff

Two files only — \`backend/package.json\` (single version line) and \`backend/package-lock.json\` regen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)