### PR TITLE
refactor(frontend): group admin API files under api/admin/ (rebuild/55)

### DIFF
--- a/frontend/src/api/admin/index.ts
+++ b/frontend/src/api/admin/index.ts
@@ -4,7 +4,7 @@
  * All admin endpoints require authentication with admin role.
  */
 
-import { authFetchJson } from './fetchUtils';
+import { authFetchJson } from '../fetchUtils';
 
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001';
 

--- a/frontend/src/api/admin/wikivoyageExtract.ts
+++ b/frontend/src/api/admin/wikivoyageExtract.ts
@@ -2,7 +2,7 @@
  * Admin Wikivoyage Extraction API client
  */
 
-import { authFetchJson } from './fetchUtils';
+import { authFetchJson } from '../fetchUtils';
 
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001';
 

--- a/frontend/src/api/admin/worldViewImport.ts
+++ b/frontend/src/api/admin/worldViewImport.ts
@@ -4,7 +4,7 @@
  * Handles import and match review operations.
  */
 
-import { authFetchJson, ensureFreshToken, getAccessToken } from './fetchUtils';
+import { authFetchJson, ensureFreshToken, getAccessToken } from '../fetchUtils';
 
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001';
 

--- a/frontend/src/components/WorldViewEditor/components/dialogs/DivisionPreviewDialog.tsx
+++ b/frontend/src/components/WorldViewEditor/components/dialogs/DivisionPreviewDialog.tsx
@@ -14,7 +14,7 @@ import CloseIcon from '@mui/icons-material/Close';
 import CheckIcon from '@mui/icons-material/Check';
 import MapGL, { NavigationControl, Source, Layer, MapRef } from 'react-map-gl/maplibre';
 import * as turf from '@turf/turf';
-import { fetchGeoshape } from '../../../../api/adminWorldViewImport';
+import { fetchGeoshape } from '../../../../api/admin/worldViewImport';
 
 const MAP_STYLE = 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json';
 

--- a/frontend/src/components/admin/ClusterPaintEditor.tsx
+++ b/frontend/src/components/admin/ClusterPaintEditor.tsx
@@ -14,7 +14,7 @@ import {
   parseRgbString, getDistinctColor, computeClusterPercentages,
 } from './clusterPaintUtils';
 import type { PaletteEntry } from './clusterPaintUtils';
-import type { BorderPath, ClusterReviewCluster, ManualClusterResponse } from '../../api/adminWorldViewImport';
+import type { BorderPath, ClusterReviewCluster, ManualClusterResponse } from '../../api/admin/worldViewImport';
 import {
   pointsToSmoothSvgPath, findOpenEndpoints, rasterizeBorderPaths,
   findEraserIntersection,

--- a/frontend/src/components/admin/CoverageResolveDialog.tsx
+++ b/frontend/src/components/admin/CoverageResolveDialog.tsx
@@ -45,14 +45,14 @@ import {
   geoSuggestGap,
   dismissCoverageGap,
   undismissCoverageGap,
-} from '../../api/adminWorldViewImport';
+} from '../../api/admin/worldViewImport';
 import type {
   CoverageResult,
   CoverageGap,
   SubtreeNode,
   GeoSuggestResult,
   RegionContextNode,
-} from '../../api/adminWorldViewImport';
+} from '../../api/admin/worldViewImport';
 import { searchRegions, type RegionSearchResult } from '../../api/regions';
 import type { ShadowInsertion } from './WorldViewImportReview';
 

--- a/frontend/src/components/admin/CvIcpAdjustmentSection.tsx
+++ b/frontend/src/components/admin/CvIcpAdjustmentSection.tsx
@@ -8,7 +8,7 @@
  */
 
 import { Box, Typography, Button, Alert, Stack } from '@mui/material';
-import { respondToIcpAdjustment } from '../../api/adminWorldViewImport';
+import { respondToIcpAdjustment } from '../../api/admin/worldViewImport';
 import type { CvMatchDialogState } from './useCvMatchPipeline';
 
 export interface CvIcpAdjustmentSectionProps {

--- a/frontend/src/components/admin/CvMatchDialog.tsx
+++ b/frontend/src/components/admin/CvMatchDialog.tsx
@@ -23,7 +23,7 @@ import AccordionDetails from '@mui/material/AccordionDetails';
 import {
   respondToWaterReview,
   respondToClusterReview,
-} from '../../api/adminWorldViewImport';
+} from '../../api/admin/worldViewImport';
 import type { CvMatchDialogState } from './useCvMatchPipeline';
 import { CvWaterReviewSection } from './CvWaterReviewSection';
 import { CvIcpAdjustmentSection } from './CvIcpAdjustmentSection';

