### PR TITLE
fix(ci): align review prompt + tools with canonical solutions.md pattern

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,11 +1,12 @@
 name: Claude PR Review
 
-# Aligned with anthropics/claude-code-action canonical examples:
-#   examples/claude.yml             — interactive @claude mentions
-#   examples/pr-review-comprehensive.yml — auto on PR open/sync
-# Authentication: Pro/Max subscription via CLAUDE_CODE_OAUTH_TOKEN.
-# See docs/usage.md inputs table — claude_code_oauth_token is the input
-# name for OAuth tokens (anthropic_api_key is for raw API keys).
+# Aligned with anthropics/claude-code-action canonical patterns:
+#   docs/solutions.md > "Automatic PR Code Review"  — basic structure
+#   docs/solutions.md > "Custom PR Review Checklist" — per-team criteria
+#   docs/solutions.md > "Tips for All Solutions"    — REPO/PR NUMBER context, tool perms
+#   docs/configuration.md > "Custom Tools"          — Bash whitelist required for gh CLI
+#   docs/usage.md inputs table                       — claude_code_oauth_token for OAuth
+# Auth: Pro/Max subscription via CLAUDE_CODE_OAUTH_TOKEN.
 
 on:
   pull_request:
@@ -18,7 +19,7 @@ on:
     types: [created]
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
   issues: write
   id-token: write
@@ -27,11 +28,10 @@ permissions:
 
 jobs:
   review:
-    # For pull_request events: the action enforces "users with write access
-    # only" internally (docs/security.md), and GitHub strips secrets for fork
-    # PRs — so we let it through unconditionally here.
-    # For comment / review events: filter by @claude mention to avoid
-    # spinning up a runner on every drive-by comment.
+    # pull_request: action enforces "users with write access only" internally
+    # (docs/security.md), and GitHub strips secrets for fork PRs.
+    # Comment / review events: filter by @claude mention so we don't spin up
+    # a runner on every drive-by comment.
     if: |
       github.event_name == 'pull_request' ||
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
@@ -42,27 +42,40 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          # Action runs `git fetch origin main --depth=1` internally to
-          # restore trusted base-branch config (CLAUDE.md, .claude/, etc.) —
-          # shallow checkout is sufficient.
+          # Action runs `git fetch origin main --depth=1` internally to restore
+          # trusted base-branch config (CLAUDE.md, .claude/, etc.). Shallow OK.
           fetch-depth: 1
 
       - name: Run Claude Code
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # Self-contained prompt — no external doc references that would
+          # cost turns to read. Project conventions (CLAUDE.md, etc.) are
+          # auto-loaded into Claude Code's system context by the action.
           prompt: |
-            Review this PR following the project's conventions documented in CLAUDE.md.
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
 
