### PR TITLE
refactor(import): extract lifecycle controller (ADR-0009 spine, 1 of 8)

### DIFF
--- a/backend/src/controllers/admin/worldViewImportController.ts
+++ b/backend/src/controllers/admin/worldViewImportController.ts
@@ -9,9 +9,6 @@ import { Response } from 'express';
 import { pool } from '../../db/index.js';
 import type { AuthenticatedRequest } from '../../middleware/auth.js';
 import {
-  startImport,
-  getLatestImportStatus,
-  cancelImport,
   matchCountryLevel,
   matchChildrenAsCountries,
 } from '../../services/worldViewImport/index.js';
@@ -80,144 +77,6 @@ import {
   geocodeMatchRegion,
 } from '../../services/worldViewImport/aiMatcher.js';
 import { isOpenAIAvailable } from '../../services/ai/openaiService.js';
-
-// =============================================================================
-// Geoshape proxy
-// =============================================================================
-
-/**
- * Proxy Wikidata geoshape GeoJSON for a given Wikidata ID.
- * GET /api/admin/wv-import/geoshape/:wikidataId
- *
- * The maps.wikimedia.org endpoint requires User-Agent + Referer headers
- * that browsers won't send cross-origin, so we proxy through the backend.
- */
-export async function getGeoshape(req: AuthenticatedRequest, res: Response): Promise<void> {
-  const { wikidataId } = req.params;
-
-  try {
-    const url = `https://maps.wikimedia.org/geoshape?getgeojson=1&ids=${wikidataId}`;
-    const response = await fetch(url, {
-      headers: {
-        'User-Agent': 'TrackYourRegions/1.0 (https://github.com/nikolay/track-your-regions)',
-        'Referer': 'https://en.wikivoyage.org/',
-      },
-    });
-
-    if (!response.ok) {
-      res.status(response.status).json({ error: `Geoshape fetch failed: ${response.statusText}` });
-      return;
-    }
-
-    const geojson = await response.json();
-    res.json(geojson);
-  } catch (err) {
-    console.error(`[WV Import] Geoshape fetch error for ${wikidataId}:`, err);
-    res.status(502).json({ error: 'Failed to fetch geoshape from Wikimedia' });
-  }
-}
-
-// =============================================================================
-// Import endpoints
-// =============================================================================
-
-/**
- * Start a world view import from JSON data.
- * POST /api/admin/wv-import/import
- */
-/** Count nodes and max depth in a tree (for size validation) */
-function treeStats(node: { children?: unknown[] }, depth = 0): { nodes: number; maxDepth: number } {
-  let nodes = 1;
-  let maxDepth = depth;
-  const children = Array.isArray(node.children) ? node.children : [];
-  for (const child of children) {
-    const stats = treeStats(child as { children?: unknown[] }, depth + 1);
-    nodes += stats.nodes;
-    if (stats.maxDepth > maxDepth) maxDepth = stats.maxDepth;
-  }
-  return { nodes, maxDepth };
-}
-
-const MAX_TREE_NODES = 50_000;
-const MAX_TREE_DEPTH = 15;
-
-export async function startWorldViewImport(req: AuthenticatedRequest, res: Response): Promise<void> {
-  const { name, tree, matchingPolicy } = req.body;
-  console.log(`[WV Import] POST /import — name="${name}", children count=${tree?.children?.length ?? 'N/A'}, policy=${matchingPolicy ?? 'country-based'}`);
-
-  // Zod handles structural validation; check size limits
-  const stats = treeStats(tree);
-  if (stats.nodes > MAX_TREE_NODES) {
-    res.status(400).json({ error: `Tree too large: ${stats.nodes} nodes exceeds limit of ${MAX_TREE_NODES}` });
-    return;
-  }
-  if (stats.maxDepth > MAX_TREE_DEPTH) {
-    res.status(400).json({ error: `Tree too deep: depth ${stats.maxDepth} exceeds limit of ${MAX_TREE_DEPTH}` });
-    return;
-  }
-
-  // Check no import is already running
-  const existing = getLatestImportStatus();
-  if (existing && (existing.progress.status === 'importing' || existing.progress.status === 'matching')) {
-    res.status(409).json({ error: 'An import is already running' });
-    return;
-  }
-
-  const opId = startImport(tree, name, {
-    matchingPolicy: matchingPolicy ?? 'country-based',
-    sourceType: 'imported',
-    source: 'File upload',
-  });
-  console.log(`[WV Import] POST /import — started opId=${opId}`);
-  res.json({ started: true, operationId: opId });
-}
-
-/**
- * Get import status.
- * GET /api/admin/wv-import/import/status
- *
- * Returns in-memory progress when an import is running/recently completed,
- * otherwise falls back to querying DB for existing imported world views
- * so the review UI survives page reloads and re-logins.
- */
-export async function getWorldViewImportStatus(_req: AuthenticatedRequest, res: Response): Promise<void> {
-  const status = getLatestImportStatus();
-
-  // Always fetch existing imported world views from DB (both active and finalized)
-  const result = await pool.query(`
-    SELECT id, name, source_type FROM world_views
-    WHERE source_type IN ('wikivoyage', 'wikivoyage_done', 'imported', 'imported_done')
-    ORDER BY id DESC
-  `);
-  const importedWorldViews = result.rows.length > 0
-    ? result.rows.map(r => ({
-        id: r.id as number,
-        name: r.name as string,
-        sourceType: r.source_type as string,
-        reviewComplete: (r.source_type as string).endsWith('_done'),
-      }))
-    : undefined;
-
-  if (status) {
-    const isActive = status.progress.status === 'importing' || status.progress.status === 'matching';
-    console.log(`[WV Import] GET /import/status — opId=${status.opId}, status=${status.progress.status}, running=${isActive}, regions=${status.progress.createdRegions}/${status.progress.totalRegions}, countries=${status.progress.countriesMatched}/${status.progress.totalCountries}`);
-    res.json({ running: isActive, operationId: status.opId, ...status.progress, importedWorldViews });
-    return;
-  }
-
-  res.json({ running: false, importedWorldViews });
-}
-
-/**
- * Cancel a running import.
- * POST /api/admin/wv-import/import/cancel
- */
-export async function cancelWorldViewImport(_req: AuthenticatedRequest, res: Response): Promise<void> {
-  console.log(`[WV Import] POST /import/cancel`);
-  const cancelled = cancelImport();
-  console.log(`[WV Import] POST /import/cancel — result: ${cancelled}`);
-  res.json({ cancelled });
-}
 
 // =============================================================================
 // Match review endpoints
