### PR TITLE
ci(claude-review): adopt Anthropic's review-prompt pattern + --effort xhigh

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -70,15 +70,76 @@ jobs:
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            Review this PR. Project conventions live in CLAUDE.md (already in your context).
+            You are reviewing this PR. Project conventions live in CLAUDE.md
+            (already in your context). The structure below mirrors
+            anthropics/claude-code-security-review's prompt design — phased
+            methodology, generic categories, confidence-based filter.
 
-            Focus areas (in order):
-            1. **Security** — OWASP ASVS 5.0 Level 2: input validation (Zod via validate() middleware), parameterized queries / Drizzle ORM, auth middleware on new endpoints, IDOR (resource-ownership checks), no secrets in code/logs, no concatenated SQL.
-            2. **Correctness** — logic errors, missing edge cases, incorrect error handling. Don't flag missing defensive code where internal guarantees exist.
-            3. **Refactoring hygiene** — unused imports, dead variables, redundant null checks after early returns, leftover commented code.
-            4. **Code reuse** — flag inline reimplementations of patterns already in `frontend/src/components/shared/` or `frontend/src/utils/`.
-            5. **File size** — flag files exceeding ~1000 lines unless they're dense JSX with internal sub-components.
-            6. **Commit hygiene** — granular commits with title + body, refactoring not mixed with feature work.
+            ## CRITICAL INSTRUCTIONS
+
+            1. **Confidence-based filter.** Only flag findings you'd defend
+               in a real PR review. Skip speculative ("could be"),
+               theoretical, or low-impact findings. If you can't name the
+               specific control-flow path that's broken or the specific
+               contract that's violated, you're guessing — trace harder or
+               skip.
+            2. **Avoid noise.** Skip stylistic preferences, defensive-code
+               wishes where internal guarantees exist, reformatting wishes.
+            3. **Verify before flagging.** When tempted to flag "X is
+               missing", check upstream (middleware, wrappers, project
+               conventions in CLAUDE.md / dev-guide) and downstream (is the
+               supposed gap actually reachable?). If verification shows it's
+               handled elsewhere — Zod `validate()` at the route layer,
+               `requireAuth` middleware, generic error handler — DON'T flag.
+               False positives waste reviewer attention.
+            4. **Pre-existing ≠ skip.** Latent bugs in moved/refactored code
+               STILL get flagged with a `[pre-existing]` prefix. Refactoring
+               is the natural moment to surface latent issues.
+            5. **Calibrate severity.** Critical / Major / Minor / Note based
+               on blast radius, exploitability, recoverability — NOT on
+               visual prominence.
+
+            ## ANALYSIS METHODOLOGY (phases)
+
+            **Phase 1 — Context.** Read CLAUDE.md and any relevant
+            `docs/tech/*` doc for the area touched by this PR. Note the
+            project's patterns and conventions for this domain.
+
+            **Phase 2 — Diff.** Get the diff with `gh pr diff`. Identify
+            what changed: pure move vs new behavior vs deletion.
+
+            **Phase 3 — Trace.** For each non-trivial change, MENTALLY
+            EXECUTE the code paths — happy path, early returns, error
+            paths, edge conditions. Don't assume a familiar pattern
+            (try/finally, async/await, transactions, locks) is implemented
+            correctly because the shape is correct. Each control-flow exit
+            must satisfy the required contract (commit/rollback, release,
+            close, unlock, cleanup). Verify, don't pattern-match.
+
+            **Phase 4 — Verify.** For each candidate finding, run the
+            CRITICAL INSTRUCTION #3 check (upstream/downstream) before
+            posting. Drop verified-handled candidates.
+
+            ## CATEGORIES (general — not exhaustive, not bug-specific)
+
+            - **Security** — OWASP ASVS 5.0 L2: input handling at trust
+              boundaries, authn/authz on endpoints, parameterized queries,
+              secret handling, access control (IDOR), injection vectors
+            - **Correctness** — logic errors, missing edge cases, control-flow
+              exits that skip required cleanup, error-path correctness,
+              concurrent state handling
+            - **Refactoring hygiene** — dead code left behind, unused imports,
+              redundant guards, leftover commented code
+            - **Convention adherence** — code reuse (shared components/utils),
+              file-size limits, dev-guide patterns, commit hygiene
+
+            ## EXCLUSIONS (don't report)
+
+            - Style preferences without correctness impact
+            - "Could be more readable" without naming a specific contract
+              violated
+            - Defensive code suggestions where internal guarantees exist
+            - Theoretical issues with no plausible exploitation/failure path
 
             ## OUTPUT RULES (mandatory)
 