--- a/frontend/src/components/admin/CvWaterReviewSection.tsx
+++ b/frontend/src/components/admin/CvWaterReviewSection.tsx
@@ -6,7 +6,7 @@
  */
 
 import { Box, Typography, Button } from '@mui/material';
-import { respondToWaterReview } from '../../api/adminWorldViewImport';
+import { respondToWaterReview } from '../../api/admin/worldViewImport';
 import { AuthImage } from '../shared/AuthImage';
 import type { CvMatchDialogState } from './useCvMatchPipeline';
 

--- a/frontend/src/components/admin/SmartSimplifyDialog.tsx
+++ b/frontend/src/components/admin/SmartSimplifyDialog.tsx
@@ -37,7 +37,7 @@ import {
   type SmartSimplifyMove,
   type SiblingRegionGeometry,
   type SpatialAnomaly,
-} from '../../api/adminWorldViewImport';
+} from '../../api/admin/worldViewImport';
 import { fetchDivisionGeometry } from '../../api/divisions';
 import type { GeoJSONGeometry } from '../../types';
 

--- a/frontend/src/components/admin/TreeNodeActions.tsx
+++ b/frontend/src/components/admin/TreeNodeActions.tsx
@@ -23,7 +23,7 @@ import {
   Palette as CVMatchIcon,
   Map as MapshapeMatchIcon,
 } from '@mui/icons-material';
-import type { MatchTreeNode } from '../../api/adminWorldViewImport';
+import type { MatchTreeNode } from '../../api/admin/worldViewImport';
 import { Tooltip } from './treeNodeShared';
 
 interface TreeNodeActionsProps {

--- a/frontend/src/components/admin/TreeNodeContent.tsx
+++ b/frontend/src/components/admin/TreeNodeContent.tsx
@@ -10,7 +10,7 @@ import {
   Map as MapIcon,
   DoneAll as AcceptAndRejectRestIcon,
 } from '@mui/icons-material';
-import type { MatchTreeNode } from '../../api/adminWorldViewImport';
+import type { MatchTreeNode } from '../../api/admin/worldViewImport';
 import { Tooltip, type ShadowInsertion } from './treeNodeShared';
 
 /** Render a single assigned division (already accepted) */

--- a/frontend/src/components/admin/TreeNodeRow.tsx
+++ b/frontend/src/components/admin/TreeNodeRow.tsx
@@ -14,7 +14,7 @@ import {
   OpenInNew as OpenInNewIcon,
   Image as ImageIcon,
 } from '@mui/icons-material';
-import type { MatchTreeNode } from '../../api/adminWorldViewImport';
+import type { MatchTreeNode } from '../../api/admin/worldViewImport';
 import { Tooltip, type ShadowInsertion } from './treeNodeShared';
 import { TreeNodeActions } from './TreeNodeActions';
 import { TreeNodeContent } from './TreeNodeContent';

--- a/frontend/src/components/admin/WorldViewImportPanel.tsx
+++ b/frontend/src/components/admin/WorldViewImportPanel.tsx
@@ -42,12 +42,12 @@ import {
   startWorldViewImport,
   getImportStatus,
   cancelImport,
-} from '../../api/adminWorldViewImport';
+} from '../../api/admin/worldViewImport';
 import {
   startWikivoyageExtraction,
   getExtractionStatus,
   cancelExtraction,
-} from '../../api/adminWikivoyageExtract';
+} from '../../api/admin/wikivoyageExtract';
 import { WorldViewImportReview } from './WorldViewImportReview';
 
 export function WorldViewImportPanel() {

--- a/frontend/src/components/admin/WorldViewImportReview.tsx
+++ b/frontend/src/components/admin/WorldViewImportReview.tsx
@@ -36,8 +36,8 @@ import {
   rejectRemaining,
   acceptWithTransfer as acceptWithTransferApi,
   getTransferPreview,
-} from '../../api/adminWorldViewImport';
-import type { CoverageResult } from '../../api/adminWorldViewImport';
+} from '../../api/admin/worldViewImport';
+import type { CoverageResult } from '../../api/admin/worldViewImport';
 
 import { WorldViewImportTree } from './WorldViewImportTree';
 import { CoverageResolveDialog } from './CoverageResolveDialog';