@@ -2374,3 +2233,13 @@ export function getRematchStatus(req: AuthenticatedRequest, res: Response): void
     res.json({ status: 'idle' });
   }
 }
+
+// =============================================================================
+// Domain-split barrel (see ADR-0009)
+// =============================================================================
+export {
+  getGeoshape,
+  startWorldViewImport,
+  getWorldViewImportStatus,
+  cancelWorldViewImport,
+} from './wvImportLifecycleController.js';

--- a/backend/src/controllers/admin/wvImportLifecycleController.ts
+++ b/backend/src/controllers/admin/wvImportLifecycleController.ts
@@ -1,0 +1,157 @@
+/**
+ * Admin WorldView Import — Lifecycle controller
+ *
+ * Owns: import session start/status/cancel + Wikidata geoshape proxy.
+ * See ADR-0009 for the domain-split rationale.
+ */
+
+import { Response } from 'express';
+import { pool } from '../../db/index.js';
+import type { AuthenticatedRequest } from '../../middleware/auth.js';
+import {
+  startImport,
+  getLatestImportStatus,
+  cancelImport,
+} from '../../services/worldViewImport/index.js';
+
+// =============================================================================
+// Geoshape proxy
+// =============================================================================
+
+/**
+ * Proxy Wikidata geoshape GeoJSON for a given Wikidata ID.
+ * GET /api/admin/wv-import/geoshape/:wikidataId
+ *
+ * The maps.wikimedia.org endpoint requires User-Agent + Referer headers
+ * that browsers won't send cross-origin, so we proxy through the backend.
+ */
+export async function getGeoshape(req: AuthenticatedRequest, res: Response): Promise<void> {
+  const { wikidataId } = req.params;
+
+  try {
+    const url = `https://maps.wikimedia.org/geoshape?getgeojson=1&ids=${wikidataId}`;
+    const response = await fetch(url, {
+      headers: {
+        'User-Agent': 'TrackYourRegions/1.0 (https://github.com/nikolay/track-your-regions)',
+        'Referer': 'https://en.wikivoyage.org/',
+      },
+    });
+
+    if (!response.ok) {
+      res.status(response.status).json({ error: `Geoshape fetch failed: ${response.statusText}` });
+      return;
+    }
+
+    const geojson = await response.json();
+    res.json(geojson);
+  } catch (err) {
+    console.error(`[WV Import] Geoshape fetch error for ${wikidataId}:`, err);
+    res.status(502).json({ error: 'Failed to fetch geoshape from Wikimedia' });
+  }
+}
+
+// =============================================================================
+// Tree validation helper (used by startWorldViewImport)
+// =============================================================================
+
+/** Count nodes and max depth in a tree (for size validation) */
+function treeStats(node: { children?: unknown[] }, depth = 0): { nodes: number; maxDepth: number } {
+  let nodes = 1;
+  let maxDepth = depth;
+  const children = Array.isArray(node.children) ? node.children : [];
+  for (const child of children) {
+    const stats = treeStats(child as { children?: unknown[] }, depth + 1);
+    nodes += stats.nodes;
+    if (stats.maxDepth > maxDepth) maxDepth = stats.maxDepth;
+  }
+  return { nodes, maxDepth };
+}
+
+const MAX_TREE_NODES = 50_000;
+const MAX_TREE_DEPTH = 15;
+
+// =============================================================================
+// Import endpoints
+// =============================================================================
+
+/**
+ * Start a world view import from JSON data.
+ * POST /api/admin/wv-import/import
+ */
+export async function startWorldViewImport(req: AuthenticatedRequest, res: Response): Promise<void> {
+  const { name, tree, matchingPolicy } = req.body;
+  console.log(`[WV Import] POST /import — name="${name}", children count=${tree?.children?.length ?? 'N/A'}, policy=${matchingPolicy ?? 'country-based'}`);
+
+  // Zod handles structural validation; check size limits
+  const stats = treeStats(tree);
+  if (stats.nodes > MAX_TREE_NODES) {
+    res.status(400).json({ error: `Tree too large: ${stats.nodes} nodes exceeds limit of ${MAX_TREE_NODES}` });
+    return;
+  }
+  if (stats.maxDepth > MAX_TREE_DEPTH) {
+    res.status(400).json({ error: `Tree too deep: depth ${stats.maxDepth} exceeds limit of ${MAX_TREE_DEPTH}` });
+    return;
+  }
+
+  // Check no import is already running
+  const existing = getLatestImportStatus();
+  if (existing && (existing.progress.status === 'importing' || existing.progress.status === 'matching')) {
+    res.status(409).json({ error: 'An import is already running' });
+    return;
+  }
+
+  const opId = startImport(tree, name, {
+    matchingPolicy: matchingPolicy ?? 'country-based',
+    sourceType: 'imported',
+    source: 'File upload',
+  });
+  console.log(`[WV Import] POST /import — started opId=${opId}`);
+  res.json({ started: true, operationId: opId });
+}
+
+/**
+ * Get import status.
+ * GET /api/admin/wv-import/import/status
+ *
+ * Returns in-memory progress when an import is running/recently completed,
+ * otherwise falls back to querying DB for existing imported world views
+ * so the review UI survives page reloads and re-logins.
+ */
+export async function getWorldViewImportStatus(_req: AuthenticatedRequest, res: Response): Promise<void> {
+  const status = getLatestImportStatus();
+
+  // Always fetch existing imported world views from DB (both active and finalized)
+  const result = await pool.query(`
+    SELECT id, name, source_type FROM world_views
+    WHERE source_type IN ('wikivoyage', 'wikivoyage_done', 'imported', 'imported_done')
+    ORDER BY id DESC
+  `);
+  const importedWorldViews = result.rows.length > 0
+    ? result.rows.map(r => ({
+        id: r.id as number,
+        name: r.name as string,
+        sourceType: r.source_type as string,
+        reviewComplete: (r.source_type as string).endsWith('_done'),
+      }))
+    : undefined;
+
+  if (status) {
+    const isActive = status.progress.status === 'importing' || status.progress.status === 'matching';
+    console.log(`[WV Import] GET /import/status — opId=${status.opId}, status=${status.progress.status}, running=${isActive}, regions=${status.progress.createdRegions}/${status.progress.totalRegions}, countries=${status.progress.countriesMatched}/${status.progress.totalCountries}`);
+    res.json({ running: isActive, operationId: status.opId, ...status.progress, importedWorldViews });
+    return;
+  }
+
+  res.json({ running: false, importedWorldViews });
+}
+
+/**
+ * Cancel a running import.
+ * POST /api/admin/wv-import/import/cancel
+ */
+export async function cancelWorldViewImport(_req: AuthenticatedRequest, res: Response): Promise<void> {
+  console.log(`[WV Import] POST /import/cancel`);
+  const cancelled = cancelImport();
+  console.log(`[WV Import] POST /import/cancel — result: ${cancelled}`);
+  res.json({ cancelled });
+}