@@ -107,5 +168,6 @@ jobs:
 
           claude_args: |
             --model claude-sonnet-4-6
-            --max-turns 30
+            --effort xhigh
+            --max-turns 50
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*)"


### PR DESCRIPTION
## Description

Strengthens the Claude PR review prompt after PR #336 (Claude said _"Clean. No issues."_ but CodeRabbit caught two critical transaction leaks).

**First draft attempted to list specific bug classes** ("transaction lifecycle", "resource lifecycle", etc.). Reverted that approach — example-specific rules don't generalize, they bias toward yesterday's bug shape and miss new ones.

**Studied the canonical reference**: [`anthropics/claude-code-security-review/claudecode/prompts.py`](https://github.com/anthropics/claude-code-security-review/blob/main/claudecode/prompts.py) — Anthropic's own dedicated review action. Adopted the same pattern.

## Pattern adopted (mirrors claude-code-security-review)

| Section | Purpose |
|---|---|
| **CRITICAL INSTRUCTIONS** (up front) | Domain-agnostic principles: confidence-based filter, avoid noise, verify before flagging, pre-existing-bug flagging convention, severity calibration |
| **ANALYSIS METHODOLOGY (phased)** | Context → Diff → Trace → Verify. Phase 3 explicitly says _"MENTALLY EXECUTE the code paths — happy path, early returns, error paths, edge conditions. Don't assume a familiar pattern is implemented correctly because the shape is correct."_ This is the methodology that would have caught PR #336 — without mentioning transactions specifically. The same principle applies to file handles, locks, sockets, anything. |
| **Generic CATEGORIES** | security / correctness / refactoring hygiene / convention adherence — categories named, no specific bug instances |
| **Explicit EXCLUSIONS** | Style preferences, defensive-code wishes, theoretical issues |
| **OUTPUT RULES** (unchanged) | Inline for line-level, top-level summary only, prefer mcp inline tool, etc. |

## Why no specific bug examples

Specific examples ("transaction lifecycle in pg pools") bias the reviewer toward that exact pattern and create a false sense of completeness. Tomorrow's bug will be in a different shape. Generic principles ("trace every control-flow exit") + a methodology that forces the reviewer to mentally execute paths catches the same class without the bias.

## --effort xhigh

The Claude Code CLI exposes `--effort low|medium|high|xhigh|max`. Higher effort = more per-turn thinking budget, slower runs, better deep-tracing. `xhigh` is the sweet spot for review depth without going to `max` (which can run away on long PRs). Source: [code.claude.com/docs/en/cli-reference](https://code.claude.com/docs/en/cli-reference).

## Other changes

- `--max-turns 30 → 50`: gives Phase 3's path-tracing budget headroom

## What this is NOT

- Not a model bump (still Sonnet 4.6 — issue was prompt structure, not raw capability)
- Not adding allowedTools (same set)
- Not changing claude-qa.yml or claude-dependabot.yml (specialized prompts for their use cases)

## Related Issues

None.

## How Was This Tested?

- YAML validation: `python3 -c "import yaml; yaml.safe_load(...)"` — valid
- Manual cross-check against PR #336's missed bug: the new Phase 3 ("MENTALLY EXECUTE the code paths — happy path, early returns") is precisely the rule that would have caught the transaction-leak case
- Cross-check against the recurring false-positive class on PR #328 (wikidataId Zod check) and PR #336 (param validation): the new CRITICAL INSTRUCTION #3 (verify upstream before flagging) explicitly addresses it

End-to-end test (post-merge): the next PR with substantive code (e.g. rebuild/15) will exercise both the deeper tracing AND the higher effort budget.

## Checklist

- [x] Commit messages follow the standard template (title + body, signed)
- [x] All commits are signed
- [x] Related issues are mentioned in the description above
- [x] Linter checks have been passed (YAML)

## Additional Comments

- **Diff stat**: workflow file +72 / -10
- **Two iterations on this branch**: original draft (specific bug classes) → force-pushed amend (Anthropic's pattern). Second iteration after the user pointed out that listing specific bugs doesn't generalize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)