### PR TITLE
fix(ci): align Claude PR Review workflow with canonical docs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,8 +1,17 @@
 name: Claude PR Review
 
+# Aligned with anthropics/claude-code-action canonical examples:
+#   examples/claude.yml             — interactive @claude mentions
+#   examples/pr-review-comprehensive.yml — auto on PR open/sync
+# Authentication: Pro/Max subscription via CLAUDE_CODE_OAUTH_TOKEN.
+# See docs/usage.md inputs table — claude_code_oauth_token is the input
+# name for OAuth tokens (anthropic_api_key is for raw API keys).
+
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, ready_for_review, reopened]
+  pull_request_review:
+    types: [submitted]
   pull_request_review_comment:
     types: [created]
   issue_comment:
@@ -13,39 +22,35 @@ permissions:
   pull-requests: write
   issues: write
   id-token: write
+  # Required for Claude to read CI results on PRs (docs/security.md).
   actions: read
 
 jobs:
   review:
-    # Authorization guard — public repo, subscription tokens.
-    # Only OWNER / MEMBER / COLLABORATOR can spend our CLAUDE_CODE_OAUTH_TOKEN.
-    #
-    # - pull_request from a fork: GitHub strips secrets, so the action would
-    #   fail safely — but we block earlier via author_association to avoid the
-    #   wasted run + visible failure.
-    # - issue_comment / pull_request_review_comment: secrets ARE available
-    #   even on public PRs, so without this guard ANY GitHub user could post
-    #   "@claude" and burn the subscription token. Block by comment author.
+    # For pull_request events: the action enforces "users with write access
+    # only" internally (docs/security.md), and GitHub strips secrets for fork
+    # PRs — so we let it through unconditionally here.
+    # For comment / review events: filter by @claude mention to avoid
+    # spinning up a runner on every drive-by comment.
     if: |
-      (
-        github.event_name == 'pull_request' &&
-        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
-      ) || (
-        github.event_name != 'pull_request' &&
-        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
-      )
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v6
         with:
-          # Full history needed: the action restores trusted config files
-          # (CLAUDE.md, .claude/, etc.) from origin/main when reviewing PRs,
-          # because the PR head is treated as untrusted input.
-          fetch-depth: 0
-      - uses: anthropics/claude-code-action@v1
+          # Action runs `git fetch origin main --depth=1` internally to
+          # restore trusted base-branch config (CLAUDE.md, .claude/, etc.) —
+          # shallow checkout is sufficient.
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          trigger_phrase: "@claude"
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             Review this PR following the project's conventions documented in CLAUDE.md.
 


### PR DESCRIPTION
## Summary

Brings \`.github/workflows/claude-review.yml\` (added in #312) in line with the canonical examples and inputs table from [\`anthropics/claude-code-action\`](https://github.com/anthropics/claude-code-action).

The first run after #312 failed with \`fatal: not a git repository\` (fixed in #313 — added \`actions/checkout\`). The second run failed with \`Invalid API key\` — that is the issue this PR fixes, plus several alignment items.

## Changes

### 1. Auth input (the actual bug fix)

Per [\`docs/usage.md\` inputs table](https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md):

| Input | Description |
|---|---|
| \`anthropic_api_key\` | Anthropic API key (required for direct API, not needed for Bedrock/Vertex) |
| \`claude_code_oauth_token\` | Claude Code OAuth token (alternative to \`anthropic_api_key\`) |

\`CLAUDE_CODE_OAUTH_TOKEN\` (from \`claude setup-token\`) belongs on the \`claude_code_oauth_token\` input. Wiring it to \`anthropic_api_key\` made the SDK try to use the OAuth token as an \`x-api-key\` header → \"Invalid API key\".

### 2. Triggers — match \`docs/examples/pr-review-comprehensive.yml\` and \`docs/examples/claude.yml\`

\`\`\`diff
 pull_request:
-  types: [opened, synchronize]
+  types: [opened, synchronize, ready_for_review, reopened]
+pull_request_review:
+  types: [submitted]
\`\`\`

Reviews now also fire on draft → ready, reopen, and \`@claude\` in formal reviews.

### 3. Drop the custom \`author_association\` guard

[\`docs/security.md\`](https://github.com/anthropics/claude-code-action/blob/main/docs/security.md) explicitly states:

> **Repository Access**: The action can only be triggered by users with write access to the repository

So the previous custom \`author_association\` whitelist was redundant defense-in-depth. The canonical \`claude.yml\` example doesn't have it. Dropping it to match.

The remaining \`if:\` filter is purely for runner-cost optimization — skip the runner spin-up on PR comments that don't say \`@claude\`.

### 4. Checkout

\`\`\`diff
-uses: actions/checkout@v4
+uses: actions/checkout@v6
 with:
-  fetch-depth: 0
+  fetch-depth: 1
\`\`\`

Action runs \`git fetch origin main --depth=1\` internally to restore trusted base-branch config — shallow checkout is sufficient. Matches both canonical examples.

### 5. Doc citations in workflow comments

Each non-obvious choice now cites the upstream doc section it came from, so future maintenance can verify against canonical sources instead of guessing.

## Verification

- ✅ YAML parses (\`python3 -c \"import yaml; yaml.safe_load(...)\"\`)
- ✅ Auth input matches \`docs/usage.md\` inputs table
- ✅ Trigger types match \`examples/pr-review-comprehensive.yml\`
- ✅ Permissions block matches \`examples/claude.yml\`
- ✅ Checkout step + version + fetch-depth match canonical examples

## Test plan

- [ ] Merge this PR
- [ ] Push a no-op or rebase any open PR (e.g. #310) to trigger the workflow
- [ ] Confirm the action posts a review comment

## Outstanding setup the user must complete

For the action to actually run after this PR merges:

1. **Claude GitHub App must be installed** — \`docs/setup.md\` step 1: <https://github.com/apps/claude>. Easiest path: run \`claude setup-token\` in this repo and follow the \`/install-github-app\` prompt.
2. **\`CLAUDE_CODE_OAUTH_TOKEN\` repo secret** — already added (otherwise the previous run wouldn't have reached the SDK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)