--- a/frontend/src/components/admin/WorldViewImportTree.tsx
+++ b/frontend/src/components/admin/WorldViewImportTree.tsx
@@ -61,7 +61,7 @@ import {
   type MatchTreeNode,
   type AIReviewChildrenResult,
   type ReviewChildAction,
-} from '../../api/adminWorldViewImport';
+} from '../../api/admin/worldViewImport';
 import { MapImagePickerDialog } from './MapImagePickerDialog';
 import { SmartSimplifyDialog } from './SmartSimplifyDialog';
 import { useCvMatchPipeline } from './useCvMatchPipeline';

--- a/frontend/src/components/admin/importTreeUtils.ts
+++ b/frontend/src/components/admin/importTreeUtils.ts
@@ -1,4 +1,4 @@
-import type { MatchTreeNode } from '../../api/adminWorldViewImport';
+import type { MatchTreeNode } from '../../api/admin/worldViewImport';
 
 /**
  * Is a node blocking the Coverage Check?

--- a/frontend/src/components/admin/svgBorderUtils.test.ts
+++ b/frontend/src/components/admin/svgBorderUtils.test.ts
@@ -3,7 +3,7 @@ import {
   pointsToSmoothSvgPath, findOpenEndpoints, pointToSegmentDistance,
   findEraserIntersection,
 } from './svgBorderUtils';
-import type { BorderPath } from '../../api/adminWorldViewImport';
+import type { BorderPath } from '../../api/admin/worldViewImport';
 
 describe('pointsToSmoothSvgPath', () => {
   it('returns empty for 0-1 points', () => {

--- a/frontend/src/components/admin/svgBorderUtils.ts
+++ b/frontend/src/components/admin/svgBorderUtils.ts
@@ -1,4 +1,4 @@
-import type { BorderPath } from '../../api/adminWorldViewImport';
+import type { BorderPath } from '../../api/admin/worldViewImport';
 
 // ---------------------------------------------------------------------------
 // Public types

--- a/frontend/src/components/admin/useCvMatchPipeline.ts
+++ b/frontend/src/components/admin/useCvMatchPipeline.ts
@@ -19,7 +19,7 @@ import {
   type SpatialAnomaly,
   type AdjacencyEdge,
   type BorderPath,
-} from '../../api/adminWorldViewImport';
+} from '../../api/admin/worldViewImport';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Description

Pure file-shuffle refactor — moves admin-only API client modules out of the flat `frontend/src/api/` directory into a dedicated `frontend/src/api/admin/` subdirectory and updates all import paths.

The `frontend/src/api/admin/ai.ts` file already exists (added in PR #353); this regroup brings the rest of the admin API surface into the same namespace so the next PR (rebuild/30 — AI management layer) can land its new admin modules in a coherent folder rather than continuing to scatter across `frontend/src/api/`.

1 commit, ~23/-23 LOC (pure path moves + import updates across 20 files).

## Related Issues

No issue number — tracked via the rebuild plan.

## How Was This Tested?

All four pre-commit gates green locally:
- `npm run check` (lint + typecheck): ✅
- `npm run knip` (unused files / deps): ✅
- `TEST_REPORT_LOCAL=1 npm test` (backend + frontend): ✅
- `npm run security:all` (Semgrep + npm audit): ✅ (0 findings, 0 vulns)

## Checklist
- [x] Commit messages follow the standard template.
- [x] All commits are signed.
- [x] Related issues are mentioned in the description above.
- [x] Linter checks have been passed.

## Additional Comments

- Frontend-only file rearrangement. No behavior change. No backend / DB changes.
- Net diff is balanced (`23/-23`) because each file move shows as one delete + one add of the import path (no actual content edits beyond the path).
- Sets up rebuild/30 (AI management layer, next in the plan) so its new admin modules land alongside the existing `frontend/src/api/admin/ai.ts` rather than adding more flat files to `frontend/src/api/`.