### PR TITLE
fix(ci): add actions/checkout step for Claude PR Review action

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -36,6 +36,12 @@ jobs:
       )
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history needed: the action restores trusted config files
+          # (CLAUDE.md, .claude/, etc.) from origin/main when reviewing PRs,
+          # because the PR head is treated as untrusted input.
+          fetch-depth: 0
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary

The Claude PR Review action (added in #312) failed on its first run with:

\`\`\`
fatal: not a git repository (or any of the parent directories): .git
Action failed with error: Command failed: git fetch origin main --depth=1
\`\`\`

[Failing run on PR #310](https://github.com/uncovering-world/track-your-regions/actions/runs/25568403364/job/75057628648)

## Root cause

The action's startup phase restores trusted config files (\`CLAUDE.md\`, \`.claude/\`, \`.mcp.json\`, \`.gitmodules\`, \`.ripgreprc\`, \`.husky\`) from \`origin/main\` before invoking Claude. This is a security feature — the PR head is treated as untrusted input, so the action only honors base-branch config. To do the restore it shells out to \`git fetch\` / \`git checkout\` against the workspace.

The original workflow had no \`actions/checkout\` step, so the workspace was empty and the \`git fetch\` failed.

## Fix

Add \`actions/checkout@v4\` with \`fetch-depth: 0\` before the action. Full history is needed so the action can fetch \`origin/main\` and restore trusted files even if main has diverged from the PR head.

## Test plan

- [ ] Merge this PR
- [ ] Wait for the next \`pull_request\` synchronize event on any open PR (e.g. #310 — push a no-op or just rebase) to trigger the workflow
- [ ] Confirm the action runs past the \`configureGitAuth\` step and posts a review

🤖 Generated with [Claude Code](https://claude.com/claude-code)