-            Priorities (in order):
-            1. Security — OWASP ASVS 5.0 Level 2 (see docs/security/SECURITY.md). Verify input validation (Zod via validate() middleware), parameterized queries / Drizzle, auth middleware on new endpoints, IDOR (resource-ownership checks), no secrets in logs/code.
-            2. Correctness — logic errors, missing error handling at system boundaries (don't flag defensive code requests where internal guarantees exist).
-            3. Refactoring hygiene — unused imports, dead variables, redundant null checks after early returns. See CLAUDE.md "Refactoring Hygiene" section.
-            4. Code reuse — flag inline reimplementations of patterns already in frontend/src/components/shared/ or frontend/src/utils/. See docs/tech/shared-frontend-patterns.md.
-            5. File size — flag files exceeding ~1000 lines (CLAUDE.md threshold) unless dense JSX with internal sub-components.
-            6. Dev-guide compliance — docs/tech/development-guide.md (commit format, granular commits, branch discipline).
+            Review this PR. Project conventions live in CLAUDE.md (already in your context).
 
-            Output format: inline review comments for specific issues, then one concise summary at the end. Be terse — actionable findings only, no narration of what the PR does.
+            Focus areas (in order):
+            1. **Security** — OWASP ASVS 5.0 Level 2: input validation (Zod via validate() middleware), parameterized queries / Drizzle ORM, auth middleware on new endpoints, IDOR (resource-ownership checks), no secrets in code/logs, no concatenated SQL.
+            2. **Correctness** — logic errors, missing edge cases, incorrect error handling. Don't flag missing defensive code where internal guarantees exist.
+            3. **Refactoring hygiene** — unused imports, dead variables, redundant null checks after early returns, leftover commented code.
+            4. **Code reuse** — flag inline reimplementations of patterns already in `frontend/src/components/shared/` or `frontend/src/utils/`.
+            5. **File size** — flag files exceeding ~1000 lines unless they're dense JSX with internal sub-components.
+            6. **Commit hygiene** — granular commits with title + body, refactoring not mixed with feature work.
+
+            Workflow:
+            - Get the diff with `gh pr diff` and review it directly.
+            - Use `mcp__github_inline_comment__create_inline_comment` (with `confirmed: true`) for specific line-level issues.
+            - Use `gh pr comment` for the overall summary at the end.
+            - Only post GitHub comments — don't submit review text as chat messages.
+            - Be terse. Actionable findings only, no narration of what the PR does.
+
           claude_args: |
             --model claude-sonnet-4-6
-            --max-turns 15
+            --max-turns 30
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## Summary

Previous run (post-#314) reached the Claude SDK successfully but burned 15 turns and posted **zero comments**. Cost meter showed \$0.36 sub-token equivalent — wasted entirely on exploration.

This PR brings the workflow in line with [\`docs/solutions.md\` "Automatic PR Code Review"](https://github.com/anthropics/claude-code-action/blob/main/docs/solutions.md#automatic-pr-code-review) — the project's own canonical pattern.

## Why the previous run posted nothing

Researched against the docs:

1. **No tool whitelist** — Per [\`docs/configuration.md\` "Custom Tools"](https://github.com/anthropics/claude-code-action/blob/main/docs/configuration.md#custom-tools): _"Claude does NOT have access to execute arbitrary Bash commands by default."_ Without \`Bash(gh pr diff:*)\` whitelisted, Claude couldn't run \`gh pr diff\` and fell back to the default Read tool — opening files one-by-one to reconstruct what \`gh pr diff\` would give in a single call. Turn budget gone.

2. **Prompt referenced external docs** — saying _"see CLAUDE.md"_, _"see docs/security/SECURITY.md"_ made Claude actually open those files, more turn burn. CLAUDE.md is auto-loaded into Claude's context by the action; pointing at it is wasteful.

3. **Missing canonical context lines** — \`docs/solutions.md > Tips\` says always include \`REPO\` and \`PR NUMBER\` at the top of every prompt.

## Changes

All sourced from [\`docs/solutions.md\`](https://github.com/anthropics/claude-code-action/blob/main/docs/solutions.md):

| Change | Source |
|---|---|
| Add \`REPO\` + \`PR NUMBER\` to prompt | "Tips for All Solutions" |
| Self-contained prompt — embed conventions instead of doc references | "Automatic PR Code Review" |
| Explicit workflow instructions (use \`gh pr diff\`, \`mcp__github_inline_comment\` with \`confirmed:true\`, \`gh pr comment\` for summary) | "Automatic PR Code Review" basic example |
| \`--allowedTools\` whitelist matching the canonical example | "Automatic PR Code Review" |
| \`--max-turns 15 → 30\` | "Limiting Conversation Turns": _"Choose a value that gives Claude enough turns to complete typical tasks"_ — 30 gives headroom for thorough review now that exploration overhead is gone |
| \`contents: write → read\` | matches "Automatic PR Code Review" example (review job doesn't need write) |

## Verification

- ✅ YAML parses (\`python3 -c "import yaml; yaml.safe_load(...)"\`)
- ✅ Tool whitelist matches \`docs/solutions.md\` canonical example exactly
- ✅ Prompt structure matches "Automatic PR Code Review" pattern
- ✅ Each non-obvious choice cites the doc section in workflow comments

## Test plan

- [ ] Merge this PR
- [ ] Push a no-op or rebase any open PR (e.g. #310) to retrigger the workflow
- [ ] Confirm Claude posts at least one comment (top-level or inline) within 30 turns

## Sources

- [\`docs/solutions.md\` — Automatic PR Code Review](https://github.com/anthropics/claude-code-action/blob/main/docs/solutions.md#automatic-pr-code-review)
- [\`docs/configuration.md\` — Custom Tools](https://github.com/anthropics/claude-code-action/blob/main/docs/configuration.md#custom-tools)
- [\`docs/configuration.md\` — Limiting Conversation Turns](https://github.com/anthropics/claude-code-action/blob/main/docs/configuration.md#limiting-conversation-turns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)