### PR TITLE
ci: enable track_progress on Claude PR Review

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -51,6 +51,13 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
+          # Visible progress — posts a "Claude is reviewing..." tracking
+          # comment that updates with checkboxes and finalizes to "Completed".
+          # Useful signal even on no-issue PRs where the summary alone is
+          # easy to miss. See docs/solutions.md "Enhanced Example (With
+          # Progress Tracking)".
+          track_progress: true
+
           # Self-contained prompt — no external doc references that would
           # cost turns to read. Project conventions (CLAUDE.md, etc.) are
           # auto-loaded into Claude Code's system context by the action.


### PR DESCRIPTION
## Summary

Adds \`track_progress: true\` to the Claude PR Review action.

## Behavior change

The action now posts a tracking comment on every PR:

1. **\"Claude Code is reviewing this pull request...\"** (initial)
2. Updates with checkboxes as the review proceeds
3. Finalizes to **\"Completed\"** when done

This gives a visible signal in the PR thread even on no-issue PRs (where the review summary alone is easy to overlook). Matches Directus's production setup.

## Source

[\`docs/solutions.md\` "Enhanced Example (With Progress Tracking)"](https://github.com/anthropics/claude-code-action/blob/main/docs/solutions.md#enhanced-example-with-progress-tracking)

## Test plan

- [ ] Merge this PR
- [ ] Push a no-op or rebase any open PR (e.g. #316) to retrigger the workflow
- [ ] Verify a tracking comment appears and updates through the review

🤖 Generated with [Claude Code](https://claude.com/claude-code)