### PR TITLE
ci(claude): enable thread-resolve capability via gh api graphql

### DIFF
--- a/.github/workflows/claude-qa.yml
+++ b/.github/workflows/claude-qa.yml
@@ -56,5 +56,12 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # No `prompt:` — drops into tag mode, treats the @claude
           # comment as the user's request. See docs/experimental.md.
+          #
+          # Whitelist gh CLI + GraphQL so Claude can act on the PR
+          # when asked: read the diff, post comments, AND resolve
+          # review threads (e.g. "@claude resolve the addressed
+          # threads on this PR" → uses GraphQL resolveReviewThread).
+          # GitHub REST has no "resolve" endpoint; only GraphQL does.
           claude_args: |
             --model claude-sonnet-4-6
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos:*),Bash(grep:*),Bash(rg:*)"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -98,12 +98,14 @@ jobs:
             1. Get the diff: `gh pr diff`
             2. For each specific line-level concern → inline comment
             3. Once all inline comments are posted → ONE top-level summary via `gh pr comment`
+            4. **Re-run only**: if there are existing UNRESOLVED claude[bot] inline review threads on this PR (use `gh api graphql` with the `reviewThreads` query), check whether the diff at the thread's path/line still contains the issue you previously flagged. For each thread whose concern is now addressed, resolve it via the GraphQL `resolveReviewThread` mutation. Skip threads where the original concern still applies — leave those open. Skip threads from other authors (CodeQL, CodeRabbit, humans) — only resolve your own.
 
             Other rules:
             - Only post GitHub comments — don't submit review text as chat messages.
             - Be terse. Actionable findings only, no narration of what the PR does.
+            - On a clean re-review (everything resolved + no new findings), the top-level summary should explicitly mention how many threads you resolved (e.g. "Resolved 3 prior findings; no new issues.").
 
           claude_args: |
             --model claude-sonnet-4-6
             --max-turns 30
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*)"


### PR DESCRIPTION
## Description

Lets Claude resolve PR review threads when appropriate. Two scopes added in one commit:

| Scope | Workflow | Trigger | Behavior |
|---|---|---|---|
| **A — Reactive** | \`claude-qa.yml\` | \`@claude\` mention | When user explicitly asks ("@claude resolve the addressed threads on this PR"), Claude calls the GraphQL \`resolveReviewThread\` mutation. No auto-resolve without an explicit user request. |
| **B — Proactive on re-runs** | \`claude-review.yml\` | \`pull_request\` synchronize | New 4th step in the review prompt: on re-runs, check existing unresolved \`claude[bot]\` threads, verify whether the diff at each thread's path/line still contains the original issue, and resolve those that are addressed. Only resolves Claude's own threads — never CodeQL/CodeRabbit/human ones. |

## Why GraphQL?

The claude-code-action's MCP doesn't expose a resolve-thread tool. GitHub REST has no resolve endpoint either. Only [GitHub GraphQL](https://docs.github.com/en/graphql/reference/mutations#resolvereviewthread)'s \`resolveReviewThread\` mutation supports it — so we wire it via the gh CLI's GraphQL passthrough (\`gh api graphql\`).

## Related Issues

None.

## How Was This Tested?

- YAML validation: both modified files parse with \`python3 -c "import yaml; yaml.safe_load(...)"\`.
- Manual API check: confirmed \`resolveReviewThread\` mutation exists in GitHub's GraphQL schema and takes \`threadId\` as input.

End-to-end test (post-merge):
- A) Comment \`@claude resolve the addressed threads\` on any open PR with prior Claude threads → \`claude-qa.yml\` fires; Claude lists threads, evaluates, resolves the addressed ones.
- B) Push a no-op or rebase to a PR that has prior \`claude[bot]\` review threads → \`claude-review.yml\` re-runs; Claude reviews the new diff AND resolves any old threads now addressed.

## Checklist

- [x] Commit messages follow the standard template (title + body, signed)
- [x] All commits are signed
- [x] Related issues are mentioned in the description above
- [x] Linter checks have been passed (YAML validation)

## Additional Comments

- **Whitelist scope**: \`Bash(gh api graphql:*)\` is general — Claude could in principle make any GraphQL call. Permissions on the workflow's \`GITHUB_TOKEN\` constrain what's actually possible (e.g. the QA workflow is \`contents: read\` after the previous PR's hardening). For tighter restriction we could later add a wrapper script that only invokes \`resolveReviewThread\`, but that's overkill for now.
- **Claude only resolves its OWN threads** in Approach B — explicit prompt rule. CodeQL / CodeRabbit / human threads are left alone unless a human resolves them.
- **False-positive risk** (Approach B): Claude could misjudge "addressed" and close a thread that still needs attention. Bounded by "own threads only" and easy to unresolve manually if it happens.
- **Diff stat**: \`claude-qa.yml\` +7 lines (whitelist + comment), \`claude-review.yml\` +3 / -1 (workflow step + tool whitelist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)