--- a/docs/decisions/0009-import-controller-domain-split.md
+++ b/docs/decisions/0009-import-controller-domain-split.md
@@ -1,0 +1,57 @@
+# ADR-0009: Split worldViewImportController by domain (lifecycle, match, coverage, AI, tree-ops, etc.)
+
+## Status
+Accepted — 2026-04-25
+
+## Context
+`backend/src/controllers/admin/worldViewImportController.ts` grew to 2376 lines covering
+seven distinct concerns: import session lifecycle, region-to-division match operations
+(accept/reject/batch), coverage gap analysis, AI-assisted match endpoints, tree
+operations (dismiss children, undo), hierarchy flattening, and finalization/rematch
+flows. Editing one concern requires loading the entire file in context; testing one
+concern requires understanding shared state across all of them. CLAUDE.md flags files
+over ~1000 lines for refactor consideration.
+
+## Decision
+Split by **domain** (the conceptual operation a handler performs) rather than by
+**HTTP verb** (GET vs POST) or **lifecycle phase** (import vs review vs finalize).
+Eight focused files, each owning one domain:
+
+- `wvImportLifecycleController.ts` — session start/status/cancel + Wikidata geoshape proxy
+- `wvImportMatchController.ts` — accept/reject/batch match operations + match tree retrieval
+- `wvImportCoverageController.ts` — coverage gap detection + SSE progress + geo-suggest
+- `wvImportAIController.ts` — AI-assisted match endpoints (start, status, cancel, single-region search)
+- `wvImportTreeOpsController.ts` — destructive tree operations (dismiss children)
+- `wvImportHierarchyController.ts` — non-destructive hierarchy ops (undo)
+- `wvImportFlattenController.ts` — flattening + sync-instances + handle-as-grouping
+- `wvImportFinalizeController.ts` + `wvImportRematchController.ts` — finalization + rematch flow
+
+The monolith `worldViewImportController.ts` becomes a re-export barrel so existing
+import sites in `adminRoutes.ts` don't change.
+
+## Alternatives considered
+- **By HTTP verb:** Group all `GET` handlers together, all `POST` together. Rejected
+  because verb says nothing about cohesion — `GET /coverage` and `GET /match-tree` have
+  no shared concepts.
+- **By lifecycle phase (import / review / finalize):** Initially appealing but the
+  match operations span all three phases, so splitting by phase produces fragmented
+  files that all touch `region_match_status`.
+- **Keep monolith, split into helper modules:** Solves file size but not the
+  conceptual coupling — handlers still cohabit, exports still flat.
+
+## Consequences
+- **+** Each domain file fits comfortably in an editor context (largest is ~600
+  lines after extraction).
+- **+** Future feature work on one domain (e.g. CV matching enhancements) doesn't
+  touch unrelated domain files.
+- **+** The monolith becomes a routing-stable barrel; route imports never need to
+  follow split events.
+- **−** Some shared state (`undoEntries` Map, used by tree-ops + flatten + hierarchy)
+  remains in the monolith / a shared utils module rather than being inlined in any
+  one domain. Documented per-PR.
+- **−** Initial split costs 8 stacked PRs of refactor churn before any feature work
+  resumes. Acceptable: tier-0 cleanup unblocks the lint gate, spine refactor
+  unblocks all subsequent feature PRs from inheriting the monolith.
+
+## Implementation
+Spine PRs 10–17 in `docs/inbox/2026-04-25-rebuild-spine-plan.md`.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -17,6 +17,7 @@ and mark the old one as `Superseded by ADR-XXXX`.
 | [0006](0006-martin-for-vector-tiles.md) | Martin for vector tile serving | Accepted | 2025-01-01 |
 | [0007](0007-jwt-with-httponly-refresh-tokens.md) | JWT with httpOnly refresh tokens | Accepted | 2025-02-01 |
 | [0008](0008-tanstack-query-for-server-state.md) | TanStack Query for server state | Accepted | 2025-01-01 |
