### PR TITLE
feat(worldview): show delete-impact preview before confirming deletion (rebuild/52)

### DIFF
--- a/backend/src/controllers/worldView/index.ts
+++ b/backend/src/controllers/worldView/index.ts
@@ -16,6 +16,7 @@ export {
   getWorldViews,
   createWorldView,
   updateWorldView,
+  getDeleteImpact,
   deleteWorldView,
 } from './worldViewCrud.js';
 

--- a/backend/src/controllers/worldView/worldViewCrud.ts
+++ b/backend/src/controllers/worldView/worldViewCrud.ts
@@ -63,6 +63,42 @@ export async function updateWorldView(req: Request, res: Response): Promise<void
 }
 
 /**
+ * Get a preview of what deleting a World View will destroy.
+ * Returns counts of regions, experience-to-region assignments, and user visit
+ * records so admins can see the blast radius before confirming deletion.
+ */
+export async function getDeleteImpact(req: Request, res: Response): Promise<void> {
+  const worldViewId = parseInt(String(req.params.worldViewId));
+
+  const check = await pool.query(
+    'SELECT is_default FROM world_views WHERE id = $1',
+    [worldViewId],
+  );
+  if (check.rows.length === 0) {
+    throw notFound(`World View ${worldViewId} not found`);
+  }
+
+  const result = await pool.query(`
+    SELECT
+      (SELECT COUNT(*) FROM regions WHERE world_view_id = $1)::int AS region_count,
+      (SELECT COUNT(*) FROM experience_regions er
+       JOIN regions r ON r.id = er.region_id
+       WHERE r.world_view_id = $1)::int AS experience_assignment_count,
+      (SELECT COUNT(*) FROM user_visited_regions uvr
+       JOIN regions r ON r.id = uvr.region_id
+       WHERE r.world_view_id = $1)::int AS user_visit_count
+  `, [worldViewId]);
+
+  const row = result.rows[0];
+  res.json({
+    regionCount: row.region_count,
+    experienceAssignmentCount: row.experience_assignment_count,
+    userVisitCount: row.user_visit_count,
+    isDefault: check.rows[0].is_default,
+  });
+}
+
+/**
  * Delete a World View
  */
 export async function deleteWorldView(req: Request, res: Response): Promise<void> {

--- a/backend/src/routes/worldViewRoutes.ts
+++ b/backend/src/routes/worldViewRoutes.ts
@@ -3,6 +3,7 @@ import {
   getWorldViews,
   createWorldView,
   updateWorldView,
+  getDeleteImpact,
   deleteWorldView,
   getRegions,
   getRootRegions,
@@ -76,6 +77,7 @@ const router = Router();
 router.get('/', publicReadLimiter, optionalAuth, getWorldViews);
 router.post('/', requireAuth, requireAdmin, validate(createWorldViewBodySchema), createWorldView);
 router.put('/:worldViewId', validate(worldViewIdParamSchema, 'params'), requireAuth, requireAdmin, validate(updateWorldViewBodySchema), updateWorldView);
+router.get('/:worldViewId/delete-impact', validate(worldViewIdParamSchema, 'params'), requireAuth, requireAdmin, getDeleteImpact);
 router.delete('/:worldViewId', validate(worldViewIdParamSchema, 'params'), requireAuth, requireAdmin, deleteWorldView);
 
 // =============================================================================

--- a/frontend/src/api/worldViews.ts
+++ b/frontend/src/api/worldViews.ts
@@ -23,6 +23,17 @@ export async function updateWorldView(worldViewId: number, data: { name?: string
   });
 }
 
+export interface DeleteImpact {
+  regionCount: number;
+  experienceAssignmentCount: number;
+  userVisitCount: number;
+  isDefault: boolean;
+}
+
+export async function getDeleteImpact(worldViewId: number): Promise<DeleteImpact> {
+  return authFetchJson<DeleteImpact>(`${API_URL}/api/world-views/${worldViewId}/delete-impact`);
+}
+
 export async function deleteWorldView(worldViewId: number): Promise<void> {
   await authFetchJson<void>(`${API_URL}/api/world-views/${worldViewId}`, {
     method: 'DELETE',

--- a/frontend/src/components/HierarchySwitcher.tsx
+++ b/frontend/src/components/HierarchySwitcher.tsx
@@ -16,6 +16,7 @@ import {
   Menu,
   ListItemIcon,
   ListItemText,
+  CircularProgress,
 } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
 import AddIcon from '@mui/icons-material/Add';
@@ -27,6 +28,8 @@ import { useNavigation } from '../hooks/useNavigation';
 import { useAuth } from '../hooks/useAuth';
 import { WorldViewEditor } from './WorldViewEditor';
 import { createWorldView, updateWorldView, deleteWorldView } from '../api';
+import { getDeleteImpact } from '../api/worldViews';
+import type { DeleteImpact } from '../api/worldViews';
 
 export function HierarchySwitcher() {
   const { worldViews, selectedWorldView, setSelectedWorldView, invalidateTileCache } = useNavigation();
@@ -41,6 +44,8 @@ export function HierarchySwitcher() {
   const [editName, setEditName] = useState('');
   const [editDescription, setEditDescription] = useState('');
   const [adminMenuEl, setAdminMenuEl] = useState<HTMLElement | null>(null);
+  const [deleteImpact, setDeleteImpact] = useState<DeleteImpact | null>(null);
+  const [loadingImpact, setLoadingImpact] = useState(false);
 
   const createMutation = useMutation({
     mutationFn: (data: { name: string; description?: string }) => createWorldView(data),
@@ -268,9 +273,22 @@ export function HierarchySwitcher() {
               variant="outlined"
               color="error"
               startIcon={<DeleteIcon />}
-              onClick={() => {
+              onClick={async () => {
                 setSettingsDialogOpen(false);
                 setDeleteDialogOpen(true);
+                setDeleteImpact(null);
+                setLoadingImpact(true);
+                try {
+                  const impact = await getDeleteImpact(selectedWorldView!.id);
+                  setDeleteImpact(impact);
+                } catch (err) {
+                  // Impact fetch failed (network / 4xx / 5xx). Leave deleteImpact
+                  // null so the generic warning text stays visible — the admin
+                  // can still proceed but should know counts couldn't be loaded.
+                  console.error('[HierarchySwitcher] delete-impact fetch failed:', err);
+                } finally {
+                  setLoadingImpact(false);
+                }
               }}
             >
               Delete World View
@@ -294,11 +312,42 @@ export function HierarchySwitcher() {
         <DialogTitle>Delete World View?</DialogTitle>
         <DialogContent>
           <Typography>
-            Are you sure you want to delete "{selectedWorldView?.name}"?
+            Are you sure you want to delete &quot;{selectedWorldView?.name}&quot;?
           </Typography>
-          <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
-            This will permanently delete this world view and all its custom regions. This action cannot be undone.
-          </Typography>
+          {loadingImpact && (
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 2 }}>
+              <CircularProgress size={16} />
+              <Typography variant="body2" color="text.secondary">Loading impact data...</Typography>
+            </Box>
+          )}
+          {deleteImpact && !loadingImpact && (
+            <Box sx={{ mt: 2 }}>
+              <Typography variant="body2" color="text.secondary" gutterBottom>
+                This will permanently delete:
+              </Typography>
+              <Typography variant="body2">
+                &bull; {deleteImpact.regionCount} region{deleteImpact.regionCount !== 1 ? 's' : ''}
+              </Typography>
+              {deleteImpact.experienceAssignmentCount > 0 && (
+                <Typography variant="body2" color="warning.main">
+                  &bull; {deleteImpact.experienceAssignmentCount} experience-to-region assignment{deleteImpact.experienceAssignmentCount !== 1 ? 's' : ''}
+                </Typography>
+              )}
+              {deleteImpact.userVisitCount > 0 && (
+                <Typography variant="body2" color="error.main">
+                  &bull; {deleteImpact.userVisitCount} user visit record{deleteImpact.userVisitCount !== 1 ? 's' : ''}
+                </Typography>
+              )}
+              <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1 }}>
+                Experiences themselves are not deleted, only their region assignments. This action cannot be undone.
+              </Typography>
+            </Box>
+          )}
+          {!loadingImpact && !deleteImpact && (
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+              This will permanently delete this world view and all its custom regions. This action cannot be undone.
+            </Typography>
+          )}
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setDeleteDialogOpen(false)}>Cancel</Button>
@@ -306,7 +355,7 @@ export function HierarchySwitcher() {
             variant="contained"
             color="error"
             onClick={handleDeleteWorldView}
-            disabled={deleteMutation.isPending}
+            disabled={loadingImpact || deleteMutation.isPending}
           >
             {deleteMutation.isPending ? 'Deleting...' : 'Delete'}
           </Button>


### PR DESCRIPTION
## Description

Adds a **delete-impact preview** to the World View deletion flow so admins see the blast radius (region count, experience-to-region assignments, user visit records) before confirming a destructive delete.

**Backend:**
- `GET /api/world-views/:worldViewId/delete-impact` — returns `{ regionCount, experienceAssignmentCount, userVisitCount, isDefault }`. Pure read-only, no transaction.
- Wired into `worldViewRoutes.ts` with `requireAuth + requireAdmin + worldViewIdParamSchema` validation.

**Frontend:**
- `HierarchySwitcher.tsx`: confirmation dialog now fetches and displays the impact counts before the admin confirms deletion.
- `worldViews.ts` API helper for the new endpoint.

1 commit, ~100/-6 LOC.

## Related Issues

No issue number — tracked via the rebuild plan.

## How Was This Tested?

All four pre-commit gates green locally:
- `npm run check` (lint + typecheck): ✅
- `npm run knip` (unused files / deps): ✅
- `TEST_REPORT_LOCAL=1 npm test` (backend + frontend): ✅
- `npm run security:all` (Semgrep + npm audit): ✅ (0 findings, 0 vulns)

## Checklist
- [x] Commit messages follow the standard template.
- [x] All commits are signed.
- [x] Related issues are mentioned in the description above.
- [x] Linter checks have been passed.

## Additional Comments

- 1 new admin route: `GET /api/world-views/:worldViewId/delete-impact`. Admin-only via `requireAuth + requireAdmin` (mounted at the route level — same pattern as the existing `worldViewRoutes` admin endpoints, NOT under `/api/admin`). Param Zod-validated. Pure read-only — no DB writes, no transaction. CodeQL false-positive playbook applies if rate-limit alerts fire (admin endpoints are exempt per `docs/tech/rate-limiting.md`).
- The endpoint counts via three subselects against `regions`, `experience_regions` (joined to regions for the world view filter), and `user_visited_regions` (also joined). Returns ints + the `isDefault` flag so the UI can warn extra-loud about deleting the default world view.