### PR TITLE
ci: add Claude PR Review GitHub Action (subscription auth)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,57 @@
+name: Claude PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+  pull_request_review_comment:
+    types: [created]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+  actions: read
+
+jobs:
+  review:
+    # Authorization guard — public repo, subscription tokens.
+    # Only OWNER / MEMBER / COLLABORATOR can spend our CLAUDE_CODE_OAUTH_TOKEN.
+    #
+    # - pull_request from a fork: GitHub strips secrets, so the action would
+    #   fail safely — but we block earlier via author_association to avoid the
+    #   wasted run + visible failure.
+    # - issue_comment / pull_request_review_comment: secrets ARE available
+    #   even on public PRs, so without this guard ANY GitHub user could post
+    #   "@claude" and burn the subscription token. Block by comment author.
+    if: |
+      (
+        github.event_name == 'pull_request' &&
+        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
+      ) || (
+        github.event_name != 'pull_request' &&
+        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          trigger_phrase: "@claude"
+          prompt: |
+            Review this PR following the project's conventions documented in CLAUDE.md.
+
+            Priorities (in order):
+            1. Security — OWASP ASVS 5.0 Level 2 (see docs/security/SECURITY.md). Verify input validation (Zod via validate() middleware), parameterized queries / Drizzle, auth middleware on new endpoints, IDOR (resource-ownership checks), no secrets in logs/code.
+            2. Correctness — logic errors, missing error handling at system boundaries (don't flag defensive code requests where internal guarantees exist).
+            3. Refactoring hygiene — unused imports, dead variables, redundant null checks after early returns. See CLAUDE.md "Refactoring Hygiene" section.
+            4. Code reuse — flag inline reimplementations of patterns already in frontend/src/components/shared/ or frontend/src/utils/. See docs/tech/shared-frontend-patterns.md.
+            5. File size — flag files exceeding ~1000 lines (CLAUDE.md threshold) unless dense JSX with internal sub-components.
+            6. Dev-guide compliance — docs/tech/development-guide.md (commit format, granular commits, branch discipline).
+
+            Output format: inline review comments for specific issues, then one concise summary at the end. Be terse — actionable findings only, no narration of what the PR does.
+          claude_args: |
+            --model claude-sonnet-4-6
+            --max-turns 15


### PR DESCRIPTION
## Summary

Adds \`.github/workflows/claude-review.yml\` so PRs get an automated review from Claude using your Pro/Max subscription (no per-call billing).

## Authorization (the important part for a public repo)

The workflow is **guarded by \`author_association\`**. Only \`OWNER\` / \`MEMBER\` / \`COLLABORATOR\` can trigger the action.

| Scenario | What happens |
|---|---|
| **You open / push to a PR** | ✅ Review runs |
| **A collaborator opens / pushes** | ✅ Review runs |
| **You or a collaborator comment \`@claude\`** | ✅ Review runs |
| **Stranger forks + opens a PR** | ❌ Blocked early. (Even without the guard, GitHub strips secrets for fork PRs — but the guard prevents wasted CI minutes and visible auth failures.) |
| **Stranger comments \`@claude\` on a public PR** | ❌ Blocked. Without this guard, this would burn your subscription token because \`issue_comment\` runs with secrets available regardless of commenter. |

Repo is currently public with one collaborator (you). Adding more collaborators automatically grants them review-trigger ability — that's the trust boundary.

## Behavior

- **Automatic**: review fires on PR \`opened\` and \`synchronize\` (every push)
- **On-demand**: \`@claude\` mention in PR comments / review comments triggers a fresh review

## Configuration choices

| Setting | Value | Rationale |
|---|---|---|
| Action | \`anthropics/claude-code-action@v1\` | Official Anthropic action |
| Auth | \`CLAUDE_CODE_OAUTH_TOKEN\` secret | Subscription auth — counts against Pro/Max quota, no API billing |
| Model | \`claude-sonnet-4-6\` | Balance: strong code review without burning subscription tokens fast across the 40-PR delivery campaign |
| Max turns | 15 | Enough for thorough review on small/medium PRs; bounded to prevent runaway |
| Trigger phrase | \`@claude\` | Standard convention |

## Reviewer prompt

The prompt encodes this project's conventions:

1. **Security** — OWASP ASVS 5.0 Level 2 (Zod validation, parameterized queries, IDOR checks, auth middleware, no secrets in logs)
2. **Correctness** — logic errors, error handling at boundaries only
3. **Refactoring hygiene** — unused imports, dead vars, redundant null checks (per CLAUDE.md)
4. **Code reuse** — flag inline reimplementations of shared components/utils
5. **File size** — flag files > 1000 lines
6. **Dev-guide compliance** — \`docs/tech/development-guide.md\`

Output: inline comments + concise summary, terse and actionable.

## Setup steps required after merge

Reviews **will not fire** until the secret is configured:

1. Locally: \`claude setup-token\` → copies an OAuth token tied to your subscription
2. Repo: **Settings → Secrets and variables → Actions → New repository secret**
3. Name: \`CLAUDE_CODE_OAUTH_TOKEN\`, Value: paste token
4. Done — next PR open will trigger an automated review

## Test plan

- [ ] Merge this PR
- [ ] Add the secret per setup steps above
- [ ] Open a tiny test PR (or push a no-op commit to an existing PR) and verify the workflow runs and posts a review
- [ ] (Optional) ask someone outside the repo to comment \`@claude\` on a PR and confirm the workflow is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)