+| [0009](0009-import-controller-domain-split.md) | Split worldViewImportController by domain | Accepted | 2026-04-25 |
 | [adr-template](adr-template.md) | — Template — | — | — |
 
 ## When to create an ADR


### PR DESCRIPTION
## Description

First PR of the **ADR-0009 spine refactor** — splitting the 2376-line \`worldViewImportController.ts\` by domain into eight focused files.

This PR introduces ADR-0009 and lands the **first split**: extracts the **import session lifecycle** concern (session start/status/cancel + Wikidata geoshape proxy) into a dedicated \`wvImportLifecycleController.ts\`. The original file shrinks accordingly; everything else is unchanged. Same routes, same behavior — just different file boundaries.

Subsequent PRs in the chain will extract \`match\`, \`coverage\`, \`AI\`, \`tree-ops\`, \`hierarchy\`, \`flatten\`, and \`finalize+rematch\` controllers in turn until the original file becomes a thin re-export shim and the split is complete.

**ADR**: \`docs/decisions/0009-import-controller-domain-split.md\` (added in this PR).

## Related Issues

None.

## How Was This Tested?

- \`npm run check\` — lint + typecheck clean (backend + frontend)
- \`npm run knip\` — no unused files / dependencies / unlisted
- \`TEST_REPORT_LOCAL=1 npm test\` — full backend + frontend unit suite passes
- \`npm run security:all\` — Semgrep 0 findings, npm audit 0 vulnerabilities

No new tests added — pure file-boundary refactor. Behavior covered by existing route-level tests for the import flow.

## Checklist

- [x] Commit messages follow the standard template (title + body, signed)
- [x] All commits are signed
- [x] Related issues are mentioned in the description above
- [x] Linter checks have been passed

## Additional Comments

- **Diff stat**: 4 files changed, +225/-141. \`worldViewImportController.ts\` shrinks from 2376→2226 lines as the lifecycle handlers move out.
- **Wave 2 of multi-PR delivery**: this is the first of 8 stacked PRs that complete ADR-0009. The remaining 7 (rebuild/11–17) are queued and rebase cleanly on top of each predecessor.
- **No DB or API contract changes** — pure backend refactor; routes still mount the same handlers, just imported from the new file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)