### PR TITLE
chore: restore /vibe-ship slash commands (rebuild/56)

### DIFF
--- a/.claude/commands/vibe-cleanup.md
+++ b/.claude/commands/vibe-cleanup.md
@@ -1,0 +1,76 @@
+# Clean Up Vibe-Coded Working Tree
+
+Scan a dirty working tree for debug artifacts, dead code, and structural issues left over from rapid prototyping. Fix them systematically with user approval.
+
+This command only cleans code — it does NOT create commits, branches, or update docs.
+
+## Instructions
+
+### 1. Snapshot the current state
+
+Run `git diff --stat` and `git status` to catalog all changed and new files. Present a summary: how many files changed, how many new, total lines added/removed.
+
+### 2. Scan for issues
+
+Dispatch parallel subagents to scan all changed/new files for these categories:
+
+**Debug artifacts:**
+- `console.log`, `console.debug`, `console.warn` (that aren't intentional logging)
+- `debugger` statements
+- Hardcoded test values, mock data left in production code
+- `// TODO HACK`, `// FIXME`, `// TEMP`, `// XXX` comments
+- Commented-out code blocks (more than 2 consecutive commented lines)
+
+**Dead code:**
+- Unused imports (imports not referenced anywhere in the file)
+- Unreferenced functions, variables, types, interfaces
+- Orphaned files (new files that nothing imports)
+- Unused dependencies added to package.json
+
+**Structural issues:**
+- Files exceeding 500 lines — flag for potential splitting
+- Duplicated logic across files (same pattern in 2+ places)
+- Inline code that duplicates existing shared utilities or components
+- Missing barrel exports for new modules
+
+For each finding, record: category, file path, line number(s), description, and severity:
+- **auto-fix**: Can be removed/fixed without judgment (unused imports, console.logs)
+- **needs-judgment**: Requires user decision (split file, extract to shared util, remove commented code that might be intentional)
+
+### 3. Present the report
+
+Group findings by category. For each category show:
+- Count of issues found
+- Table with file:line, description, severity
+- Proposed fix for each item
+
+Ask the user how to proceed:
+- **Batch auto-fix**: Apply all auto-fixable items at once
+- **Review each**: Walk through every item
+- **Category by category**: Batch auto-fix per category, review judgment items individually
+
+### 4. Apply fixes with approval
+
+Based on user's choice, apply fixes. For judgment items:
+- Show the current code and proposed change
+- Wait for user approval before each change
+- If the user says skip, move on
+
+### 5. Verify
+
+Run the project's linter and type checker to confirm nothing broke:
+
+```bash
+npm run check
+```
+
+If there are errors, show them and fix. Repeat until clean.
+
+### 6. Summary
+
+Report what was done:
+- How many issues found per category
+- How many fixed, how many skipped
+- Any remaining issues the user chose to skip
+
+Remind the user: "Code is cleaned up but not committed. Next steps: run `/vibe-compliance` to check guidelines, or `/vibe-ship` for the full pipeline."

--- a/.claude/commands/vibe-compliance.md
+++ b/.claude/commands/vibe-compliance.md
@@ -1,0 +1,111 @@
+# Check Guidelines Compliance
+
+Verify that all changed code follows project guidelines and conventions by reading the actual docs and checking against them. Fix violations and fill documentation gaps.
+
+This command checks compliance but does NOT touch commit history or branching.
+
+## Prerequisites
+
+Read `CLAUDE.md` to understand the project's documentation structure, required reading areas, and security standards.
+
+## Instructions
+
+### 1. Identify scope
+
+Run `git fetch origin main && git diff origin/main --stat` to get all changed and new files. Classify each file by area:
+- Backend controller, service, route, middleware
+- Frontend component, hook, utility, API layer
+- Database schema, migration
+- Configuration, documentation
+
+### 2. Load relevant documentation
+
+For each area touched, read the corresponding docs. Use the "Required Reading by Area" table in `CLAUDE.md` to determine which docs apply. **Always** read:
+- `docs/tech/development-guide.md` (universal code conventions)
+- `docs/security/SECURITY.md` (security rules)
+- `CLAUDE.md` (Skill Integration Rules, Security Standards)
+
+Read **all** area-specific docs that apply — most changes touch 2-3 areas.
+
+### 3. Check per-file compliance
+
+Dispatch parallel subagents, one per area. Each subagent reads the area docs and checks every changed file in that area against them. Check for:
+
+**Code conventions:**
+- File size limits (controllers 100-600 lines, components similar)
+- Barrel exports for controller directories (`index.ts`)
+- Co-location of hooks and types near their components
+- Naming patterns (kebab-case files, PascalCase components, camelCase functions)
+- Hook extraction (3+ useState in a component should be extracted to a hook)
+
+**Security:**
+- Parameterized queries (never string concatenation in SQL)
+- Input validation (Zod schemas for all new endpoints)
+- Auth middleware on protected routes (`requireAuth`, `requireAdmin`, `requireCurator`)
+- No hardcoded secrets, API keys, or credentials
+- No rendering of unsanitized user-generated content
+- CSRF protection on state-changing endpoints
+
+**Patterns:**
+- Correct use of shared components and utilities (check against `docs/tech/shared-frontend-patterns.md`)
+- Proper error handling patterns
+- Consistent API response formats
+- Correct hook usage (TanStack Query patterns, context usage)
+
+**Reuse:**
+- Flag code that duplicates existing shared utilities or components
+- Flag inline implementations of patterns that have shared abstractions
+
+**Architecture:**
+- Check against existing ADRs in `docs/decisions/`
+- Flag any architectural choices that should have an ADR but don't
+
+### 4. Documentation gap analysis
+
+For each changed area, check if docs need updating:
+- New or changed user-facing behavior → needs `docs/vision/vision.md` update?
+- New endpoint or API change → needs `docs/tech/` update?
+- Security-relevant change (new auth flow, input surface, token handling) → needs `docs/security/` update?
+- Architectural choice (new library, schema pattern, API convention) → needs an ADR in `docs/decisions/`?
+- New shared component or utility → needs `docs/tech/shared-frontend-patterns.md` update?
+
+### 5. Present the compliance report
+
+Group findings into:
+- **Violations** (blocking — must fix): What breaks a documented rule, with the specific doc reference and file:line
+- **Doc gaps** (blocking — must address): Missing documentation updates
+- **Reuse opportunities** (advisory — should fix): Where shared code should replace inline
+- **ADR candidates** (advisory): Architectural decisions that should be recorded
+
+### 6. Fix violations
+
+Walk through each finding:
+- For code violations: show current code, the rule it breaks (with doc reference), and proposed fix. Apply with user approval.
+- For doc gaps: draft the documentation update and show it for approval.
+- For reuse opportunities: show the existing shared code and how to use it instead of the inline version.
+
+### 7. Run full verification suite
+
+Run ALL project checks to verify everything is clean:
+
+```bash
+npm run check          # lint + typecheck
+npm run knip           # unused files + dependencies
+npm run security:all   # Semgrep SAST + npm audit
+TEST_REPORT_LOCAL=1 npm test  # unit tests
+```
+
+Also run `/security-check` for Claude Code security review of changed files.
+
+If any check fails, fix and re-run until all pass.
+
+### 8. Summary
+
+Report:
+- Violations found and fixed (count per category)
+- Doc updates made
+- Reuse improvements applied
+- Any advisory items the user chose to skip
+- Verification results (all checks passing?)
+
+Remind the user: "Code is compliant and verified. Next steps: run `/vibe-history` to create proper branches and commits, or `/vibe-ship` for the full pipeline."

--- a/.claude/commands/vibe-history.md
+++ b/.claude/commands/vibe-history.md
@@ -1,0 +1,151 @@
+# Create Proper Commit History
+
+Analyze a large diff and transform it into clean git history with proper feature branches, atomic commits, and PRs.
+
+**Precondition:** Code should already be cleaned up and compliant. This command does NOT fix code — it only organizes it into git history. Run `/vibe-cleanup` and `/vibe-compliance` first (or use `/vibe-ship` for the full pipeline).
+
+**Critical rule:** The planning phase (steps 1-4) is entirely READ-ONLY. Do NOT create branches, stash changes, switch branches, or modify the working tree in any way until the user has approved the plan. The current code may be running in production.
+
+## Prerequisites
+
+Read the project's commit conventions:
+- `docs/tech/development-guide.md` — commit format, branch naming, granularity rules
+- `CLAUDE.md` — commit and PR conventions
+
+## Instructions
+
+### 1. Analyze the full diff (read-only)
+
+Compare current state against the base branch (usually `main`) using only read-only git commands:
+
+```bash
+git fetch origin main
+git diff origin/main --stat
+git diff origin/main --name-status
+git log origin/main..HEAD --oneline
+```
+
+Read every changed file's diff to understand WHAT each change does. For each file, note:
+- What feature/fix/refactor it belongs to
+- Whether it's backend, frontend, database, docs, or config
+- Dependencies on other changes (does it use a function added in another file?)
+
+**Do NOT run any commands that modify the working tree, index, or branches.**
+
+### 2. Identify logical units
+
+Group changes into coherent branches. Each branch must be:
+- **Self-contained**: Compiles and tests pass with just those changes applied to main
+- **Single-purpose**: One feature, one fix, or one refactor
+- **Dependency-ordered**: If branch B uses code from branch A, A must be created first
+
+Common groupings:
+- Backend API endpoint + its route + validation schemas
+- Frontend component + its hook + its API integration
+- Database schema change + backend migration code
+- Refactoring of shared utilities (often a prerequisite branch)
+- Documentation updates (can be a separate branch or included per-feature)
+
+**Handle cross-cutting files carefully:** When multiple features modify the same file:
+1. Create a "shared infrastructure" branch that goes first, containing the shared file changes
+2. Or assign the file to the primary feature and have other branches build on top
+
+### 3. Propose the plan
+
+Present to the user:
+
+**Branch list** (in dependency/merge order):
+
+For each branch:
+- Branch name (e.g., `feature/add-hull-editor`, `refactor/shared-image-utils`)
+- One-line description
+- Files included (list each file)
+- Commits it will contain (e.g., "1. Add backend endpoint, 2. Add frontend hook, 3. Wire up UI, 4. Update docs")
+- Dependencies (which branches must exist/merge first)
+- Any cross-cutting concerns or tricky splits
+
+**Merge order:** Which branch merges to main first, second, etc.
+
+**Flagged items:** Changes that don't fit cleanly anywhere — ask the user where they belong.
+
+**Wait for user approval and adjustments before proceeding.** Nothing has been modified yet — the user can safely cancel at this point.
+
+### 4. Safety checkpoint
+
+**Only after the user approves the plan**, create safety nets before any git modifications:
+
+```bash
+# Backup branch capturing current state
+git branch backup/vibe-history-$(date +%Y%m%d-%H%M)
+
+# Stash any uncommitted changes
+git stash push -m "vibe-history backup $(date +%Y%m%d-%H%M)"
+
+# Patch file as last resort
+git diff origin/main > /tmp/vibe-history-backup-$(date +%Y%m%d-%H%M).patch
+```
+
+Print all backup references so the user knows exactly how to restore:
+- Backup branch name
+- Stash reference (if changes were stashed)
+- Patch file path
+
+Confirm: **"Safety backups created. Starting branch creation now."**
+
+### 5. Execute branch-by-branch
+
+For each branch in dependency order:
+
+**a. Create the branch:**
+```bash
+git checkout main  # or the dependency branch
+git checkout -b <branch-name>
+```
+
+**b. Apply relevant changes:**
+Cherry-pick the specific files/hunks that belong to this branch. Use `git checkout <source> -- <file>` for whole files or manual editing for partial file changes.
+
+**c. Structure into atomic commits:**
+Follow the project's commit conventions:
+- Imperative mood title, max 72 characters
+- Body explains "what" and "why"
+- Granular by layer: backend, frontend, docs as separate commits
+- Documentation in dedicated commits
+- Sign all commits (`-s` flag)
+- Add `Co-Authored-By: Claude <noreply@anthropic.com>` trailer (substitute the actual model name at runtime, e.g. `Claude Sonnet 4.6`)
+
+**d. Verify the branch:**
+```bash
+npm run check
+```
+Must pass — the branch must compile on its own. If it fails because the branch depends on another branch's changes, that signals the grouping or dependency order is wrong. Fix it.
+
+**e. Push and create PR:**
+```bash
+git push -u origin <branch-name>
+```
+
+Create a PR with:
+- Short title (under 70 characters)
+- Summary section with 1-3 bullet points
+- Test plan
+- Reference to related PRs in the chain (if applicable)
+
+### 6. Final verification — nothing lost
+
+After all branches are created, verify the combined changes equal the original diff:
+
+```bash
+git diff backup/vibe-history-YYYYMMDD-HHMM
+```
+
+The diff should be empty (or only contain expected ordering differences). If changes were lost, identify what's missing and fix it.
+
+### 7. Summary
+
+Report:
+- List of branches and PRs created (with URLs)
+- Merge order
+- Any items that couldn't be cleanly split
+- Backup branch name (can be deleted once all PRs are merged)
+- Suggested next steps: "Review each PR, merge in the suggested order"

--- a/.claude/commands/vibe-ship.md
+++ b/.claude/commands/vibe-ship.md
@@ -1,0 +1,117 @@
+# Ship Vibe-Coded Work
+
+Full pipeline to transform a messy vibe-coded working tree into proper branches, commits, and PRs. Chains three phases — cleanup, compliance, history — with safety backups and approval gates between each.
+
+Use this after a vibe-coding session when you have a mix of messy commits and uncommitted changes that need to become a proper commit history.
+
+## Prerequisites
+
+Read `docs/tech/development-guide.md` and `CLAUDE.md` — all conventions apply throughout this pipeline.
+
+## Instructions
+
+### Phase 0: Safety & Orientation
+
+Show the current state:
+
+```bash
+git status
+git diff --stat
+git log --oneline -20
+```
+
+Present a summary: how many files changed, uncommitted vs committed changes, which areas affected (backend, frontend, database, docs).
+
+Create the initial safety backup:
+
+```bash
+git branch backup/vibe-ship-start-$(date +%Y%m%d-%H%M)
+```
+
+If there are uncommitted changes, snapshot them onto the backup branch before
+proceeding (the working tree must stay populated so the pipeline can analyze
+it). Use a WIP commit on the backup branch rather than `git stash pop` —
+`stash pop` removes the entry from `refs/stash` and recovery would require
+forensic-level `git fsck --unreachable` work:
+```bash
+git stash push -m "vibe-ship initial backup $(date +%Y%m%d-%H%M)"
+STASH_REF=$(git rev-parse stash@{0})
+git checkout backup/vibe-ship-start-$(date +%Y%m%d-%H%M)
+git stash apply --index "$STASH_REF"
+git add -A && git commit -m "vibe-ship: WIP snapshot before cleanup"
+git checkout -
+git stash pop --quiet 2>/dev/null || true
+```
+
+Print all backup references (the branch name and the stash ref if uncommitted
+changes existed) and confirm: **"Ready to start the cleanup pipeline? This
+will modify your working tree in three phases, with approval gates between
+each."**
+
+---
+
+### Phase 1: Cleanup
+
+Invoke `/vibe-cleanup` to scan and fix:
+- Debug artifacts (console.log, debugger, TODO hacks)
+- Dead code (unused imports, orphaned files)
+- Structural issues (oversized files, duplicated logic)
+
+After cleanup completes, confirm with user: **"Phase 1 complete — code is cleaned up. Proceed to Phase 2 (compliance check)?"**
+
+---
+
+### Phase 2: Compliance
+
+Invoke `/vibe-compliance` to verify and fix:
+- Code convention compliance (file sizes, barrel exports, naming)
+- Security standards (parameterized queries, input validation, auth middleware)
+- Pattern compliance (shared components, hook extraction, error handling)
+- Documentation gaps (vision.md, tech docs, security docs, ADRs)
+
+This phase includes the full pre-commit verification suite:
+```bash
+npm run check
+npm run knip
+npm run security:all
+TEST_REPORT_LOCAL=1 npm test
+```
+
+Plus `/security-check` for Claude Code security review.
+
+After compliance completes and all checks pass, confirm with user: **"Phase 2 complete — code is compliant and all checks pass. Proceed to Phase 3 (commit history)?"**
+
+---
+
+### Phase 3: History
+
+Invoke `/vibe-history` which will:
+- Analyze the full diff (read-only — no git modifications yet)
+- Propose branch plan for user approval
+- **Only after approval**: create safety backup `backup/vibe-ship-pre-history-YYYYMMDD-HHMM`, then execute branch creation
+- Create branches with atomic commits following project conventions
+- Push and create PRs
+- Verify nothing was lost
+
+---
+
+### Summary
+
+After all phases complete, present the final report:
+
+**Cleanup results:**
+- Issues found and fixed per category
+
+**Compliance results:**
+- Violations found and fixed
+- Documentation updates made
+- Verification suite status
+
+**History results:**
+- Branches and PRs created (with URLs)
+- Suggested merge order
+
+**Backups:**
+- Initial backup: `backup/vibe-ship-start-YYYYMMDD-HHMM`
+- Pre-history backup: `backup/vibe-ship-pre-history-YYYYMMDD-HHMM`
+- "Safe to delete these backup branches after all PRs are merged and verified."


### PR DESCRIPTION
## Description

Restores 4 `.claude/commands/` slash-command markdown files that were lost to a previous `git reset --hard`:

- `vibe-cleanup.md` (76 LOC) — clean up vibe-coded working tree
- `vibe-compliance.md` (111 LOC) — check guidelines compliance
- `vibe-history.md` (150 LOC) — create proper commit history
- `vibe-ship.md` (105 LOC) — ship vibe-coded work

1 commit, +442 LOC (markdown only — no code changes).

## Related Issues

No issue number — tracked via the rebuild plan.

## How Was This Tested?

All four pre-commit gates green locally:
- `npm run check` (lint + typecheck): ✅
- `npm run knip` (unused files / deps): ✅
- `TEST_REPORT_LOCAL=1 npm test` (backend + frontend): ✅
- `npm run security:all` (Semgrep + npm audit): ✅ (0 findings, 0 vulns)

Documentation-only PR — no behavior change, no code paths exercised.

## Checklist
- [x] Commit messages follow the standard template.
- [x] All commits are signed.
- [x] Related issues are mentioned in the description above.
- [x] Linter checks have been passed.

## Additional Comments

- Markdown-only restore. No backend / frontend / DB changes. Ship-clean.
- These are project-level Claude Code slash commands, intended for use via the Claude Code CLI in this repository.