### PR TITLE
feat(frontend): CV UI sections + import-tree refactor (combined)

### DIFF
--- a/frontend/knip.json
+++ b/frontend/knip.json
@@ -3,13 +3,8 @@
   "project": ["src/**/*.{ts,tsx}"],
   "ignore": [
     "src/dev/**",
-    "src/utils/spatialAnomalyDetector.ts",
-    "src/components/admin/ClusterPaintEditor.tsx",
-    "src/components/admin/AIReviewDrawer.tsx",
-    "src/components/admin/AISettingsPanel.tsx",
-    "src/components/admin/ExtractionRulesPanel.tsx",
-    "src/components/admin/importTreeLinkify.tsx"
+    "src/components/admin/ClusterPaintEditor.tsx"
   ],
-  "ignoreDependencies": ["@react-buddy/ide-toolbox", "globals", "@vitest/coverage-v8", "react-markdown"],
+  "ignoreDependencies": ["@react-buddy/ide-toolbox", "globals", "@vitest/coverage-v8"],
   "ignoreExportsUsedInFile": true
 }

--- a/frontend/src/api/admin/worldViewImport.ts
+++ b/frontend/src/api/admin/worldViewImport.ts
@@ -45,6 +45,8 @@ export interface MatchStats {
   total_matched: string;
   total_leaves: string;
   total_regions: string;
+  /** Count of regions whose hierarchy review surfaced unreviewed warnings (string for parity with the other counts) */
+  hierarchy_warnings_count: string;
 }
 
 export interface MatchSuggestion {
@@ -95,6 +97,10 @@ export interface MatchTreeNode {
   assignedDivisions: AssignedDivision[];
   geoAvailable: boolean | null;
   markerPoints: Array<{ name: string; lat: number; lon: number }> | null;
+  /** Hierarchy-review warnings surfaced by AI/automated review (e.g., overlapping siblings, single-child branches) */
+  hierarchyWarnings: string[];
+  /** True once a curator has dismissed/acknowledged the warnings on this node */
+  hierarchyReviewed: boolean;
   children: MatchTreeNode[];
 }
 
@@ -377,22 +383,47 @@ export {
   removeRegionFromImport,
   renameRegion,
   aiReviewChildren,
+  aiSuggestChildren,
   markManualFix,
   selectMapImage,
   detectSmartSimplify,
   applySmartSimplifyMove,
+  applySmartFlatten,
+  pruneToLeaves,
+  smartFlatten,
+  smartFlattenPreview,
+  mergeChildIntoParent,
+  collapseToParent,
+  autoResolveChildren,
+  reparentRegion,
+  dismissHierarchyWarnings,
+  clearRegionMembers,
+  acceptBatchAndRejectRest,
+  rejectBatchSuggestions,
+  checkDivisionOverlap,
+  getOverlapDivisionChildren,
+  resolveOverlap,
 } from './wvImportTreeOps';
 export type {
   SimplifyHierarchyResult,
   SimplifyChildrenResult,
   ReviewChildAction,
   AIReviewChildrenResult,
+  AISuggestChildrenResult,
   SmartSimplifyDivision,
   SmartSimplifyMove,
   SpatialAnomalyDivision,
   SpatialAnomaly,
   SmartSimplifyResult,
   ApplySmartSimplifyResult,
+  PruneResult,
+  SmartFlattenResult,
+  SmartFlattenPreviewResult,
+  CollapseToParentResult,
+  AutoResolveChildrenResult,
+  DivisionOverlapResult,
+  OverlapGadmChild,
+  OverlapResolution,
 } from './wvImportTreeOps';
 
 export {
@@ -405,6 +436,12 @@ export {
   undismissCoverageGap,
   finalizeReview,
   getChildrenRegionGeometry,
+  getChildrenCoverage,
+  getCoverageGeometry,
+  analyzeCoverageGaps,
+  getUnionGeometry,
+  splitDivisionsDeeper,
+  visionMatchDivisions,
 } from './wvImportCoverage';
 export type {
   SubtreeNode,
@@ -414,6 +451,13 @@ export type {
   RegionContextNode,
   GeoSuggestResult,
   SiblingRegionGeometry,
+  ChildrenCoverageResult,
+  CoverageGeometryResult,
+  CoverageGapDivision,
+  AnalyzeCoverageGapsResult,
+  UnionGeometryResult,
+  SplitDeeperResult,
+  VisionMatchDivisionsResult,
 } from './wvImportCoverage';
 
 export {
@@ -427,6 +471,7 @@ export {
   respondToWaterReview,
   respondToIcpAdjustment,
   colorMatchWithProgress,
+  aiSuggestClusterRegions,
 } from './wvImportCvMatch';
 export type {
   ClusterGeoInfo,
@@ -444,4 +489,6 @@ export type {
   ColorMatchSSEEvent,
   MapshapeMatchResult,
   ManualClusterResponse,
+  AISuggestClusterRegionsCluster,
+  AISuggestClusterRegionsResult,
 } from './wvImportCvMatch';

--- a/frontend/src/api/admin/wvImportCoverage.ts
+++ b/frontend/src/api/admin/wvImportCoverage.ts
@@ -190,3 +190,136 @@ export async function getChildrenRegionGeometry(
 ): Promise<{ childRegions: SiblingRegionGeometry[] }> {
   return authFetchJson(`${API_URL}/api/admin/wv-import/matches/${worldViewId}/children-geometry/${regionId}`);
 }
+
+// =============================================================================
+// Children Coverage (per-region container coverage %)
+// =============================================================================
+
+/**
+ * Per-region coverage cache:
+ * - `coverage[regionId]` — fraction (0..1) of the region's GADM coverage relative to its members
+ * - `geoshapeCoverage[regionId]` — fraction relative to the matched Wikidata geoshape (when available)
+ */
+export interface ChildrenCoverageResult {
+  coverage: Record<string, number>;
+  geoshapeCoverage: Record<string, number>;
+}
+
+/**
+ * Fetch children-coverage for a world view. Three call shapes:
+ * - getChildrenCoverage(worldViewId)                   → all regions
+ * - getChildrenCoverage(worldViewId, regionId)         → ancestors of regionId
+ * - getChildrenCoverage(worldViewId, undefined, ancestorId) → single ancestor only
+ */
+export async function getChildrenCoverage(
+  worldViewId: number,
+  regionId?: number,
+  ancestorId?: number,
+): Promise<ChildrenCoverageResult> {
+  const params = new URLSearchParams();
+  if (regionId != null) params.set('regionId', String(regionId));
+  if (ancestorId != null) params.set('ancestorId', String(ancestorId));
+  const query = params.toString();
+  const url = `${API_URL}/api/admin/wv-import/matches/${worldViewId}/children-coverage${query ? '?' + query : ''}`;
+  return authFetchJson(url);
+}
+
+// =============================================================================
+// Coverage Geometry / Gap Analysis
+// =============================================================================
+
+export interface CoverageGeometryResult {
+  parentGeometry: GeoJSON.Geometry | null;
+  childrenGeometry: GeoJSON.Geometry | null;
+  geoshapeGeometry?: GeoJSON.Geometry | null;
+}
+
+export async function getCoverageGeometry(
+  worldViewId: number,
+  regionId: number,
+): Promise<CoverageGeometryResult> {
+  return authFetchJson(`${API_URL}/api/admin/wv-import/matches/${worldViewId}/coverage-geometry/${regionId}`);
+}
+
+export interface CoverageGapDivision {
+  divisionId: number;
+  name: string;
+  path: string;
+  geometry?: GeoJSON.Geometry | null;
+  areaKm2: number;
+  gadmParentId: number | null;
+  suggestedTarget?: { regionId: number } | null;
+}
+
+export interface AnalyzeCoverageGapsResult {
+  gapDivisions: CoverageGapDivision[];
+  siblingRegions: SiblingRegionGeometry[];
+}
+
+export async function analyzeCoverageGaps(
+  worldViewId: number,
+  regionId: number,
+): Promise<AnalyzeCoverageGapsResult> {
+  return authFetchJson(`${API_URL}/api/admin/wv-import/matches/${worldViewId}/analyze-coverage-gaps`, {
+    method: 'POST',
+    body: JSON.stringify({ regionId }),
+  });
+}
+
+// =============================================================================
+// Geometry preview (union / split / vision-match)
+// =============================================================================
+
+export interface UnionGeometryResult {
+  geometry: GeoJSON.FeatureCollection;
+}
+
+export async function getUnionGeometry(
+  worldViewId: number,
+  divisionIds: number[],
+  regionId?: number,
+): Promise<UnionGeometryResult> {
+  return authFetchJson(`${API_URL}/api/admin/wv-import/matches/${worldViewId}/union-geometry`, {
+    method: 'POST',
+    body: JSON.stringify({ divisionIds, regionId }),
+  });
+}
+
+export interface SplitDeeperResult {
+  divisions: Array<{ divisionId: number; name: string; path?: string }>;
+  geometry: GeoJSON.FeatureCollection;
+  points?: Array<{ name: string; lat: number; lon: number }>;
+}
+
+export async function splitDivisionsDeeper(
+  worldViewId: number,
+  divisionIds: number[],
+  wikidataId: string,
+  regionId: number,
+  source?: 'geoshape' | 'points' | 'image',
+): Promise<SplitDeeperResult> {
+  return authFetchJson(`${API_URL}/api/admin/wv-import/matches/${worldViewId}/split-divisions-deeper`, {
+    method: 'POST',
+    body: JSON.stringify({ divisionIds, wikidataId, regionId, source }),
+  });
+}
+
+export interface VisionMatchDivisionsResult {
+  suggestedIds: number[];
+  rejectedIds?: number[];
+  unclearIds?: number[];
+  reasoning?: string;
+  debugImages?: { regionMap: string; divisionsMap: string };
+}
+
+export async function visionMatchDivisions(
+  worldViewId: number,
+  divisionIds: number[],
+  regionId: number,
+  regionMapUrl: string,
+): Promise<VisionMatchDivisionsResult> {
+  return authFetchJson(`${API_URL}/api/admin/wv-import/matches/${worldViewId}/vision-match-divisions`, {
+    method: 'POST',
+    body: JSON.stringify({ divisionIds, regionId, regionMapUrl }),
+  });
+}

--- a/frontend/src/api/admin/wvImportCvMatch.ts
+++ b/frontend/src/api/admin/wvImportCvMatch.ts
@@ -166,6 +166,40 @@ export async function mapshapeMatch(
 }
 
 // =============================================================================
+// AI Suggest Cluster Regions
+// =============================================================================
+
+/** Per-cluster info supplied to the AI for region matching */
+export interface AISuggestClusterRegionsCluster {
+  clusterId: number;
+  color: string;
+  pixelShare: number;
+  /** Flattened list of GADM division names already associated with the cluster */
+  divisionNames: string[];
+}
+
+export interface AISuggestClusterRegionsResult {
+  matches: Array<{ clusterId: number; regionId: number | null }>;
+  stats: { inputTokens: number; outputTokens: number; cost: number };
+}
+
+/**
+ * Ask the AI to assign each CV cluster to one of the given child regions
+ * (or to none). Used by the geo-preview section after a CV color match.
+ */
+export async function aiSuggestClusterRegions(
+  worldViewId: number,
+  clusters: AISuggestClusterRegionsCluster[],
+  childRegions: Array<{ id: number; name: string }>,
+  modelOverride?: string,
+): Promise<AISuggestClusterRegionsResult> {
+  return authFetchJson(`${API_URL}/api/admin/wv-import/matches/${worldViewId}/ai-suggest-cluster-regions`, {
+    method: 'POST',
+    body: JSON.stringify({ clusters, childRegions, modelOverride }),
+  });
+}
+
+// =============================================================================
 // Cluster / Water Preview URLs & Review Responses
 // =============================================================================
 

--- a/frontend/src/api/admin/wvImportTreeOps.ts
+++ b/frontend/src/api/admin/wvImportTreeOps.ts
@@ -127,11 +127,11 @@ export async function renameRegion(
 }
 
 // =============================================================================
-// AI Review Children
+// AI Review / Suggest Children
 // =============================================================================
 
 export interface ReviewChildAction {
-  type: 'add' | 'remove' | 'rename';
+  type: 'add' | 'remove' | 'rename' | 'enrich';
   name: string;
   newName?: string;
   reason: string;
@@ -146,6 +146,9 @@ export interface AIReviewChildrenResult {
   stats: { inputTokens: number; outputTokens: number; cost: number } | null;
 }
 
+/** Same shape as AIReviewChildrenResult — modern alias used by the suggest-children dialog */
+export type AISuggestChildrenResult = AIReviewChildrenResult;
+
 export async function aiReviewChildren(
   worldViewId: number,
   regionId: number,
@@ -155,6 +158,9 @@ export async function aiReviewChildren(
     body: JSON.stringify({ regionId }),
   });
 }
+
+/** Modern alias for aiReviewChildren — same endpoint, different name in newer call sites */
+export const aiSuggestChildren = aiReviewChildren;
 
 // =============================================================================
 // Mark Manual Fix / Select Map Image
@@ -241,7 +247,7 @@ export async function detectSmartSimplify(
   });
 }
 
-export async function applySmartSimplifyMove(
+export async function applySmartFlatten(
   worldViewId: number,
   parentRegionId: number,
   ownerRegionId: number,
@@ -250,5 +256,233 @@ export async function applySmartSimplifyMove(
   return authFetchJson(`${API_URL}/api/admin/wv-import/matches/${worldViewId}/smart-simplify/apply-move`, {
     method: 'POST',
     body: JSON.stringify({ parentRegionId, ownerRegionId, memberRowIds }),
+  });
+}
+
+// Backward-compat alias for older call-sites
+export const applySmartSimplifyMove = applySmartFlatten;
+
+// =============================================================================
+// Prune / Smart Flatten / Merge / Collapse / Auto-Resolve
+// =============================================================================
+
+export interface PruneResult {
+  pruned: number;
+  undoAvailable?: boolean;
+}
+
+export async function pruneToLeaves(
+  worldViewId: number,
+  regionId: number,
+): Promise<PruneResult> {
+  return authFetchJson(`${API_URL}/api/admin/wv-import/matches/${worldViewId}/prune-to-leaves`, {
+    method: 'POST',
+    body: JSON.stringify({ regionId }),
+  });
+}
+
+export interface SmartFlattenResult {
+  absorbed: number;
+  divisions: number;
+  unmatched?: Array<{ id: number; name: string }>;
+  undoAvailable?: boolean;
+}
+
+export async function smartFlatten(
+  worldViewId: number,
+  regionId: number,
+): Promise<SmartFlattenResult> {
+  return authFetchJson(`${API_URL}/api/admin/wv-import/matches/${worldViewId}/smart-flatten`, {
+    method: 'POST',
+    body: JSON.stringify({ regionId }),
+  });
+}
+
+export interface SmartFlattenPreviewResult {
+  geometry?: GeoJSON.Geometry | null;
+  regionMapUrl?: string | null;
+  descendants?: number;
+  divisions?: number;
+  unmatched?: Array<{ id: number; name: string }>;
+}
+
+export async function smartFlattenPreview(
+  worldViewId: number,
+  regionId: number,
+): Promise<SmartFlattenPreviewResult> {
+  return authFetchJson(`${API_URL}/api/admin/wv-import/matches/${worldViewId}/smart-flatten/preview`, {
+    method: 'POST',
+    body: JSON.stringify({ regionId }),
+  });
+}
+
+export async function mergeChildIntoParent(
+  worldViewId: number,
+  regionId: number,
+): Promise<{ merged: boolean }> {
+  return authFetchJson(`${API_URL}/api/admin/wv-import/matches/${worldViewId}/merge-child-into-parent`, {
+    method: 'POST',
+    body: JSON.stringify({ regionId }),
+  });
+}
+
+export interface CollapseToParentResult {
+  collapsed: number;
+  parentSuggestions: number;
+  undoAvailable?: boolean;
+}
+
+export async function collapseToParent(
+  worldViewId: number,
+  regionId: number,
+): Promise<CollapseToParentResult> {
+  return authFetchJson(`${API_URL}/api/admin/wv-import/matches/${worldViewId}/collapse-to-parent`, {
+    method: 'POST',
+    body: JSON.stringify({ regionId }),
+  });
+}
+
+export interface AutoResolveChildrenResult {
+  resolved: number;
+  review: number;
+  failed: Array<{ id: number; name: string }>;
+  total: number;
+  undoAvailable?: boolean;
+}
+
+export async function autoResolveChildren(
+  worldViewId: number,
+  regionId: number,
+): Promise<AutoResolveChildrenResult> {
+  return authFetchJson(`${API_URL}/api/admin/wv-import/matches/${worldViewId}/auto-resolve-children`, {
+    method: 'POST',
+    body: JSON.stringify({ regionId }),
+  });
+}
+
+export async function reparentRegion(
+  worldViewId: number,
+  regionId: number,
+  newParentId: number | null,
+): Promise<{ reparented: boolean }> {
+  return authFetchJson(`${API_URL}/api/admin/wv-import/matches/${worldViewId}/reparent-region`, {
+    method: 'POST',
+    body: JSON.stringify({ regionId, newParentId }),
+  });
+}
+
+export async function dismissHierarchyWarnings(
+  worldViewId: number,
+  regionId: number,
+): Promise<{ dismissed: boolean }> {
+  return authFetchJson(`${API_URL}/api/admin/wv-import/matches/${worldViewId}/dismiss-hierarchy-warnings`, {
+    method: 'POST',
+    body: JSON.stringify({ regionId }),
+  });
+}
+
+export async function clearRegionMembers(
+  worldViewId: number,
+  regionId: number,
+): Promise<{ cleared: number }> {
+  return authFetchJson(`${API_URL}/api/admin/wv-import/matches/${worldViewId}/clear-region-members`, {
+    method: 'POST',
+    body: JSON.stringify({ regionId }),
+  });
+}
+
+// =============================================================================
+// Batch accept/reject
+// =============================================================================
+
+export async function acceptBatchAndRejectRest(
+  worldViewId: number,
+  regionId: number,
+  divisionIds: number[],
+): Promise<{ accepted: number; rejected: number }> {
+  return authFetchJson(`${API_URL}/api/admin/wv-import/matches/${worldViewId}/accept-batch-and-reject-rest`, {
+    method: 'POST',
+    body: JSON.stringify({ regionId, divisionIds }),
+  });
+}
+
+export async function rejectBatchSuggestions(
+  worldViewId: number,
+  regionId: number,
+  divisionIds: number[],
+): Promise<{ rejected: number }> {
+  return authFetchJson(`${API_URL}/api/admin/wv-import/matches/${worldViewId}/reject-batch`, {
+    method: 'POST',
+    body: JSON.stringify({ regionId, divisionIds }),
+  });
+}
+
+// =============================================================================
+// Division Overlap Detection / Resolution
+// =============================================================================
+
+export interface DivisionOverlapResult {
+  overlaps: Array<{
+    divisionId: number;
+    divisionName: string;
+    /** GADM hierarchy path (e.g., "World > France > Île-de-France") for display */
+    divisionPath: string;
+    regions: Array<{
+      regionId: number;
+      regionName: string;
+      viaDivisionId: number;
+      viaDivisionName: string;
+      /** True for direct (region's own member); false when this region holds the
+       * division via a coarser ancestor (containment overlap). */
+      isDirect: boolean;
+    }>;
+  }>;
+}
+
+export interface OverlapGadmChild {
+  divisionId: number;
+  name: string;
+  areaKm2?: number;
+  assignedToRegionId?: number;
+}
+
+export async function checkDivisionOverlap(
+  worldViewId: number,
+  parentRegionId: number,
+): Promise<DivisionOverlapResult> {
+  return authFetchJson(`${API_URL}/api/admin/wv-import/matches/${worldViewId}/check-division-overlap`, {
+    method: 'POST',
+    body: JSON.stringify({ parentRegionId }),
+  });
+}
+
+export async function getOverlapDivisionChildren(
+  worldViewId: number,
+  divisionId: number,
+  regionIds: number[],
+): Promise<{ children: OverlapGadmChild[] }> {
+  return authFetchJson(`${API_URL}/api/admin/wv-import/matches/${worldViewId}/overlap-division-children`, {
+    method: 'POST',
+    body: JSON.stringify({ divisionId, regionIds }),
+  });
+}
+
+export type OverlapResolution =
+  | { action: 'keep'; divisionId: number; keepInRegionId: number; removeFromRegionIds: number[] }
+  | {
+      action: 'split';
+      divisionId: number;
+      /** Region whose coarse parent division is being split into GADM children */
+      splitRegionId: number;
+      assignments: Array<{ gadmChildId: number; targetRegionId: number }>;
+    };
+
+export async function resolveOverlap(
+  worldViewId: number,
+  resolution: OverlapResolution,
+): Promise<{ resolved: boolean }> {
+  return authFetchJson(`${API_URL}/api/admin/wv-import/matches/${worldViewId}/resolve-overlap`, {
+    method: 'POST',
+    body: JSON.stringify(resolution),
   });
 }

--- a/frontend/src/components/WorldViewEditor/components/dialogs/DivisionPreviewDialog.tsx
+++ b/frontend/src/components/WorldViewEditor/components/dialogs/DivisionPreviewDialog.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useEffect, useMemo } from 'react';
+import { useRef, useMemo, useState, useEffect, useCallback } from 'react';
 import {
   Dialog,
   DialogTitle,
@@ -12,39 +12,342 @@ import {
 } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import CheckIcon from '@mui/icons-material/Check';
+import UnfoldMoreIcon from '@mui/icons-material/UnfoldMore';
+import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
 import MapGL, { NavigationControl, Source, Layer, MapRef } from 'react-map-gl/maplibre';
+import type maplibregl from 'maplibre-gl';
 import * as turf from '@turf/turf';
-import { fetchGeoshape } from '../../../../api/admin/worldViewImport';
+import { fetchGeoshape, getChildrenRegionGeometry } from '../../../../api/admin/worldViewImport';
 
 const MAP_STYLE = 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json';
+const CHILD_COLORS = ['#3388ff', '#33aa55', '#9955cc', '#cc7733', '#5599dd', '#aa3366', '#55bb88', '#8866cc', '#dd5555', '#44bbaa', '#7766bb', '#bb8844'];
 
 interface PreviewDivision {
   name: string;
   path?: string;
 }
 
+// Helper: render the right panel — either color-coded children, a spinner, the divisions map, or a "no geometry" placeholder.
+type DivisionGeometry = GeoJSON.Geometry | GeoJSON.FeatureCollection | null;
+interface RenderRightPanelArgs {
+  rightMode: 'divisions' | 'children';
+  loading: boolean;
+  geometry: DivisionGeometry;
+  childRegions: Array<{ regionId: number; name: string; geometry: GeoJSON.Geometry }> | null;
+  childrenLoading: boolean;
+  mapRef: React.RefObject<MapRef>;
+  aiSuggestedIds: Set<number>;
+  aiRejectedIds: Set<number>;
+  aiUnclearIds: Set<number>;
+}
+function renderRightPanel(args: RenderRightPanelArgs) {
+  const { rightMode, loading, geometry, childRegions, childrenLoading, mapRef, aiSuggestedIds, aiRejectedIds, aiUnclearIds } = args;
+  if (rightMode === 'children') {
+    return (
+      <ChildrenMapPanel
+        childRegions={childRegions}
+        loading={childrenLoading}
+        geometry={geometry}
+      />
+    );
+  }
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', flex: 1 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+  if (geometry) {
+    return (
+      <DivisionsMapPanel
+        mapRef={mapRef}
+        geometry={geometry}
+        aiSuggestedIds={aiSuggestedIds}
+        aiRejectedIds={aiRejectedIds}
+        aiUnclearIds={aiUnclearIds}
+      />
+    );
+  }
+  return (
+    <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', flex: 1 }}>
+      <Typography color="text.secondary">No geometry available</Typography>
+    </Box>
+  );
+}
+
+function getRightPanelToggleLabel(
+  childrenLoading: boolean,
+  rightMode: 'divisions' | 'children',
+): string {
+  if (childrenLoading) return 'loading...';
+  if (rightMode === 'children') return 'show divisions';
+  return 'show subregions';
+}
+
+// Sub-component: renders the geoshape map section (loading / map / empty).
+interface GeoshapeMapContentProps {
+  geoshapeLoading: boolean;
+  geoshapeData: GeoJSON.FeatureCollection | null;
+  geoshapeMapRef: React.RefObject<MapRef>;
+}
+
+function GeoshapeMapContent({ geoshapeLoading, geoshapeData, geoshapeMapRef }: GeoshapeMapContentProps) {
+  if (geoshapeLoading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', flex: 1 }}>
+        <CircularProgress size={24} />
+      </Box>
+    );
+  }
+  if (!geoshapeData) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', flex: 1 }}>
+        <Typography variant="caption" color="text.secondary">No geoshape available</Typography>
+      </Box>
+    );
+  }
+  const handleLoad = () => {
+    if (!geoshapeMapRef.current) return;
+    try {
+      const bbox = turf.bbox(geoshapeData) as [number, number, number, number];
+      geoshapeMapRef.current.fitBounds(
+        [[bbox[0], bbox[1]], [bbox[2], bbox[3]]],
+        { padding: 40, duration: 0 },
+      );
+    } catch (e) {
+      console.error('Failed to fit geoshape bounds:', e);
+    }
+  };
+  return (
+    <MapGL
+      ref={geoshapeMapRef}
+      initialViewState={{ longitude: 0, latitude: 0, zoom: 1 }}
+      style={{ width: '100%', flex: 1 }}
+      mapStyle={MAP_STYLE}
+      onLoad={handleLoad}
+    >
+      <NavigationControl position="top-right" showCompass={false} />
+      <Source id="geoshape" type="geojson" data={geoshapeData}>
+        <Layer
+          id="geoshape-fill"
+          type="fill"
+          paint={{ 'fill-color': '#e53935', 'fill-opacity': 0.3 }}
+        />
+        <Layer
+          id="geoshape-outline"
+          type="line"
+          paint={{ 'line-color': '#e53935', 'line-width': 2 }}
+        />
+      </Source>
+    </MapGL>
+  );
+}
+
+// Helper: classify a division ID against AI suggestion/rejection/unclear sets.
+function classifyDivision(
+  divId: number,
+  aiSuggestedIds: Set<number>,
+  aiRejectedIds: Set<number>,
+  aiUnclearIds: Set<number>,
+): 'inside' | 'outside' | 'unclear' | null {
+  if (aiSuggestedIds.has(divId)) return 'inside';
+  if (aiRejectedIds.has(divId)) return 'outside';
+  if (aiUnclearIds.has(divId)) return 'unclear';
+  return null;
+}
+
 interface DivisionPreviewDialogProps {
   division: PreviewDivision | null;
-  /** GADM division geometry, or a role-tagged FeatureCollection for transfer preview */
+  /** Single geometry or FeatureCollection (for multi-division with individual borders) */
   geometry: GeoJSON.Geometry | GeoJSON.FeatureCollection | null;
   loading: boolean;
   onClose: () => void;
   /** Region map image URL for side-by-side comparison */
   regionMapUrl?: string;
+  /** Label override for the region map panel (e.g. "Parent region map" when using fallback) */
+  regionMapLabel?: string;
+  /** Name of the region being reviewed (shown in the strip header) */
+  regionName?: string;
   /** Wikidata ID for geoshape fallback (when no regionMapUrl) */
   wikidataId?: string;
+  /** World view ID for fetching children geometry */
+  worldViewId?: number;
+  /** Region ID for fetching children geometry */
+  regionId?: number;
   /** Optional accept callback — when provided, shows an Accept button */
   onAccept?: () => void;
   /** Optional reject callback — when provided, shows a Reject button */
   onReject?: () => void;
   /** Optional accept-and-reject-rest callback — accepts this and rejects remaining suggestions */
   onAcceptAndRejectRest?: () => void;
+  /** Optional split-deeper callback — replaces divisions with finer-grained children. Receives the active left-panel source. */
+  onSplitDeeper?: (source: 'geoshape' | 'points' | 'image' | null) => void;
+  /** Optional AI vision match callback — suggests divisions via image analysis */
+  onVisionMatch?: () => Promise<{ ids: number[]; rejectedIds?: number[]; unclearIds?: number[]; reasoning?: string; debugImages?: { regionMap: string; divisionsMap: string } }>;
+  /** Marker points from point matching (shown when no image/geoshape) */
+  markerPoints?: Array<{ name: string; lat: number; lon: number }>;
   /** Whether accept/reject actions are in progress */
   actionPending?: boolean;
-  /** Override label for the Accept button (default: "Accept") */
-  acceptLabel?: string;
-  /** Marker points extracted from Wikivoyage article (shown when no geoshape/image) */
-  markerPoints?: Array<{ name: string; lat: number; lon: number }>;
+}
+
+/** Right panel: GADM divisions with AI classification colors */
+function DivisionsMapPanel({ mapRef, geometry, aiSuggestedIds, aiRejectedIds, aiUnclearIds }: {
+  mapRef: React.RefObject<MapRef>;
+  geometry: GeoJSON.Geometry | GeoJSON.FeatureCollection;
+  aiSuggestedIds: Set<number>;
+  aiRejectedIds: Set<number>;
+  aiUnclearIds: Set<number>;
+}) {
+  const rawData: GeoJSON.FeatureCollection = geometry.type === 'FeatureCollection'
+    ? geometry as GeoJSON.FeatureCollection
+    : { type: 'FeatureCollection', features: [{ type: 'Feature', properties: {}, geometry: geometry as GeoJSON.Geometry }] };
+  const hasAiResults = aiSuggestedIds.size > 0 || aiRejectedIds.size > 0 || aiUnclearIds.size > 0;
+  const geoData: GeoJSON.FeatureCollection = hasAiResults
+    ? {
+        ...rawData,
+        features: rawData.features.map(f => {
+          const divId = f.properties?.divisionId;
+          if (divId == null) return f;
+          const aiClass = classifyDivision(divId, aiSuggestedIds, aiRejectedIds, aiUnclearIds);
+          return aiClass ? { ...f, properties: { ...f.properties, aiClass } } : f;
+        }),
+      }
+    : rawData;
+  return (
+    <MapGL
+      ref={mapRef}
+      initialViewState={{ longitude: 0, latitude: 0, zoom: 1 }}
+      style={{ width: '100%', height: '100%' }}
+      mapStyle={MAP_STYLE}
+      onLoad={() => {
+        if (mapRef.current) {
+          try {
+            const bbox = turf.bbox(geoData) as [number, number, number, number];
+            mapRef.current.fitBounds([[bbox[0], bbox[1]], [bbox[2], bbox[3]]], { padding: 40, duration: 0 });
+          } catch (e) { console.error('Failed to fit bounds:', e); }
+        }
+      }}
+    >
+      <NavigationControl position="top-right" showCompass={false} />
+      <Source id="preview-division" type="geojson" data={geoData}>
+        <Layer id="preview-division-fill" type="fill" filter={['!=', ['geometry-type'], 'Point']} paint={{
+          'fill-color': ['case', ['has', 'assignedTo'], '#9e9e9e', ['==', ['get', 'aiClass'], 'inside'], '#4caf50', ['==', ['get', 'aiClass'], 'outside'], '#f44336', ['==', ['get', 'aiClass'], 'unclear'], '#ff9800', ['==', ['get', 'hasPoints'], true], '#4caf50', '#3388ff'],
+          'fill-opacity': ['case', ['has', 'assignedTo'], 0.15, ['==', ['get', 'aiClass'], 'inside'], 0.5, ['==', ['get', 'aiClass'], 'outside'], 0.2, ['==', ['get', 'aiClass'], 'unclear'], 0.4, ['==', ['get', 'hasPoints'], true], 0.5, 0.4],
+        }} />
+        <Layer id="preview-division-outline" type="line" filter={['!=', ['geometry-type'], 'Point']} paint={{
+          'line-color': ['case', ['has', 'assignedTo'], '#9e9e9e', ['==', ['get', 'aiClass'], 'inside'], '#2e7d32', ['==', ['get', 'aiClass'], 'outside'], '#c62828', ['==', ['get', 'aiClass'], 'unclear'], '#e65100', ['==', ['get', 'hasPoints'], true], '#2e7d32', '#3388ff'],
+          'line-width': ['case', ['has', 'assignedTo'], 1, ['has', 'aiClass'], 2, 2],
+        }} />
+        <Layer id="preview-markers" type="circle" filter={['==', ['geometry-type'], 'Point']} paint={{ 'circle-radius': 5, 'circle-color': '#e53935', 'circle-stroke-color': '#fff', 'circle-stroke-width': 1.5 }} />
+      </Source>
+    </MapGL>
+  );
+}
+
+/** Right panel: color-coded children regions */
+function ChildrenMapPanel({ childRegions, loading, geometry }: {
+  childRegions: Array<{ regionId: number; name: string; geometry: GeoJSON.Geometry }> | null;
+  loading: boolean;
+  geometry: GeoJSON.Geometry | GeoJSON.FeatureCollection | null;
+}) {
+  const mapRef = useRef<MapRef>(null);
+  const colored = useMemo(() =>
+    (childRegions ?? []).map((c, i) => ({
+      ...c,
+      color: CHILD_COLORS[i % CHILD_COLORS.length],
+      fc: { type: 'FeatureCollection' as const, features: [{ type: 'Feature' as const, properties: { name: c.name }, geometry: c.geometry }] },
+    })),
+  [childRegions]);
+
+  // Fit to the same extent as the division geometry (if available) or children
+  const fitData = useMemo(() => {
+    if (geometry) {
+      return geometry.type === 'FeatureCollection'
+        ? geometry as GeoJSON.FeatureCollection
+        : { type: 'FeatureCollection', features: [{ type: 'Feature', properties: {}, geometry }] } as GeoJSON.FeatureCollection;
+    }
+    if (!childRegions?.length) return null;
+    return {
+      type: 'FeatureCollection' as const,
+      features: childRegions.map(c => ({ type: 'Feature' as const, properties: {}, geometry: c.geometry })),
+    };
+  }, [geometry, childRegions]);
+
+  // Hover tooltip — all hooks must be before early returns
+  const [tooltip, setTooltip] = useState<{ x: number; y: number; name: string } | null>(null);
+  const interactiveIds = useMemo(() => colored.map((_, i) => `child-fill-${i}`), [colored]);
+  const handleMouseMove = useCallback((e: maplibregl.MapLayerMouseEvent) => {
+    const name = e.features?.[0]?.properties?.name;
+    if (name) setTooltip({ x: e.point.x, y: e.point.y, name });
+    else setTooltip(null);
+  }, []);
+  const handleMouseLeave = useCallback(() => setTooltip(null), []);
+
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', flex: 1 }}>
+        <CircularProgress size={24} />
+      </Box>
+    );
+  }
+  if (!colored.length) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', flex: 1 }}>
+        <Typography color="text.secondary">No child regions with divisions</Typography>
+      </Box>
+    );
+  }
+  return (
+    <>
+      <Box sx={{ position: 'relative', flex: 1 }}>
+        <MapGL
+          ref={mapRef}
+          initialViewState={{ longitude: 0, latitude: 0, zoom: 1 }}
+          style={{ width: '100%', height: '100%' }}
+          mapStyle={MAP_STYLE}
+          interactiveLayerIds={interactiveIds}
+          onMouseMove={handleMouseMove}
+          onMouseLeave={handleMouseLeave}
+          cursor={tooltip ? 'pointer' : 'grab'}
+          onLoad={() => {
+            if (mapRef.current && fitData) {
+              try {
+                const bbox = turf.bbox(fitData) as [number, number, number, number];
+                mapRef.current.fitBounds([[bbox[0], bbox[1]], [bbox[2], bbox[3]]], { padding: 40, duration: 0 });
+              } catch { /* ignore */ }
+            }
+          }}
+        >
+          <NavigationControl position="top-right" showCompass={false} />
+          {colored.map((c, i) => (
+            <Source key={`child-${c.regionId}`} id={`child-${i}`} type="geojson" data={c.fc}>
+              <Layer id={`child-fill-${i}`} type="fill" paint={{ 'fill-color': c.color, 'fill-opacity': 0.45 }} />
+              <Layer id={`child-outline-${i}`} type="line" paint={{ 'line-color': c.color, 'line-width': 1.5 }} />
+            </Source>
+          ))}
+        </MapGL>
+        {tooltip && (
+          <Box sx={{
+            position: 'absolute', left: tooltip.x + 12, top: tooltip.y - 28,
+            bgcolor: 'rgba(0,0,0,0.8)', color: '#fff', px: 1, py: 0.25,
+            borderRadius: 0.5, fontSize: '0.75rem', pointerEvents: 'none',
+            whiteSpace: 'nowrap', zIndex: 10,
+          }}>
+            {tooltip.name}
+          </Box>
+        )}
+      </Box>
+      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, p: 0.5, borderTop: 1, borderColor: 'divider', maxHeight: 55, overflow: 'auto' }}>
+        {colored.map(c => (
+          <Box key={c.regionId} sx={{ display: 'flex', alignItems: 'center', gap: 0.5, px: 0.5 }}>
+            <Box sx={{ width: 10, height: 10, borderRadius: '50%', bgcolor: c.color, flexShrink: 0 }} />
+            <Typography variant="caption" noWrap sx={{ maxWidth: 120 }}>{c.name}</Typography>
+          </Box>
+        ))}
+      </Box>
+    </>
+  );
 }
 
 export function DivisionPreviewDialog({
@@ -53,25 +356,65 @@ export function DivisionPreviewDialog({
   loading,
   onClose,
   regionMapUrl,
+  regionMapLabel,
+  regionName,
   wikidataId,
+  worldViewId,
+  regionId,
   onAccept,
   onReject,
   onAcceptAndRejectRest,
-  actionPending,
-  acceptLabel,
+  onSplitDeeper,
+  onVisionMatch,
   markerPoints,
+  actionPending,
 }: DivisionPreviewDialogProps) {
   const mapRef = useRef<MapRef>(null);
   const geoshapeMapRef = useRef<MapRef>(null);
   const [geoshapeData, setGeoshapeData] = useState<GeoJSON.FeatureCollection | null>(null);
   const [geoshapeLoading, setGeoshapeLoading] = useState(false);
   const [geoshapeError, setGeoshapeError] = useState(false);
+  const [selectedSource, setSelectedSource] = useState<string | null>(null);
+  const [aiSuggestedIds, setAiSuggestedIds] = useState<Set<number>>(new Set());
+  const [aiRejectedIds, setAiRejectedIds] = useState<Set<number>>(new Set());
+  const [aiUnclearIds, setAiUnclearIds] = useState<Set<number>>(new Set());
+  const [aiLoading, setAiLoading] = useState(false);
+  const [aiReasoning, setAiReasoning] = useState<string | null>(null);
+  const [aiDebugImages, setAiDebugImages] = useState<{ regionMap: string; divisionsMap: string } | null>(null);
 
-  // Fetch geoshape when dialog opens with wikidataId (and no regionMapUrl)
+  // Color-coded children view for right panel
+  const [rightMode, setRightMode] = useState<'divisions' | 'children'>('divisions');
+  const [childRegions, setChildRegions] = useState<Array<{ regionId: number; name: string; geometry: GeoJSON.Geometry }> | null>(null);
+  const [childrenLoading, setChildrenLoading] = useState(false);
+  const canShowChildren = worldViewId != null && regionId != null;
+
+  // Reset children state when region changes
+  useEffect(() => { setRightMode('divisions'); setChildRegions(null); }, [regionId]);
+
+  const handleToggleChildren = async () => {
+    if (rightMode === 'children') { setRightMode('divisions'); return; }
+    setRightMode('children');
+    if (childRegions || !canShowChildren) return;
+    setChildrenLoading(true);
+    try {
+      const result = await getChildrenRegionGeometry(worldViewId!, regionId!);
+      setChildRegions(result.childRegions);
+    } finally {
+      setChildrenLoading(false);
+    }
+  };
+
+  // Fetch geoshape when dialog opens with wikidataId (preferred over image)
   useEffect(() => {
-    if (!division || regionMapUrl || !wikidataId) {
+    if (!division || !wikidataId) {
       setGeoshapeData(null);
       setGeoshapeError(false);
+      setSelectedSource(null);
+      setAiSuggestedIds(new Set());
+      setAiRejectedIds(new Set());
+      setAiUnclearIds(new Set());
+      setAiReasoning(null);
+      setAiDebugImages(null);
       return;
     }
 
@@ -83,9 +426,9 @@ export function DivisionPreviewDialog({
       .catch(() => { if (!stale) setGeoshapeError(true); })
       .finally(() => { if (!stale) setGeoshapeLoading(false); });
     return () => { stale = true; };
-  }, [division, regionMapUrl, wikidataId]);
+  }, [division, wikidataId]);
 
-  // Detect transfer preview: a FeatureCollection with role-tagged features
+  // Detect transfer preview: a FeatureCollection with role properties (donor, moving, target_outline)
   const isTransferPreview = geometry != null
     && 'type' in geometry && geometry.type === 'FeatureCollection'
     && (geometry as GeoJSON.FeatureCollection).features.some(f => f.properties?.role === 'donor');
@@ -101,20 +444,27 @@ export function DivisionPreviewDialog({
     };
   }, [isTransferPreview, geometry]);
 
-  const hasImageSideBySide = !isTransferPreview && !!regionMapUrl;
-  const hasGeoshapeSideBySide = !isTransferPreview && !regionMapUrl && !!wikidataId && !geoshapeError;
-  const hasMarkerPointsSideBySide = !isTransferPreview && !regionMapUrl && (!wikidataId || geoshapeError) && !!markerPoints && markerPoints.length > 0;
-  const hasSideBySide = hasImageSideBySide || hasGeoshapeSideBySide || hasMarkerPointsSideBySide;
+  // Build list of available left-panel sources
+  const geoshapeHasFeatures = !!geoshapeData && geoshapeData.features.length > 0;
+  const geoshapeAvailable = !!wikidataId && !geoshapeError && (geoshapeLoading || geoshapeHasFeatures);
+  const imageAvailable = !!regionMapUrl;
+  const pointsAvailable = !!markerPoints && markerPoints.length > 0;
 
-  // Build GeoJSON FeatureCollection for marker points
-  const markerPointsGeoJSON: GeoJSON.FeatureCollection | null = hasMarkerPointsSideBySide && markerPoints ? {
-    type: 'FeatureCollection',
-    features: markerPoints.map(p => ({
-      type: 'Feature' as const,
-      properties: { name: p.name },
-      geometry: { type: 'Point' as const, coordinates: [p.lon, p.lat] },
-    })),
-  } : null;
+  const availableSources = useMemo(() => {
+    const sources: Array<{ key: string; label: string }> = [];
+    if (geoshapeAvailable) sources.push({ key: 'geoshape', label: 'Geoshape' });
+    if (imageAvailable) sources.push({ key: 'image', label: regionMapLabel ?? 'Region map' });
+    if (pointsAvailable) sources.push({ key: 'points', label: 'Marker points' });
+    return sources;
+  }, [geoshapeAvailable, imageAvailable, pointsAvailable, regionMapLabel]);
+
+  const activeSource = selectedSource && availableSources.some(s => s.key === selectedSource)
+    ? selectedSource
+    : availableSources[0]?.key ?? null;
+  const showGeoshape = activeSource === 'geoshape';
+  const showImage = activeSource === 'image';
+  const showPoints = activeSource === 'points';
+  const hasSideBySide = availableSources.length > 0 || !!wikidataId;
 
   return (
     <Dialog
@@ -127,6 +477,11 @@ export function DivisionPreviewDialog({
         <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
           <Box>
             <Typography variant="h6">{division?.name}</Typography>
+            {regionName && (
+              <Typography variant="body2" color="text.secondary">
+                reviewing for <strong>{regionName}</strong>
+              </Typography>
+            )}
             {division?.path && (
               <Typography variant="caption" color="text.secondary">
                 {division.path}
@@ -139,9 +494,70 @@ export function DivisionPreviewDialog({
         </Box>
       </DialogTitle>
       <DialogContent sx={{ p: 0 }}>
-        <Box sx={{ display: 'flex', height: 400 }}>
+        {/* Transfer preview: 3-layer map with donor, moving, and target outline */}
+        {transferData && (
+          <Box>
+            <Box sx={{ width: '100%', height: 400 }}>
+              <MapGL
+                initialViewState={{ bounds: transferData.bounds, fitBoundsOptions: { padding: 40 } }}
+                style={{ width: '100%', height: '100%' }}
+                mapStyle={MAP_STYLE}
+              >
+                <NavigationControl position="top-right" />
+                <Source id="donor" type="geojson" data={transferData.donor}>
+                  <Layer id="donor-fill" type="fill" paint={{ 'fill-color': '#9e9e9e', 'fill-opacity': 0.3 }} />
+                  <Layer id="donor-line" type="line" paint={{ 'line-color': '#757575', 'line-width': 1.5 }} />
+                </Source>
+                <Source id="moving" type="geojson" data={transferData.moving}>
+                  <Layer id="moving-fill" type="fill" paint={{ 'fill-color': '#ff9800', 'fill-opacity': 0.5 }} />
+                  <Layer id="moving-line" type="line" paint={{ 'line-color': '#e65100', 'line-width': 2 }} />
+                </Source>
+                <Source id="target-outline" type="geojson" data={transferData.outline}>
+                  <Layer id="target-line" type="line" paint={{ 'line-color': '#1976d2', 'line-width': 2, 'line-dasharray': [4, 3] }} />
+                </Source>
+              </MapGL>
+            </Box>
+            <Box sx={{ display: 'flex', gap: 2, mt: 1, justifyContent: 'center' }}>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                <Box sx={{ width: 12, height: 12, bgcolor: '#9e9e9e', opacity: 0.5, borderRadius: 0.5 }} />
+                <Typography variant="caption">Stays with donor</Typography>
+              </Box>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                <Box sx={{ width: 12, height: 12, bgcolor: '#ff9800', borderRadius: 0.5 }} />
+                <Typography variant="caption">Moving to target</Typography>
+              </Box>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                <Box sx={{ width: 12, height: 12, border: '2px dashed #1976d2', borderRadius: 0.5 }} />
+                <Typography variant="caption">Target geoshape</Typography>
+              </Box>
+            </Box>
+          </Box>
+        )}
+        {/* Fixed toggle strip between title and maps */}
+        {!isTransferPreview && hasSideBySide && (
+          <Box sx={{ display: 'flex', justifyContent: 'space-between', px: 2, py: 0.5, borderBottom: 1, borderColor: 'divider', bgcolor: 'grey.50' }}>
+            <Typography variant="caption" color="text.secondary" sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              {availableSources.find(s => s.key === activeSource)?.label ?? 'Source region'}
+              {availableSources.length > 1 && availableSources.filter(s => s.key !== activeSource).map(s => (
+                <Typography key={s.key} component="span" variant="caption" sx={{ cursor: 'pointer', color: 'primary.main', '&:hover': { textDecoration: 'underline' } }} onClick={() => setSelectedSource(s.key)}>
+                  {s.label.toLowerCase()}
+                </Typography>
+              ))}
+            </Typography>
+            <Typography variant="caption" color="text.secondary" sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              {rightMode === 'children' ? 'Subregions (color-coded)' : <>GADM division <strong>{division?.name}</strong></>}
+              {canShowChildren && (
+                <Typography component="span" variant="caption" sx={{ cursor: 'pointer', color: 'primary.main', '&:hover': { textDecoration: 'underline' } }} onClick={handleToggleChildren}>
+                  {getRightPanelToggleLabel(childrenLoading, rightMode)}
+                </Typography>
+              )}
+            </Typography>
+          </Box>
+        )}
+        {!isTransferPreview && (
+        <Box sx={{ display: 'flex', height: hasSideBySide ? 380 : 400 }}>
           {/* Region map image (left side) */}
-          {hasImageSideBySide && (
+          {showImage && (
             <Box sx={{
               flex: 1,
               display: 'flex',
@@ -153,9 +569,6 @@ export function DivisionPreviewDialog({
               bgcolor: 'grey.50',
               p: 1,
             }}>
-              <Typography variant="caption" color="text.secondary" sx={{ mb: 0.5 }}>
-                Region map
-              </Typography>
               <Box
                 component="img"
                 src={`${regionMapUrl}?width=500`}
@@ -169,8 +582,8 @@ export function DivisionPreviewDialog({
             </Box>
           )}
 
-          {/* Wikidata geoshape map (left side, fallback when no regionMapUrl) */}
-          {hasGeoshapeSideBySide && (
+          {/* Wikidata geoshape map (left side) */}
+          {showGeoshape && (
             <Box sx={{
               flex: 1,
               display: 'flex',
@@ -178,225 +591,166 @@ export function DivisionPreviewDialog({
               borderRight: 1,
               borderColor: 'divider',
             }}>
-              <Typography variant="caption" color="text.secondary" sx={{ display: 'block', textAlign: 'center', pt: 0.5 }}>
-                Source region
-              </Typography>
-              {geoshapeLoading ? (
-                <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', flex: 1 }}>
-                  <CircularProgress size={24} />
-                </Box>
-              ) : geoshapeData ? (
-                <MapGL
-                  ref={geoshapeMapRef}
-                  initialViewState={{ longitude: 0, latitude: 0, zoom: 1 }}
-                  style={{ width: '100%', flex: 1 }}
-                  mapStyle={MAP_STYLE}
-                  onLoad={() => {
-                    if (geoshapeMapRef.current && geoshapeData) {
-                      try {
-                        const bbox = turf.bbox(geoshapeData) as [number, number, number, number];
-                        geoshapeMapRef.current.fitBounds(
-                          [[bbox[0], bbox[1]], [bbox[2], bbox[3]]],
-                          { padding: 40, duration: 500 },
-                        );
-                      } catch (e) {
-                        console.error('Failed to fit geoshape bounds:', e);
-                      }
-                    }
-                  }}
-                >
-                  <NavigationControl position="top-right" showCompass={false} />
-                  <Source id="geoshape" type="geojson" data={geoshapeData}>
-                    <Layer
-                      id="geoshape-fill"
-                      type="fill"
-                      paint={{ 'fill-color': '#e53935', 'fill-opacity': 0.3 }}
-                    />
-                    <Layer
-                      id="geoshape-outline"
-                      type="line"
-                      paint={{ 'line-color': '#e53935', 'line-width': 2 }}
-                    />
-                  </Source>
-                </MapGL>
-              ) : (
-                <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', flex: 1 }}>
-                  <Typography variant="caption" color="text.secondary">No geoshape available</Typography>
-                </Box>
-              )}
+              <GeoshapeMapContent
+                geoshapeLoading={geoshapeLoading}
+                geoshapeData={geoshapeData}
+                geoshapeMapRef={geoshapeMapRef}
+              />
             </Box>
           )}
 
-          {/* Wikivoyage marker points map (left side, fallback when no regionMapUrl and no geoshape) */}
-          {hasMarkerPointsSideBySide && markerPointsGeoJSON && (
+          {/* Marker points map */}
+          {hasSideBySide && showPoints && markerPoints && markerPoints.length > 0 && (
+            <Box sx={{ flex: 1, borderRight: 1, borderColor: 'divider' }}>
+              <MapGL
+                initialViewState={{
+                  bounds: [
+                    Math.min(...markerPoints.map(p => p.lon)) - 0.5,
+                    Math.min(...markerPoints.map(p => p.lat)) - 0.5,
+                    Math.max(...markerPoints.map(p => p.lon)) + 0.5,
+                    Math.max(...markerPoints.map(p => p.lat)) + 0.5,
+                  ] as [number, number, number, number],
+                  fitBoundsOptions: { padding: 40 },
+                }}
+                style={{ width: '100%', height: '100%' }}
+                mapStyle={MAP_STYLE}
+              >
+                <NavigationControl position="top-right" />
+                <Source id="marker-points" type="geojson" data={{
+                  type: 'FeatureCollection',
+                  features: markerPoints.map(p => ({
+                    type: 'Feature' as const,
+                    properties: { name: p.name },
+                    geometry: { type: 'Point' as const, coordinates: [p.lon, p.lat] },
+                  })),
+                }}>
+                  <Layer id="marker-circles" type="circle" paint={{
+                    'circle-radius': 5,
+                    'circle-color': '#e65100',
+                    'circle-stroke-width': 1.5,
+                    'circle-stroke-color': '#fff',
+                  }} />
+                </Source>
+              </MapGL>
+            </Box>
+          )}
+          {/* Placeholder when no source data at all */}
+          {hasSideBySide && !showGeoshape && !showImage && !showPoints && (
             <Box sx={{
               flex: 1,
               display: 'flex',
               flexDirection: 'column',
+              alignItems: 'center',
+              justifyContent: 'center',
               borderRight: 1,
               borderColor: 'divider',
+              bgcolor: 'grey.50',
+              p: 2,
             }}>
-              <Typography variant="caption" color="text.secondary" sx={{ display: 'block', textAlign: 'center', pt: 0.5 }}>
-                Marker points ({markerPoints!.length})
+              <Typography variant="body2" color="text.secondary" textAlign="center">
+                No source map available
               </Typography>
-              <MapGL
-                initialViewState={{ longitude: 0, latitude: 0, zoom: 1 }}
-                style={{ width: '100%', flex: 1 }}
-                mapStyle={MAP_STYLE}
-                onLoad={(e) => {
-                  try {
-                    const bbox = turf.bbox(markerPointsGeoJSON) as [number, number, number, number];
-                    e.target.fitBounds(
-                      [[bbox[0], bbox[1]], [bbox[2], bbox[3]]],
-                      { padding: 60, duration: 500, maxZoom: 10 },
-                    );
-                  } catch (err) {
-                    console.error('Failed to fit marker points bounds:', err);
-                  }
-                }}
-              >
-                <NavigationControl position="top-right" showCompass={false} />
-                <Source id="marker-points" type="geojson" data={markerPointsGeoJSON}>
-                  <Layer
-                    id="marker-points-circle"
-                    type="circle"
-                    paint={{
-                      'circle-color': '#ff9800',
-                      'circle-radius': 5,
-                      'circle-stroke-color': '#e65100',
-                      'circle-stroke-width': 1,
-                    }}
-                  />
-                </Source>
-              </MapGL>
+              <Typography variant="caption" color="text.disabled" textAlign="center" sx={{ mt: 0.5 }}>
+                Neither a region map image nor a Wikidata geoshape exists for this region
+              </Typography>
             </Box>
           )}
 
-          {/* Transfer preview map — full-width 3-layer map (donor/moving/target_outline) */}
-          {isTransferPreview && transferData && (
-            <Box sx={{ flex: 1, minWidth: 0 }}>
-              <Box sx={{ display: 'flex', justifyContent: 'center', gap: 2, pt: 0.5, pb: 0.25 }}>
-                <Typography variant="caption" sx={{ color: '#e53935', fontSize: '0.65rem' }}>■ donor region</Typography>
-                <Typography variant="caption" sx={{ color: '#ff9800', fontSize: '0.65rem' }}>■ moving divisions</Typography>
-                <Typography variant="caption" sx={{ color: '#3388ff', fontSize: '0.65rem' }}>□ target outline</Typography>
-              </Box>
-              <MapGL
-                ref={mapRef}
-                initialViewState={{ longitude: 0, latitude: 0, zoom: 1 }}
-                style={{ width: '100%', height: 'calc(100% - 26px)' }}
-                mapStyle={MAP_STYLE}
-                onLoad={() => {
-                  if (mapRef.current) {
-                    try {
-                      const b = transferData.bounds;
-                      mapRef.current.fitBounds(
-                        [[b[0], b[1]], [b[2], b[3]]],
-                        { padding: 40, duration: 500 },
-                      );
-                    } catch (e) {
-                      console.error('Failed to fit transfer bounds:', e);
-                    }
-                  }
-                }}
-              >
-                <NavigationControl position="top-right" showCompass={false} />
-                <Source id="transfer-donor" type="geojson" data={transferData.donor}>
-                  <Layer id="transfer-donor-fill" type="fill" paint={{ 'fill-color': '#e53935', 'fill-opacity': 0.2 }} />
-                  <Layer id="transfer-donor-outline" type="line" paint={{ 'line-color': '#e53935', 'line-width': 2 }} />
-                </Source>
-                <Source id="transfer-moving" type="geojson" data={transferData.moving}>
-                  <Layer id="transfer-moving-fill" type="fill" paint={{ 'fill-color': '#ff9800', 'fill-opacity': 0.45 }} />
-                  <Layer id="transfer-moving-outline" type="line" paint={{ 'line-color': '#ff9800', 'line-width': 2 }} />
-                </Source>
-                <Source id="transfer-outline" type="geojson" data={transferData.outline}>
-                  <Layer id="transfer-outline-line" type="line" paint={{ 'line-color': '#3388ff', 'line-width': 2, 'line-dasharray': [4, 3] }} />
-                </Source>
-              </MapGL>
-            </Box>
-          )}
-
-          {/* GADM division map (right side, or full width if no WV image/geoshape) */}
-          {!isTransferPreview && (
-            <Box sx={{ flex: 1, minWidth: 0 }}>
-              {loading ? (
-                <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
-                  <CircularProgress />
-                </Box>
-              ) : geometry ? (
-                <>
-                  {hasSideBySide && (
-                    <Typography variant="caption" color="text.secondary" sx={{ display: 'block', textAlign: 'center', pt: 0.5 }}>
-                      GADM division
-                    </Typography>
-                  )}
-                  <MapGL
-                    ref={mapRef}
-                    initialViewState={{
-                      longitude: 0,
-                      latitude: 0,
-                      zoom: 1,
-                    }}
-                    style={{ width: '100%', height: hasSideBySide ? 'calc(100% - 20px)' : '100%' }}
-                    mapStyle={MAP_STYLE}
-                    onLoad={() => {
-                      if (mapRef.current && geometry) {
-                        try {
-                          const geom = geometry as GeoJSON.Geometry;
-                          const fc: GeoJSON.FeatureCollection = {
-                            type: 'FeatureCollection',
-                            features: [{ type: 'Feature', properties: {}, geometry: geom }],
-                          };
-                          const bbox = turf.bbox(fc) as [number, number, number, number];
-                          mapRef.current.fitBounds(
-                            [[bbox[0], bbox[1]], [bbox[2], bbox[3]]],
-                            { padding: 40, duration: 500 }
-                          );
-                        } catch (e) {
-                          console.error('Failed to fit bounds:', e);
-                        }
-                      }
-                    }}
-                  >
-                    <NavigationControl position="top-right" showCompass={false} />
-                    <Source
-                      id="preview-division"
-                      type="geojson"
-                      data={{
-                        type: 'Feature',
-                        properties: {},
-                        geometry: geometry as GeoJSON.Geometry,
-                      }}
-                    >
-                      <Layer
-                        id="preview-division-fill"
-                        type="fill"
-                        paint={{
-                          'fill-color': '#3388ff',
-                          'fill-opacity': 0.4,
-                        }}
-                      />
-                      <Layer
-                        id="preview-division-outline"
-                        type="line"
-                        paint={{
-                          'line-color': '#3388ff',
-                          'line-width': 2,
-                        }}
-                      />
-                    </Source>
-                  </MapGL>
-                </>
-              ) : (
-                <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
-                  <Typography color="text.secondary">No geometry available</Typography>
-                </Box>
-              )}
-            </Box>
+          {/* Right side: GADM divisions or color-coded children */}
+          <Box sx={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column' }}>
+            {renderRightPanel({
+              rightMode,
+              loading,
+              geometry,
+              childRegions,
+              childrenLoading,
+              mapRef,
+              aiSuggestedIds,
+              aiRejectedIds,
+              aiUnclearIds,
+            })}
+          </Box>
+        </Box>
+        )}
+      {aiReasoning && (
+        <Box sx={{ px: 2, py: 0.5, borderTop: 1, borderColor: 'divider', bgcolor: 'action.hover', display: 'flex', alignItems: 'center', gap: 1 }}>
+          <Typography variant="caption" color="text.secondary" sx={{ flex: 1 }}>
+            <strong>AI reasoning:</strong> {aiReasoning}
+          </Typography>
+          {aiDebugImages && (
+            <Button size="small" variant="text" sx={{ fontSize: '0.7rem', minWidth: 0, py: 0 }} onClick={() => {
+              const w = window.open('', '_blank', 'width=1400,height=700');
+              if (!w) return;
+              w.document.title = 'AI Vision Debug';
+              const doc = w.document;
+              const root = doc.createElement('div');
+              Object.assign(root.style, { display: 'flex', gap: '16px', padding: '16px', fontFamily: 'sans-serif', background: '#f5f5f5', minHeight: '100vh' });
+              const entries: [string, string][] = [['Image 1: Region Map', aiDebugImages.regionMap], ['Image 2: Numbered Divisions', aiDebugImages.divisionsMap]];
+              for (const [title, src] of entries) {
+                const col = doc.createElement('div');
+                col.style.flex = '1';
+                const h = doc.createElement('h3');
+                h.textContent = title;
+                Object.assign(h.style, { margin: '0 0 8px' });
+                const img = doc.createElement('img');
+                img.src = src;
+                Object.assign(img.style, { maxWidth: '100%', border: '1px solid #ccc', borderRadius: '4px' });
+                col.append(h, img);
+                root.appendChild(col);
+              }
+              doc.body.appendChild(root);
+            }}>
+              Show AI inputs
+            </Button>
           )}
         </Box>
+      )}
       </DialogContent>
-      {(onAccept || onReject) && (
+      {(onAccept || onReject || onSplitDeeper || onVisionMatch) && (
         <DialogActions sx={{ px: 2, py: 1.5 }}>
+          <Box sx={{ display: 'flex', gap: 1, mr: 'auto' }}>
+            {onSplitDeeper && (
+              <Button
+                variant="outlined"
+                color="info"
+                size="small"
+                startIcon={<UnfoldMoreIcon />}
+                onClick={() => onSplitDeeper((activeSource ?? null) as 'geoshape' | 'points' | 'image' | null)}
+                disabled={actionPending || aiLoading}
+              >
+                Split deeper
+              </Button>
+            )}
+            {onVisionMatch && (
+              <Button
+                variant="outlined"
+                color="warning"
+                size="small"
+                startIcon={aiLoading ? <CircularProgress size={14} /> : <AutoFixHighIcon />}
+                onClick={async () => {
+                  setAiLoading(true);
+                  setAiReasoning(null);
+                  setAiDebugImages(null);
+                  try {
+                    const result = await onVisionMatch();
+                    setAiSuggestedIds(new Set(result.ids));
+                    setAiRejectedIds(new Set(result.rejectedIds ?? []));
+                    setAiUnclearIds(new Set(result.unclearIds ?? []));
+                    if (result.reasoning) setAiReasoning(result.reasoning);
+                    if (result.debugImages) setAiDebugImages(result.debugImages);
+                  } catch (err) {
+                    console.error('Vision match failed:', err);
+                    setAiReasoning(`Error: ${err instanceof Error ? err.message : 'AI analysis failed'}`);
+                  } finally {
+                    setAiLoading(false);
+                  }
+                }}
+                disabled={actionPending || aiLoading}
+              >
+                {aiLoading ? 'Analyzing...' : 'Suggest with AI'}
+              </Button>
+            )}
+          </Box>
           {onReject && (
             <Button
               variant="outlined"
@@ -430,7 +784,7 @@ export function DivisionPreviewDialog({
               onClick={onAccept}
               disabled={actionPending}
             >
-              {acceptLabel ?? 'Accept'}
+              Accept
             </Button>
           )}
         </DialogActions>

--- a/frontend/src/components/admin/AdminDashboard.tsx
+++ b/frontend/src/components/admin/AdminDashboard.tsx
@@ -31,7 +31,9 @@ import {
   ArrowBack as ArrowBackIcon,
   SupervisorAccount as CuratorIcon,
   Public as PublicIcon,
-  Visibility as CvIcon,
+  SmartToy as AIIcon,
+  Gavel as RulesIcon,
+  CameraEnhance as CVIcon,
 } from '@mui/icons-material';
 import { useAuth } from '../../hooks/useAuth';
 import { SyncPanel } from './SyncPanel';
@@ -39,11 +41,13 @@ import { SyncHistoryPanel } from './SyncHistoryPanel';
 import { AssignmentPanel } from './AssignmentPanel';
 import { CuratorPanel } from './CuratorPanel';
 import { WorldViewImportPanel } from './WorldViewImportPanel';
+import { AISettingsPanel } from './AISettingsPanel';
 import { CVSettingsPanel } from './CVSettingsPanel';
+import { ExtractionRulesPanel } from './ExtractionRulesPanel';
 
 const DRAWER_WIDTH = 240;
 
-type AdminSection = 'overview' | 'sync' | 'assignment' | 'history' | 'curators' | 'wvImport' | 'cvSettings';
+type AdminSection = 'overview' | 'sync' | 'assignment' | 'history' | 'curators' | 'ai' | 'cv' | 'extractionRules' | 'wvImport';
 
 export function AdminDashboard() {
   const { isAdmin, isLoading } = useAuth();
@@ -87,8 +91,10 @@ export function AdminDashboard() {
     { id: 'assignment', label: 'Region Assignment', icon: <MapIcon /> },
     { id: 'history', label: 'Sync History', icon: <HistoryIcon /> },
     { id: 'curators', label: 'Curators', icon: <CuratorIcon /> },
+    { id: 'ai', label: 'AI Settings', icon: <AIIcon /> },
+    { id: 'cv', label: 'CV Settings', icon: <CVIcon /> },
+    { id: 'extractionRules', label: 'Learned Rules', icon: <RulesIcon /> },
     { id: 'wvImport', label: 'Import WorldView', icon: <PublicIcon /> },
-    { id: 'cvSettings', label: 'CV Settings', icon: <CvIcon /> },
   ];
 
   const drawerContent = (
@@ -138,10 +144,14 @@ export function AdminDashboard() {
         return <SyncHistoryPanel />;
       case 'curators':
         return <CuratorPanel />;
+      case 'ai':
+        return <AISettingsPanel />;
+      case 'cv':
+        return <CVSettingsPanel />;
+      case 'extractionRules':
+        return <ExtractionRulesPanel />;
       case 'wvImport':
         return <WorldViewImportPanel />;
-      case 'cvSettings':
-        return <CVSettingsPanel />;
       default:
         return null;
     }

--- a/frontend/src/components/admin/CoverageGapTree.tsx
+++ b/frontend/src/components/admin/CoverageGapTree.tsx
@@ -1,0 +1,426 @@
+/**
+ * Coverage Gap Tree Components
+ *
+ * GapNodeRow and SubtreeNodeRow -- recursive tree display for GADM coverage gaps.
+ * Also includes ContextTreeNode for geo-suggest hierarchy selection.
+ */
+
+import {
+  Box,
+  Typography,
+  IconButton,
+  Tooltip,
+  Chip,
+  Collapse,
+  Stack,
+} from '@mui/material';
+import VisibilityOff from '@mui/icons-material/VisibilityOff';
+import ExpandMore from '@mui/icons-material/ExpandMore';
+import ExpandLess from '@mui/icons-material/ExpandLess';
+import Public from '@mui/icons-material/Public';
+import CheckCircle from '@mui/icons-material/CheckCircle';
+import Undo from '@mui/icons-material/Undo';
+import type {
+  CoverageGap,
+  SubtreeNode,
+  GeoSuggestResult,
+  RegionContextNode,
+} from '../../api/admin/worldViewImport';
+import { allLeavesApplied } from './coverageResolveUtils';
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+type SuggestionAction = CoverageGap['suggestion'];
+
+/** Build the "+ Add to X" / "+ Create under X" label with optional distance suffix. */
+function buildSuggestionChipLabel(
+  suggestion: NonNullable<SuggestionAction>,
+  distanceKm: number | undefined | null,
+): string {
+  const actionLabel = suggestion.action === 'add_member' ? '+ Add to' : '+ Create under';
+  const distancePart = distanceKm ? ` (${distanceKm.toLocaleString()} km)` : '';
+  return `${actionLabel} ${suggestion.targetRegionName}${distancePart}`;
+}
+
+// =============================================================================
+// GapNodeRow -- renders a single gap and its subtree recursively
+// =============================================================================
+
+interface GapNodeRowProps {
+  gap: CoverageGap;
+  depth: number;
+  selectedNodeId: number | null;
+  expandedNodes: Set<number>;
+  nodeSuggestions: Map<number, GeoSuggestResult>;
+  appliedNodes: Set<number>;
+  getNodeSuggestion: (id: number, treeSugg: CoverageGap['suggestion'] | null) => CoverageGap['suggestion'] | null;
+  onSelect: (id: number) => void;
+  onToggleExpand: (id: number) => void;
+  onGeoSuggest: (id: number, name: string) => void;
+  onDismiss: (id: number) => void;
+  onApplySingle: (id: number, name: string) => void;
+  onUnapply: (id: number) => void;
+  geoSuggestPending: boolean;
+  dismissPending: boolean;
+}
+
+export function GapNodeRow({
+  gap,
+  depth,
+  selectedNodeId,
+  expandedNodes,
+  nodeSuggestions,
+  appliedNodes,
+  getNodeSuggestion,
+  onSelect,
+  onToggleExpand,
+  onGeoSuggest,
+  onDismiss,
+  onApplySingle,
+  onUnapply,
+  geoSuggestPending,
+  dismissPending,
+}: GapNodeRowProps) {
+  const hasSubtree = gap.subtree && gap.subtree.length > 0;
+  const directlyApplied = appliedNodes.has(gap.id);
+  // Parent is effectively applied if all its subtree leaves are applied
+  const childrenResolved = hasSubtree && allLeavesApplied(gap.subtree!, appliedNodes);
+  const isApplied = directlyApplied || childrenResolved;
+  const isExpanded = expandedNodes.has(gap.id) && !isApplied;
+  const isSelected = selectedNodeId === gap.id;
+  const effectiveSuggestion = getNodeSuggestion(gap.id, gap.suggestion);
+  const geoResult = nodeSuggestions.get(gap.id);
+
+  return (
+    <Box sx={isApplied ? { opacity: 0.45 } : undefined}>
+      {/* Gap node row */}
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          pl: depth * 2.5,
+          py: 0.25,
+          pr: 0.5,
+          borderRadius: 1,
+          bgcolor: isSelected ? 'action.selected' : 'transparent',
+          '&:hover': { bgcolor: isSelected ? 'action.selected' : 'action.hover' },
+          cursor: 'pointer',
+        }}
+        onClick={() => !isApplied && onSelect(gap.id)}
+      >
+        {/* Expand toggle */}
+        {hasSubtree && !isApplied ? (
+          <IconButton
+            size="small"
+            onClick={(e) => { e.stopPropagation(); onToggleExpand(gap.id); }}
+            sx={{ p: 0.25 }}
+          >
+            {isExpanded ? <ExpandLess sx={{ fontSize: 18 }} /> : <ExpandMore sx={{ fontSize: 18 }} />}
+          </IconButton>
+        ) : (
+          <Box sx={{ width: 26 }} />
+        )}
+
+        {/* Name */}
+        <Typography variant="body2" sx={{ flex: 1, ml: 0.5, minWidth: 0 }} noWrap>
+          {gap.name}
+        </Typography>
+
+        {/* Action buttons */}
+        <Stack direction="row" spacing={0} sx={{ flexShrink: 0 }}>
+          {isApplied ? (
+            <Tooltip title="Undo apply">
+              <IconButton
+                size="small"
+                onClick={(e) => { e.stopPropagation(); onUnapply(gap.id); }}
+              >
+                <Undo sx={{ fontSize: 18 }} />
+              </IconButton>
+            </Tooltip>
+          ) : (
+            <>
+              <Tooltip title="Geo-suggest (find nearest region)">
+                <span>
+                  <IconButton
+                    size="small"
+                    onClick={(e) => { e.stopPropagation(); onGeoSuggest(gap.id, gap.name); }}
+                    disabled={geoSuggestPending}
+                  >
+                    <Public sx={{ fontSize: 18 }} />
+                  </IconButton>
+                </span>
+              </Tooltip>
+              {effectiveSuggestion && (
+                <Tooltip title={`Apply: ${effectiveSuggestion.action === 'add_member' ? 'Add to' : 'Create under'} ${effectiveSuggestion.targetRegionName}`}>
+                  <IconButton
+                    size="small"
+                    color="success"
+                    onClick={(e) => { e.stopPropagation(); onApplySingle(gap.id, gap.name); }}
+                  >
+                    <CheckCircle sx={{ fontSize: 18 }} />
+                  </IconButton>
+                </Tooltip>
+              )}
+              <Tooltip title="Dismiss">
+                <span>
+                  <IconButton
+                    size="small"
+                    onClick={(e) => { e.stopPropagation(); onDismiss(gap.id); }}
+                    disabled={dismissPending}
+                  >
+                    <VisibilityOff sx={{ fontSize: 18 }} />
+                  </IconButton>
+                </span>
+              </Tooltip>
+            </>
+          )}
+        </Stack>
+      </Box>
+
+      {/* Suggestion chip */}
+      {effectiveSuggestion && !isApplied && (
+        <Box sx={{ pl: depth * 2.5 + 3.5, py: 0.25 }}>
+          <Chip
+            label={buildSuggestionChipLabel(effectiveSuggestion, geoResult?.distanceKm)}
+            size="small"
+            variant="outlined"
+            color="info"
+            sx={{ height: 22, fontSize: '0.7rem' }}
+          />
+        </Box>
+      )}
+
+      {/* Subtree children */}
+      {hasSubtree && (
+        <Collapse in={isExpanded} unmountOnExit>
+          {gap.subtree!.map((child) => (
+            <SubtreeNodeRow
+              key={child.id}
+              node={child}
+              depth={depth + 1}
+              selectedNodeId={selectedNodeId}
+              expandedNodes={expandedNodes}
+              nodeSuggestions={nodeSuggestions}
+              appliedNodes={appliedNodes}
+              getNodeSuggestion={getNodeSuggestion}
+              onSelect={onSelect}
+              onToggleExpand={onToggleExpand}
+              onGeoSuggest={onGeoSuggest}
+              onApplySingle={onApplySingle}
+              onUnapply={onUnapply}
+              geoSuggestPending={geoSuggestPending}
+            />
+          ))}
+        </Collapse>
+      )}
+    </Box>
+  );
+}
+
+// =============================================================================
+// SubtreeNodeRow -- renders a GADM subtree child node (with per-node actions)
+// =============================================================================
+
+interface SubtreeNodeRowProps {
+  node: SubtreeNode;
+  depth: number;
+  selectedNodeId: number | null;
+  expandedNodes: Set<number>;
+  nodeSuggestions: Map<number, GeoSuggestResult>;
+  appliedNodes: Set<number>;
+  getNodeSuggestion: (id: number, treeSugg: CoverageGap['suggestion'] | null) => CoverageGap['suggestion'] | null;
+  onSelect: (id: number) => void;
+  onToggleExpand: (id: number) => void;
+  onGeoSuggest: (id: number, name: string) => void;
+  onApplySingle: (id: number, name: string) => void;
+  onUnapply: (id: number) => void;
+  geoSuggestPending: boolean;
+}
+
+function SubtreeNodeRow({
+  node,
+  depth,
+  selectedNodeId,
+  expandedNodes,
+  nodeSuggestions,
+  appliedNodes,
+  getNodeSuggestion,
+  onSelect,
+  onToggleExpand,
+  onGeoSuggest,
+  onApplySingle,
+  onUnapply,
+  geoSuggestPending,
+}: SubtreeNodeRowProps) {
+  const hasChildren = node.children.length > 0;
+  const isExpanded = expandedNodes.has(node.id) && !appliedNodes.has(node.id);
+  const isSelected = selectedNodeId === node.id;
+  const isApplied = appliedNodes.has(node.id);
+  const geoResult = nodeSuggestions.get(node.id);
+  const effectiveSuggestion = getNodeSuggestion(node.id, null);
+
+  return (
+    <Box sx={isApplied ? { opacity: 0.45 } : undefined}>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          pl: depth * 2.5,
+          py: 0.25,
+          pr: 0.5,
+          borderRadius: 1,
+          bgcolor: isSelected ? 'action.selected' : 'transparent',
+          '&:hover': { bgcolor: isSelected ? 'action.selected' : 'action.hover' },
+          cursor: 'pointer',
+        }}
+        onClick={() => !isApplied && onSelect(node.id)}
+      >
+        {hasChildren && !isApplied ? (
+          <IconButton
+            size="small"
+            onClick={(e) => { e.stopPropagation(); onToggleExpand(node.id); }}
+            sx={{ p: 0.25 }}
+          >
+            {isExpanded ? <ExpandLess sx={{ fontSize: 18 }} /> : <ExpandMore sx={{ fontSize: 18 }} />}
+          </IconButton>
+        ) : (
+          <Box sx={{ width: 26 }} />
+        )}
+
+        <Typography variant="body2" color="text.secondary" sx={{ flex: 1, ml: 0.5, minWidth: 0 }} noWrap>
+          {node.name}
+        </Typography>
+
+        <Stack direction="row" spacing={0} sx={{ flexShrink: 0 }}>
+          {isApplied ? (
+            <Tooltip title="Undo apply">
+              <IconButton
+                size="small"
+                onClick={(e) => { e.stopPropagation(); onUnapply(node.id); }}
+              >
+                <Undo sx={{ fontSize: 16 }} />
+              </IconButton>
+            </Tooltip>
+          ) : (
+            <>
+              <Tooltip title="Geo-suggest (find nearest region)">
+                <span>
+                  <IconButton
+                    size="small"
+                    onClick={(e) => { e.stopPropagation(); onGeoSuggest(node.id, node.name); }}
+                    disabled={geoSuggestPending}
+                  >
+                    <Public sx={{ fontSize: 16 }} />
+                  </IconButton>
+                </span>
+              </Tooltip>
+              {effectiveSuggestion && (
+                <Tooltip title={`Apply: ${effectiveSuggestion.action === 'add_member' ? 'Add to' : 'Create under'} ${effectiveSuggestion.targetRegionName}`}>
+                  <IconButton
+                    size="small"
+                    color="success"
+                    onClick={(e) => { e.stopPropagation(); onApplySingle(node.id, node.name); }}
+                  >
+                    <CheckCircle sx={{ fontSize: 16 }} />
+                  </IconButton>
+                </Tooltip>
+              )}
+            </>
+          )}
+        </Stack>
+      </Box>
+
+      {/* Suggestion chip */}
+      {effectiveSuggestion && !isApplied && (
+        <Box sx={{ pl: depth * 2.5 + 3.5, py: 0.25 }}>
+          <Chip
+            label={buildSuggestionChipLabel(effectiveSuggestion, geoResult?.distanceKm)}
+            size="small"
+            variant="outlined"
+            color="info"
+            sx={{ height: 22, fontSize: '0.7rem' }}
+          />
+        </Box>
+      )}
+
+      {hasChildren && (
+        <Collapse in={isExpanded} unmountOnExit>
+          {node.children.map((child) => (
+            <SubtreeNodeRow
+              key={child.id}
+              node={child}
+              depth={depth + 1}
+              selectedNodeId={selectedNodeId}
+              expandedNodes={expandedNodes}
+              nodeSuggestions={nodeSuggestions}
+              appliedNodes={appliedNodes}
+              getNodeSuggestion={getNodeSuggestion}
+              onSelect={onSelect}
+              onToggleExpand={onToggleExpand}
+              onGeoSuggest={onGeoSuggest}
+              onApplySingle={onApplySingle}
+              onUnapply={onUnapply}
+              geoSuggestPending={geoSuggestPending}
+            />
+          ))}
+        </Collapse>
+      )}
+    </Box>
+  );
+}
+
+// =============================================================================
+// ContextTreeNode -- compact mini-tree for geo-suggest hierarchy selection
+// =============================================================================
+
+interface ContextTreeNodeProps {
+  node: RegionContextNode;
+  depth: number;
+  selectedId: number;
+  onSelect: (id: number, name: string) => void;
+}
+
+export function ContextTreeNode({ node, depth, selectedId, onSelect }: ContextTreeNodeProps) {
+  const isSelected = node.id === selectedId;
+  return (
+    <>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          pl: depth * 2,
+          py: 0.125,
+          cursor: 'pointer',
+          borderRadius: 1,
+          bgcolor: isSelected ? 'primary.main' : 'transparent',
+          color: isSelected ? 'primary.contrastText' : 'text.primary',
+          '&:hover': { bgcolor: isSelected ? 'primary.main' : 'action.hover' },
+        }}
+        onClick={() => onSelect(node.id, node.name)}
+      >
+        <Typography
+          variant="body2"
+          sx={{
+            fontSize: '0.8rem',
+            fontWeight: node.isSuggested ? 700 : 400,
+            pl: 0.5,
+          }}
+        >
+          {node.isSuggested ? '\u25CF ' : '\u25CB '}
+          {node.name}
+        </Typography>
+      </Box>
+      {node.children.map(child => (
+        <ContextTreeNode
+          key={child.id}
+          node={child}
+          depth={depth + 1}
+          selectedId={selectedId}
+          onSelect={onSelect}
+        />
+      ))}
+    </>
+  );
+}

--- a/frontend/src/components/admin/CoverageMapPreview.tsx
+++ b/frontend/src/components/admin/CoverageMapPreview.tsx
@@ -1,0 +1,310 @@
+/**
+ * Coverage Map Preview
+ *
+ * Right panel of the CoverageResolveDialog: inline map preview with gap/suggestion
+ * geometry overlay, legend, suggestion details, context tree, and manual region search.
+ */
+
+import { type Ref } from 'react';
+import {
+  Box,
+  Typography,
+  Chip,
+  Paper,
+  CircularProgress,
+  Stack,
+  Autocomplete,
+  TextField,
+} from '@mui/material';
+import Close from '@mui/icons-material/Close';
+import MapGL, { NavigationControl, Source, Layer, type MapRef } from 'react-map-gl/maplibre';
+import type { GeoSuggestResult } from '../../api/admin/worldViewImport';
+import type { RegionSearchResult } from '../../api/regions';
+import type { TreeNodeInfo } from './coverageResolveUtils';
+import { ContextTreeNode } from './CoverageGapTree';
+
+const MAP_STYLE = 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json';
+
+interface CoverageMapPreviewProps {
+  mapRef: Ref<MapRef>;
+  selectedNodeId: number | null;
+  selectedGapInfo: TreeNodeInfo | null;
+  selectedGeoResult: GeoSuggestResult | undefined;
+  selectedTargets: Map<number, { id: number; name: string }>;
+  gapGeom: GeoJSON.Geometry | null;
+  suggGeom: GeoJSON.Geometry | null;
+  mapLoading: boolean;
+  gapFC: GeoJSON.FeatureCollection;
+  suggFC: GeoJSON.FeatureCollection;
+  circleFC: GeoJSON.FeatureCollection;
+  markersFC: GeoJSON.FeatureCollection;
+  // Region search
+  searchOpen: boolean;
+  regionQuery: string;
+  regionResults: RegionSearchResult[] | undefined;
+  isSearchingRegions: boolean;
+  onSearchOpenChange: (open: boolean) => void;
+  onRegionQueryChange: (query: string) => void;
+  onSelectTarget: (nodeId: number, target: { id: number; name: string }) => void;
+  onClearTarget: (nodeId: number) => void;
+}
+
+export function CoverageMapPreview({
+  mapRef,
+  selectedNodeId,
+  selectedGapInfo,
+  selectedGeoResult,
+  selectedTargets,
+  gapGeom,
+  suggGeom,
+  mapLoading,
+  gapFC,
+  suggFC,
+  circleFC,
+  markersFC,
+  searchOpen,
+  regionQuery,
+  regionResults,
+  isSearchingRegions,
+  onSearchOpenChange,
+  onRegionQueryChange,
+  onSelectTarget,
+  onClearTarget,
+}: CoverageMapPreviewProps) {
+  return (
+    <Paper
+      variant="outlined"
+      sx={{
+        flex: 1,
+        display: 'flex',
+        flexDirection: 'column',
+        minWidth: 0,
+        overflow: 'hidden',
+      }}
+    >
+      {/* Map */}
+      <Box sx={{ flex: 1, position: 'relative', minHeight: 200 }}>
+        {mapLoading && (
+          <Box sx={{ position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%, -50%)', zIndex: 10 }}>
+            <CircularProgress size={32} />
+          </Box>
+        )}
+        {selectedNodeId == null ? (
+          <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}>
+            <Typography variant="body2" color="text.disabled">
+              Select a gap to preview on map
+            </Typography>
+          </Box>
+        ) : (
+          <MapGL
+            ref={mapRef}
+            initialViewState={{ longitude: 0, latitude: 20, zoom: 1 }}
+            style={{ width: '100%', height: '100%' }}
+            mapStyle={MAP_STYLE}
+          >
+            <NavigationControl position="top-right" showCompass={false} />
+
+            {/* Distance circle */}
+            <Source id="circle" type="geojson" data={circleFC}>
+              <Layer
+                id="circle-fill"
+                type="fill"
+                paint={{ 'fill-color': '#ffa726', 'fill-opacity': 0.08 }}
+              />
+              <Layer
+                id="circle-outline"
+                type="line"
+                paint={{ 'line-color': '#ffa726', 'line-width': 2, 'line-dasharray': [4, 3] }}
+              />
+            </Source>
+
+            {/* Gap division (red) */}
+            <Source id="gap-division" type="geojson" data={gapFC}>
+              <Layer
+                id="gap-fill"
+                type="fill"
+                paint={{ 'fill-color': '#ef5350', 'fill-opacity': 0.35 }}
+              />
+              <Layer
+                id="gap-outline"
+                type="line"
+                paint={{ 'line-color': '#c62828', 'line-width': 2 }}
+              />
+            </Source>
+
+            {/* Suggested division (blue) */}
+            <Source id="sugg-division" type="geojson" data={suggFC}>
+              <Layer
+                id="sugg-fill"
+                type="fill"
+                paint={{ 'fill-color': '#42a5f5', 'fill-opacity': 0.35 }}
+              />
+              <Layer
+                id="sugg-outline"
+                type="line"
+                paint={{ 'line-color': '#1565c0', 'line-width': 2 }}
+              />
+            </Source>
+
+            {/* Center markers */}
+            <Source id="markers" type="geojson" data={markersFC}>
+              <Layer
+                id="marker-gap"
+                type="circle"
+                filter={['==', ['get', 'type'], 'gap']}
+                paint={{ 'circle-radius': 6, 'circle-color': '#c62828', 'circle-stroke-width': 2, 'circle-stroke-color': '#fff' }}
+              />
+              <Layer
+                id="marker-sugg"
+                type="circle"
+                filter={['==', ['get', 'type'], 'sugg']}
+                paint={{ 'circle-radius': 6, 'circle-color': '#1565c0', 'circle-stroke-width': 2, 'circle-stroke-color': '#fff' }}
+              />
+            </Source>
+          </MapGL>
+        )}
+      </Box>
+
+      {/* Suggestion details below map */}
+      {selectedGapInfo && (
+        <Box sx={{ p: 1.5, borderTop: '1px solid', borderColor: 'divider' }}>
+          <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
+            {selectedGapInfo.name}
+            {selectedGapInfo.parentName && (
+              <Typography component="span" variant="caption" color="text.secondary" sx={{ ml: 0.5 }}>
+                ({selectedGapInfo.parentName})
+              </Typography>
+            )}
+          </Typography>
+
+          {/* Legend */}
+          {(gapGeom || suggGeom) && (
+            <Stack direction="row" spacing={1.5} sx={{ mb: 1 }}>
+              <Stack direction="row" spacing={0.5} alignItems="center">
+                <Box sx={{ width: 12, height: 12, bgcolor: '#ef5350', borderRadius: '2px', opacity: 0.7 }} />
+                <Typography variant="caption" color="text.secondary">Gap</Typography>
+              </Stack>
+              {suggGeom && (
+                <Stack direction="row" spacing={0.5} alignItems="center">
+                  <Box sx={{ width: 12, height: 12, bgcolor: '#42a5f5', borderRadius: '2px', opacity: 0.7 }} />
+                  <Typography variant="caption" color="text.secondary">Nearest assigned</Typography>
+                </Stack>
+              )}
+            </Stack>
+          )}
+
+          {selectedGeoResult?.suggestion && (
+            <>
+              <Typography variant="body2" sx={{ mb: 0.5 }}>
+                Nearest: <strong>{selectedGeoResult.suggestion.targetRegionName}</strong>
+                {selectedGeoResult.distanceKm != null && (
+                  <Typography component="span" variant="caption" color="text.secondary" sx={{ ml: 0.5 }}>
+                    ({selectedGeoResult.distanceKm.toLocaleString()} km to boundary)
+                  </Typography>
+                )}
+              </Typography>
+
+              {/* Hierarchy tree -- let user pick where to add */}
+              {selectedGeoResult.contextTree && (
+                <Box sx={{ mt: 0.5 }}>
+                  <Typography variant="caption" color="text.secondary" sx={{ mb: 0.5, display: 'block' }}>
+                    Add to:
+                  </Typography>
+                  <ContextTreeNode
+                    node={selectedGeoResult.contextTree}
+                    depth={0}
+                    selectedId={selectedTargets.get(selectedNodeId!)?.id ?? selectedGeoResult.suggestion!.targetRegionId}
+                    onSelect={(id, name) => onSelectTarget(selectedNodeId!, { id, name })}
+                  />
+                </Box>
+              )}
+            </>
+          )}
+          {!selectedGeoResult?.suggestion && selectedGapInfo.suggestion && (
+            <Chip
+              label={`${selectedGapInfo.suggestion.action === 'add_member' ? 'Add to' : 'Create under'} ${selectedGapInfo.suggestion.targetRegionName}`}
+              size="small"
+              color="info"
+              variant="outlined"
+            />
+          )}
+          {!selectedGeoResult?.suggestion && !selectedGapInfo.suggestion && (
+            <Typography variant="caption" color="text.disabled">
+              No suggestion -- use geo-suggest to find nearest region
+            </Typography>
+          )}
+
+          {/* Manual region search */}
+          <Box sx={{ mt: 1 }}>
+            {/* Show manual override chip if active */}
+            {selectedTargets.has(selectedNodeId!) && !selectedGeoResult?.suggestion && (
+              <Chip
+                label={`Manual: ${selectedTargets.get(selectedNodeId!)!.name}`}
+                size="small"
+                color="success"
+                variant="outlined"
+                onDelete={() => {
+                  onClearTarget(selectedNodeId!);
+                  onSearchOpenChange(false);
+                }}
+                deleteIcon={<Close sx={{ fontSize: 16 }} />}
+                sx={{ mb: 0.5 }}
+              />
+            )}
+
+            {searchOpen ? (
+              <Autocomplete<RegionSearchResult>
+                size="small"
+                options={regionResults ?? []}
+                getOptionLabel={(opt) => opt.name}
+                onChange={(_, value) => {
+                  if (value) {
+                    onSelectTarget(selectedNodeId!, { id: value.id, name: value.name });
+                    onSearchOpenChange(false);
+                    onRegionQueryChange('');
+                  }
+                }}
+                onInputChange={(_, value) => onRegionQueryChange(value)}
+                loading={isSearchingRegions}
+                openOnFocus
+                autoFocus
+                renderOption={(props, opt) => (
+                  <li {...props} key={opt.id}>
+                    <Box>
+                      <Typography variant="body2">{opt.name}</Typography>
+                      {opt.path && opt.path !== opt.name && (
+                        <Typography variant="caption" color="text.secondary">
+                          {opt.path}
+                        </Typography>
+                      )}
+                    </Box>
+                  </li>
+                )}
+                renderInput={(params) => (
+                  <TextField
+                    {...params}
+                    placeholder="Search regions..."
+                    variant="outlined"
+                    onBlur={() => {
+                      if (!regionQuery) onSearchOpenChange(false);
+                    }}
+                  />
+                )}
+                sx={{ mt: 0.5 }}
+              />
+            ) : (
+              <Typography
+                variant="caption"
+                color="primary"
+                sx={{ cursor: 'pointer', '&:hover': { textDecoration: 'underline' } }}
+                onClick={() => onSearchOpenChange(true)}
+              >
+                Choose region manually...
+              </Typography>
+            )}
+          </Box>
+        </Box>
+      )}
+    </Paper>
+  );
+}

--- a/frontend/src/components/admin/CoverageResolveDialog.tsx
+++ b/frontend/src/components/admin/CoverageResolveDialog.tsx
@@ -21,23 +21,14 @@ import {
   Chip,
   Collapse,
   Paper,
-  CircularProgress,
   LinearProgress,
-  Stack,
-  Autocomplete,
-  TextField,
 } from '@mui/material';
-import VisibilityOff from '@mui/icons-material/VisibilityOff';
 import Visibility from '@mui/icons-material/Visibility';
 import ExpandMore from '@mui/icons-material/ExpandMore';
 import ExpandLess from '@mui/icons-material/ExpandLess';
-import Public from '@mui/icons-material/Public';
-import CheckCircle from '@mui/icons-material/CheckCircle';
 import CheckCircleOutline from '@mui/icons-material/CheckCircleOutline';
 import Refresh from '@mui/icons-material/Refresh';
-import Undo from '@mui/icons-material/Undo';
-import Close from '@mui/icons-material/Close';
-import MapGL, { NavigationControl, Source, Layer, MapRef } from 'react-map-gl/maplibre';
+import type { MapRef } from 'react-map-gl/maplibre';
 import * as turf from '@turf/turf';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { fetchDivisionGeometry } from '../../api/divisions';
@@ -49,14 +40,18 @@ import {
 import type {
   CoverageResult,
   CoverageGap,
-  SubtreeNode,
   GeoSuggestResult,
-  RegionContextNode,
 } from '../../api/admin/worldViewImport';
-import { searchRegions, type RegionSearchResult } from '../../api/regions';
-import type { ShadowInsertion } from './WorldViewImportReview';
-
-const MAP_STYLE = 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json';
+import { searchRegions } from '../../api/regions';
+import type { ShadowInsertion } from './treeNodeShared';
+import { GapNodeRow } from './CoverageGapTree';
+import { CoverageMapPreview } from './CoverageMapPreview';
+import {
+  type TreeNodeInfo,
+  findSubtreeNode,
+  collectSubtreeIds,
+  allLeavesApplied,
+} from './coverageResolveUtils';
 
 interface CoverageResolveDialogProps {
   open: boolean;
@@ -68,16 +63,6 @@ interface CoverageResolveDialogProps {
   onCoverageChange: (data: CoverageResult) => void;
   onApplyToTree: (insertions: ShadowInsertion[]) => void;
   onRecheck: () => void;
-}
-
-/** Flattened node for the gap tree — either a gap root or a subtree descendant */
-interface TreeNodeInfo {
-  divisionId: number;
-  name: string;
-  isGapRoot: boolean;
-  parentName: string | null;
-  hasChildren: boolean;
-  suggestion: CoverageGap['suggestion'] | null;
 }
 
 export function CoverageResolveDialog({
@@ -145,7 +130,7 @@ export function CoverageResolveDialog({
     setRegionQuery('');
   }, [selectedNodeId]);
 
-  // Sync appliedNodes with shadowInsertions from parent — when shadows are
+  // Sync appliedNodes with shadowInsertions from parent -- when shadows are
   // accepted/rejected in the match tree, remove them from our applied set
   useEffect(() => {
     // Build set of all IDs that should remain applied (shadow gap + its subtree descendants)
@@ -160,7 +145,7 @@ export function CoverageResolveDialog({
       for (const id of prev) {
         if (keepIds.has(id)) next.add(id);
       }
-      if (next.size === prev.size) return prev; // no change — avoid re-render
+      if (next.size === prev.size) return prev; // no change -- avoid re-render
       return next;
     });
   }, [shadowInsertions, coverageData]);
@@ -282,7 +267,7 @@ export function CoverageResolveDialog({
     },
   });
 
-  // Dismiss mutation — optimistic update, no re-fetch
+  // Dismiss mutation -- optimistic update, no re-fetch
   const dismissGapMutation = useMutation({
     mutationFn: (divisionId: number) => dismissCoverageGap(worldViewId, divisionId),
     onSuccess: (_data, divisionId) => {
@@ -330,7 +315,7 @@ export function CoverageResolveDialog({
     type GroupedChild = CoverageGap;
     const groups = new Map<string, GroupedChild[]>();
     for (const gap of coverageData.gaps) {
-      const key = gap.parentName ?? '(root — uncovered countries)';
+      const key = gap.parentName ?? '(root -- uncovered countries)';
       const arr = groups.get(key);
       if (arr) arr.push(gap);
       else groups.set(key, [gap]);
@@ -394,7 +379,7 @@ export function CoverageResolveDialog({
     });
   }, [coverageData, getNodeSuggestion, onApplyToTree]);
 
-  // Undo a per-node apply (visual only — shadow stays in tree for separate rejection)
+  // Undo a per-node apply (visual only -- shadow stays in tree for separate rejection)
   const handleUnapplySingle = useCallback((divisionId: number) => {
     const gap = coverageData?.gaps.find(g => g.id === divisionId);
     setAppliedNodes(prev => {
@@ -663,252 +648,40 @@ export function CoverageResolveDialog({
         </Paper>
 
         {/* Right panel: Map preview + suggestion */}
-        <Paper
-          variant="outlined"
-          sx={{
-            flex: 1,
-            display: 'flex',
-            flexDirection: 'column',
-            minWidth: 0,
-            overflow: 'hidden',
+        <CoverageMapPreview
+          mapRef={mapRef}
+          selectedNodeId={selectedNodeId}
+          selectedGapInfo={selectedGapInfo}
+          selectedGeoResult={selectedGeoResult}
+          selectedTargets={selectedTargets}
+          gapGeom={gapGeom}
+          suggGeom={suggGeom}
+          mapLoading={mapLoading}
+          gapFC={gapFC}
+          suggFC={suggFC}
+          circleFC={circleFC}
+          markersFC={markersFC}
+          searchOpen={searchOpen}
+          regionQuery={regionQuery}
+          regionResults={regionResults}
+          isSearchingRegions={isSearchingRegions}
+          onSearchOpenChange={setSearchOpen}
+          onRegionQueryChange={setRegionQuery}
+          onSelectTarget={(nodeId, target) => {
+            setSelectedTargets(prev => {
+              const next = new Map(prev);
+              next.set(nodeId, target);
+              return next;
+            });
           }}
-        >
-          {/* Map */}
-          <Box sx={{ flex: 1, position: 'relative', minHeight: 200 }}>
-            {mapLoading && (
-              <Box sx={{ position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%, -50%)', zIndex: 10 }}>
-                <CircularProgress size={32} />
-              </Box>
-            )}
-            {selectedNodeId == null ? (
-              <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}>
-                <Typography variant="body2" color="text.disabled">
-                  Select a gap to preview on map
-                </Typography>
-              </Box>
-            ) : (
-              <MapGL
-                ref={mapRef}
-                initialViewState={{ longitude: 0, latitude: 20, zoom: 1 }}
-                style={{ width: '100%', height: '100%' }}
-                mapStyle={MAP_STYLE}
-              >
-                <NavigationControl position="top-right" showCompass={false} />
-
-                {/* Distance circle */}
-                <Source id="circle" type="geojson" data={circleFC}>
-                  <Layer
-                    id="circle-fill"
-                    type="fill"
-                    paint={{ 'fill-color': '#ffa726', 'fill-opacity': 0.08 }}
-                  />
-                  <Layer
-                    id="circle-outline"
-                    type="line"
-                    paint={{ 'line-color': '#ffa726', 'line-width': 2, 'line-dasharray': [4, 3] }}
-                  />
-                </Source>
-
-                {/* Gap division (red) */}
-                <Source id="gap-division" type="geojson" data={gapFC}>
-                  <Layer
-                    id="gap-fill"
-                    type="fill"
-                    paint={{ 'fill-color': '#ef5350', 'fill-opacity': 0.35 }}
-                  />
-                  <Layer
-                    id="gap-outline"
-                    type="line"
-                    paint={{ 'line-color': '#c62828', 'line-width': 2 }}
-                  />
-                </Source>
-
-                {/* Suggested division (blue) */}
-                <Source id="sugg-division" type="geojson" data={suggFC}>
-                  <Layer
-                    id="sugg-fill"
-                    type="fill"
-                    paint={{ 'fill-color': '#42a5f5', 'fill-opacity': 0.35 }}
-                  />
-                  <Layer
-                    id="sugg-outline"
-                    type="line"
-                    paint={{ 'line-color': '#1565c0', 'line-width': 2 }}
-                  />
-                </Source>
-
-                {/* Center markers */}
-                <Source id="markers" type="geojson" data={markersFC}>
-                  <Layer
-                    id="marker-gap"
-                    type="circle"
-                    filter={['==', ['get', 'type'], 'gap']}
-                    paint={{ 'circle-radius': 6, 'circle-color': '#c62828', 'circle-stroke-width': 2, 'circle-stroke-color': '#fff' }}
-                  />
-                  <Layer
-                    id="marker-sugg"
-                    type="circle"
-                    filter={['==', ['get', 'type'], 'sugg']}
-                    paint={{ 'circle-radius': 6, 'circle-color': '#1565c0', 'circle-stroke-width': 2, 'circle-stroke-color': '#fff' }}
-                  />
-                </Source>
-              </MapGL>
-            )}
-          </Box>
-
-          {/* Suggestion details below map */}
-          {selectedGapInfo && (
-            <Box sx={{ p: 1.5, borderTop: '1px solid', borderColor: 'divider' }}>
-              <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
-                {selectedGapInfo.name}
-                {selectedGapInfo.parentName && (
-                  <Typography component="span" variant="caption" color="text.secondary" sx={{ ml: 0.5 }}>
-                    ({selectedGapInfo.parentName})
-                  </Typography>
-                )}
-              </Typography>
-
-              {/* Legend */}
-              {(gapGeom || suggGeom) && (
-                <Stack direction="row" spacing={1.5} sx={{ mb: 1 }}>
-                  <Stack direction="row" spacing={0.5} alignItems="center">
-                    <Box sx={{ width: 12, height: 12, bgcolor: '#ef5350', borderRadius: '2px', opacity: 0.7 }} />
-                    <Typography variant="caption" color="text.secondary">Gap</Typography>
-                  </Stack>
-                  {suggGeom && (
-                    <Stack direction="row" spacing={0.5} alignItems="center">
-                      <Box sx={{ width: 12, height: 12, bgcolor: '#42a5f5', borderRadius: '2px', opacity: 0.7 }} />
-                      <Typography variant="caption" color="text.secondary">Nearest assigned</Typography>
-                    </Stack>
-                  )}
-                </Stack>
-              )}
-
-              {selectedGeoResult?.suggestion ? (
-                <>
-                  <Typography variant="body2" sx={{ mb: 0.5 }}>
-                    Nearest: <strong>{selectedGeoResult.suggestion.targetRegionName}</strong>
-                    {selectedGeoResult.distanceKm != null && (
-                      <Typography component="span" variant="caption" color="text.secondary" sx={{ ml: 0.5 }}>
-                        ({selectedGeoResult.distanceKm.toLocaleString()} km to boundary)
-                      </Typography>
-                    )}
-                  </Typography>
-
-                  {/* Hierarchy tree — let user pick where to add */}
-                  {selectedGeoResult.contextTree && (
-                    <Box sx={{ mt: 0.5 }}>
-                      <Typography variant="caption" color="text.secondary" sx={{ mb: 0.5, display: 'block' }}>
-                        Add to:
-                      </Typography>
-                      <ContextTreeNode
-                        node={selectedGeoResult.contextTree}
-                        depth={0}
-                        selectedId={selectedTargets.get(selectedNodeId!)?.id ?? selectedGeoResult.suggestion!.targetRegionId}
-                        onSelect={(id, name) => {
-                          setSelectedTargets(prev => {
-                            const next = new Map(prev);
-                            next.set(selectedNodeId!, { id, name });
-                            return next;
-                          });
-                        }}
-                      />
-                    </Box>
-                  )}
-                </>
-              ) : selectedGapInfo.suggestion ? (
-                <Chip
-                  label={`${selectedGapInfo.suggestion.action === 'add_member' ? 'Add to' : 'Create under'} ${selectedGapInfo.suggestion.targetRegionName}`}
-                  size="small"
-                  color="info"
-                  variant="outlined"
-                />
-              ) : (
-                <Typography variant="caption" color="text.disabled">
-                  No suggestion — use geo-suggest to find nearest region
-                </Typography>
-              )}
-
-              {/* Manual region search */}
-              <Box sx={{ mt: 1 }}>
-                {/* Show manual override chip if active */}
-                {selectedTargets.has(selectedNodeId!) && !selectedGeoResult?.suggestion && (
-                  <Chip
-                    label={`Manual: ${selectedTargets.get(selectedNodeId!)!.name}`}
-                    size="small"
-                    color="success"
-                    variant="outlined"
-                    onDelete={() => {
-                      setSelectedTargets(prev => {
-                        const next = new Map(prev);
-                        next.delete(selectedNodeId!);
-                        return next;
-                      });
-                      setSearchOpen(false);
-                    }}
-                    deleteIcon={<Close sx={{ fontSize: 16 }} />}
-                    sx={{ mb: 0.5 }}
-                  />
-                )}
-
-                {searchOpen ? (
-                  <Autocomplete<RegionSearchResult>
-                    size="small"
-                    options={regionResults ?? []}
-                    getOptionLabel={(opt) => opt.name}
-                    onChange={(_, value) => {
-                      if (value) {
-                        setSelectedTargets(prev => {
-                          const next = new Map(prev);
-                          next.set(selectedNodeId!, { id: value.id, name: value.name });
-                          return next;
-                        });
-                        setSearchOpen(false);
-                        setRegionQuery('');
-                      }
-                    }}
-                    onInputChange={(_, value) => setRegionQuery(value)}
-                    loading={isSearchingRegions}
-                    openOnFocus
-                    autoFocus
-                    renderOption={(props, opt) => (
-                      <li {...props} key={opt.id}>
-                        <Box>
-                          <Typography variant="body2">{opt.name}</Typography>
-                          {opt.path && opt.path !== opt.name && (
-                            <Typography variant="caption" color="text.secondary">
-                              {opt.path}
-                            </Typography>
-                          )}
-                        </Box>
-                      </li>
-                    )}
-                    renderInput={(params) => (
-                      <TextField
-                        {...params}
-                        placeholder="Search regions..."
-                        variant="outlined"
-                        onBlur={() => {
-                          if (!regionQuery) setSearchOpen(false);
-                        }}
-                      />
-                    )}
-                    sx={{ mt: 0.5 }}
-                  />
-                ) : (
-                  <Typography
-                    variant="caption"
-                    color="primary"
-                    sx={{ cursor: 'pointer', '&:hover': { textDecoration: 'underline' } }}
-                    onClick={() => setSearchOpen(true)}
-                  >
-                    Choose region manually...
-                  </Typography>
-                )}
-              </Box>
-            </Box>
-          )}
-        </Paper>
+          onClearTarget={(nodeId) => {
+            setSelectedTargets(prev => {
+              const next = new Map(prev);
+              next.delete(nodeId);
+              return next;
+            });
+          }}
+        />
       </DialogContent>
 
       <DialogActions>
@@ -926,416 +699,4 @@ export function CoverageResolveDialog({
       </DialogActions>
     </Dialog>
   );
-}
-
-// =============================================================================
-// GapNodeRow — renders a single gap and its subtree recursively
-// =============================================================================
-
-interface GapNodeRowProps {
-  gap: CoverageGap;
-  depth: number;
-  selectedNodeId: number | null;
-  expandedNodes: Set<number>;
-  nodeSuggestions: Map<number, GeoSuggestResult>;
-  appliedNodes: Set<number>;
-  getNodeSuggestion: (id: number, treeSugg: CoverageGap['suggestion'] | null) => CoverageGap['suggestion'] | null;
-  onSelect: (id: number) => void;
-  onToggleExpand: (id: number) => void;
-  onGeoSuggest: (id: number, name: string) => void;
-  onDismiss: (id: number) => void;
-  onApplySingle: (id: number, name: string) => void;
-  onUnapply: (id: number) => void;
-  geoSuggestPending: boolean;
-  dismissPending: boolean;
-}
-
-function GapNodeRow({
-  gap,
-  depth,
-  selectedNodeId,
-  expandedNodes,
-  nodeSuggestions,
-  appliedNodes,
-  getNodeSuggestion,
-  onSelect,
-  onToggleExpand,
-  onGeoSuggest,
-  onDismiss,
-  onApplySingle,
-  onUnapply,
-  geoSuggestPending,
-  dismissPending,
-}: GapNodeRowProps) {
-  const hasSubtree = gap.subtree && gap.subtree.length > 0;
-  const directlyApplied = appliedNodes.has(gap.id);
-  // Parent is effectively applied if all its subtree leaves are applied
-  const childrenResolved = hasSubtree && allLeavesApplied(gap.subtree!, appliedNodes);
-  const isApplied = directlyApplied || childrenResolved;
-  const isExpanded = expandedNodes.has(gap.id) && !isApplied;
-  const isSelected = selectedNodeId === gap.id;
-  const effectiveSuggestion = getNodeSuggestion(gap.id, gap.suggestion);
-  const geoResult = nodeSuggestions.get(gap.id);
-
-  return (
-    <Box sx={isApplied ? { opacity: 0.45 } : undefined}>
-      {/* Gap node row */}
-      <Box
-        sx={{
-          display: 'flex',
-          alignItems: 'center',
-          pl: depth * 2.5,
-          py: 0.25,
-          pr: 0.5,
-          borderRadius: 1,
-          bgcolor: isSelected ? 'action.selected' : 'transparent',
-          '&:hover': { bgcolor: isSelected ? 'action.selected' : 'action.hover' },
-          cursor: 'pointer',
-        }}
-        onClick={() => !isApplied && onSelect(gap.id)}
-      >
-        {/* Expand toggle */}
-        {hasSubtree && !isApplied ? (
-          <IconButton
-            size="small"
-            onClick={(e) => { e.stopPropagation(); onToggleExpand(gap.id); }}
-            sx={{ p: 0.25 }}
-          >
-            {isExpanded ? <ExpandLess sx={{ fontSize: 18 }} /> : <ExpandMore sx={{ fontSize: 18 }} />}
-          </IconButton>
-        ) : (
-          <Box sx={{ width: 26 }} />
-        )}
-
-        {/* Name */}
-        <Typography variant="body2" sx={{ flex: 1, ml: 0.5, minWidth: 0 }} noWrap>
-          {gap.name}
-        </Typography>
-
-        {/* Action buttons */}
-        <Stack direction="row" spacing={0} sx={{ flexShrink: 0 }}>
-          {isApplied ? (
-            <Tooltip title="Undo apply">
-              <IconButton
-                size="small"
-                onClick={(e) => { e.stopPropagation(); onUnapply(gap.id); }}
-              >
-                <Undo sx={{ fontSize: 18 }} />
-              </IconButton>
-            </Tooltip>
-          ) : (
-            <>
-              <Tooltip title="Geo-suggest (find nearest region)">
-                <span>
-                  <IconButton
-                    size="small"
-                    onClick={(e) => { e.stopPropagation(); onGeoSuggest(gap.id, gap.name); }}
-                    disabled={geoSuggestPending}
-                  >
-                    <Public sx={{ fontSize: 18 }} />
-                  </IconButton>
-                </span>
-              </Tooltip>
-              {effectiveSuggestion && (
-                <Tooltip title={`Apply: ${effectiveSuggestion.action === 'add_member' ? 'Add to' : 'Create under'} ${effectiveSuggestion.targetRegionName}`}>
-                  <IconButton
-                    size="small"
-                    color="success"
-                    onClick={(e) => { e.stopPropagation(); onApplySingle(gap.id, gap.name); }}
-                  >
-                    <CheckCircle sx={{ fontSize: 18 }} />
-                  </IconButton>
-                </Tooltip>
-              )}
-              <Tooltip title="Dismiss">
-                <span>
-                  <IconButton
-                    size="small"
-                    onClick={(e) => { e.stopPropagation(); onDismiss(gap.id); }}
-                    disabled={dismissPending}
-                  >
-                    <VisibilityOff sx={{ fontSize: 18 }} />
-                  </IconButton>
-                </span>
-              </Tooltip>
-            </>
-          )}
-        </Stack>
-      </Box>
-
-      {/* Suggestion chip */}
-      {effectiveSuggestion && !isApplied && (
-        <Box sx={{ pl: depth * 2.5 + 3.5, py: 0.25 }}>
-          <Chip
-            label={`${effectiveSuggestion.action === 'add_member' ? '+ Add to' : '+ Create under'} ${effectiveSuggestion.targetRegionName}${geoResult?.distanceKm ? ` (${geoResult.distanceKm.toLocaleString()} km)` : ''}`}
-            size="small"
-            variant="outlined"
-            color="info"
-            sx={{ height: 22, fontSize: '0.7rem' }}
-          />
-        </Box>
-      )}
-
-      {/* Subtree children */}
-      {hasSubtree && (
-        <Collapse in={isExpanded} unmountOnExit>
-          {gap.subtree!.map((child) => (
-            <SubtreeNodeRow
-              key={child.id}
-              node={child}
-              depth={depth + 1}
-              selectedNodeId={selectedNodeId}
-              expandedNodes={expandedNodes}
-              nodeSuggestions={nodeSuggestions}
-              appliedNodes={appliedNodes}
-              getNodeSuggestion={getNodeSuggestion}
-              onSelect={onSelect}
-              onToggleExpand={onToggleExpand}
-              onGeoSuggest={onGeoSuggest}
-              onApplySingle={onApplySingle}
-              onUnapply={onUnapply}
-              geoSuggestPending={geoSuggestPending}
-            />
-          ))}
-        </Collapse>
-      )}
-    </Box>
-  );
-}
-
-// =============================================================================
-// SubtreeNodeRow — renders a GADM subtree child node (with per-node actions)
-// =============================================================================
-
-interface SubtreeNodeRowProps {
-  node: SubtreeNode;
-  depth: number;
-  selectedNodeId: number | null;
-  expandedNodes: Set<number>;
-  nodeSuggestions: Map<number, GeoSuggestResult>;
-  appliedNodes: Set<number>;
-  getNodeSuggestion: (id: number, treeSugg: CoverageGap['suggestion'] | null) => CoverageGap['suggestion'] | null;
-  onSelect: (id: number) => void;
-  onToggleExpand: (id: number) => void;
-  onGeoSuggest: (id: number, name: string) => void;
-  onApplySingle: (id: number, name: string) => void;
-  onUnapply: (id: number) => void;
-  geoSuggestPending: boolean;
-}
-
-function SubtreeNodeRow({
-  node,
-  depth,
-  selectedNodeId,
-  expandedNodes,
-  nodeSuggestions,
-  appliedNodes,
-  getNodeSuggestion,
-  onSelect,
-  onToggleExpand,
-  onGeoSuggest,
-  onApplySingle,
-  onUnapply,
-  geoSuggestPending,
-}: SubtreeNodeRowProps) {
-  const hasChildren = node.children.length > 0;
-  const isExpanded = expandedNodes.has(node.id) && !appliedNodes.has(node.id);
-  const isSelected = selectedNodeId === node.id;
-  const isApplied = appliedNodes.has(node.id);
-  const geoResult = nodeSuggestions.get(node.id);
-  const effectiveSuggestion = getNodeSuggestion(node.id, null);
-
-  return (
-    <Box sx={isApplied ? { opacity: 0.45 } : undefined}>
-      <Box
-        sx={{
-          display: 'flex',
-          alignItems: 'center',
-          pl: depth * 2.5,
-          py: 0.25,
-          pr: 0.5,
-          borderRadius: 1,
-          bgcolor: isSelected ? 'action.selected' : 'transparent',
-          '&:hover': { bgcolor: isSelected ? 'action.selected' : 'action.hover' },
-          cursor: 'pointer',
-        }}
-        onClick={() => !isApplied && onSelect(node.id)}
-      >
-        {hasChildren && !isApplied ? (
-          <IconButton
-            size="small"
-            onClick={(e) => { e.stopPropagation(); onToggleExpand(node.id); }}
-            sx={{ p: 0.25 }}
-          >
-            {isExpanded ? <ExpandLess sx={{ fontSize: 18 }} /> : <ExpandMore sx={{ fontSize: 18 }} />}
-          </IconButton>
-        ) : (
-          <Box sx={{ width: 26 }} />
-        )}
-
-        <Typography variant="body2" color="text.secondary" sx={{ flex: 1, ml: 0.5, minWidth: 0 }} noWrap>
-          {node.name}
-        </Typography>
-
-        <Stack direction="row" spacing={0} sx={{ flexShrink: 0 }}>
-          {isApplied ? (
-            <Tooltip title="Undo apply">
-              <IconButton
-                size="small"
-                onClick={(e) => { e.stopPropagation(); onUnapply(node.id); }}
-              >
-                <Undo sx={{ fontSize: 16 }} />
-              </IconButton>
-            </Tooltip>
-          ) : (
-            <>
-              <Tooltip title="Geo-suggest (find nearest region)">
-                <span>
-                  <IconButton
-                    size="small"
-                    onClick={(e) => { e.stopPropagation(); onGeoSuggest(node.id, node.name); }}
-                    disabled={geoSuggestPending}
-                  >
-                    <Public sx={{ fontSize: 16 }} />
-                  </IconButton>
-                </span>
-              </Tooltip>
-              {effectiveSuggestion && (
-                <Tooltip title={`Apply: ${effectiveSuggestion.action === 'add_member' ? 'Add to' : 'Create under'} ${effectiveSuggestion.targetRegionName}`}>
-                  <IconButton
-                    size="small"
-                    color="success"
-                    onClick={(e) => { e.stopPropagation(); onApplySingle(node.id, node.name); }}
-                  >
-                    <CheckCircle sx={{ fontSize: 16 }} />
-                  </IconButton>
-                </Tooltip>
-              )}
-            </>
-          )}
-        </Stack>
-      </Box>
-
-      {/* Suggestion chip */}
-      {effectiveSuggestion && !isApplied && (
-        <Box sx={{ pl: depth * 2.5 + 3.5, py: 0.25 }}>
-          <Chip
-            label={`${effectiveSuggestion.action === 'add_member' ? '+ Add to' : '+ Create under'} ${effectiveSuggestion.targetRegionName}${geoResult?.distanceKm ? ` (${geoResult.distanceKm.toLocaleString()} km)` : ''}`}
-            size="small"
-            variant="outlined"
-            color="info"
-            sx={{ height: 22, fontSize: '0.7rem' }}
-          />
-        </Box>
-      )}
-
-      {hasChildren && (
-        <Collapse in={isExpanded} unmountOnExit>
-          {node.children.map((child) => (
-            <SubtreeNodeRow
-              key={child.id}
-              node={child}
-              depth={depth + 1}
-              selectedNodeId={selectedNodeId}
-              expandedNodes={expandedNodes}
-              nodeSuggestions={nodeSuggestions}
-              appliedNodes={appliedNodes}
-              getNodeSuggestion={getNodeSuggestion}
-              onSelect={onSelect}
-              onToggleExpand={onToggleExpand}
-              onGeoSuggest={onGeoSuggest}
-              onApplySingle={onApplySingle}
-              onUnapply={onUnapply}
-              geoSuggestPending={geoSuggestPending}
-            />
-          ))}
-        </Collapse>
-      )}
-    </Box>
-  );
-}
-
-// =============================================================================
-// ContextTreeNode — compact mini-tree for geo-suggest hierarchy selection
-// =============================================================================
-
-interface ContextTreeNodeProps {
-  node: RegionContextNode;
-  depth: number;
-  selectedId: number;
-  onSelect: (id: number, name: string) => void;
-}
-
-function ContextTreeNode({ node, depth, selectedId, onSelect }: ContextTreeNodeProps) {
-  const isSelected = node.id === selectedId;
-  return (
-    <>
-      <Box
-        sx={{
-          display: 'flex',
-          alignItems: 'center',
-          pl: depth * 2,
-          py: 0.125,
-          cursor: 'pointer',
-          borderRadius: 1,
-          bgcolor: isSelected ? 'primary.main' : 'transparent',
-          color: isSelected ? 'primary.contrastText' : 'text.primary',
-          '&:hover': { bgcolor: isSelected ? 'primary.main' : 'action.hover' },
-        }}
-        onClick={() => onSelect(node.id, node.name)}
-      >
-        <Typography
-          variant="body2"
-          sx={{
-            fontSize: '0.8rem',
-            fontWeight: node.isSuggested ? 700 : 400,
-            pl: 0.5,
-          }}
-        >
-          {node.isSuggested ? '\u25CF ' : '\u25CB '}
-          {node.name}
-        </Typography>
-      </Box>
-      {node.children.map(child => (
-        <ContextTreeNode
-          key={child.id}
-          node={child}
-          depth={depth + 1}
-          selectedId={selectedId}
-          onSelect={onSelect}
-        />
-      ))}
-    </>
-  );
-}
-
-// =============================================================================
-// Helper: find a node in a subtree by division ID
-// =============================================================================
-
-function findSubtreeNode(nodes: SubtreeNode[], id: number): SubtreeNode | null {
-  for (const node of nodes) {
-    if (node.id === id) return node;
-    const found = findSubtreeNode(node.children, id);
-    if (found) return found;
-  }
-  return null;
-}
-
-/** Collect all descendant IDs from a subtree (recursive) */
-function collectSubtreeIds(nodes: SubtreeNode[], out: Set<number>): void {
-  for (const node of nodes) {
-    out.add(node.id);
-    collectSubtreeIds(node.children, out);
-  }
-}
-
-/** Check if every branch in the subtree is covered (node itself applied, or all its leaves applied) */
-function allLeavesApplied(nodes: SubtreeNode[], applied: Set<number>): boolean {
-  for (const node of nodes) {
-    if (applied.has(node.id)) continue; // this node is applied — covers all descendants
-    if (node.children.length === 0) return false; // unapplied leaf
-    if (!allLeavesApplied(node.children, applied)) return false;
-  }
-  return nodes.length > 0;
 }

--- a/frontend/src/components/admin/CvClusterReviewSection.tsx
+++ b/frontend/src/components/admin/CvClusterReviewSection.tsx
@@ -1,0 +1,342 @@
+/**
+ * CvClusterReviewSection — Cluster review sub-section of CvMatchDialog.
+ *
+ * Shows detected color clusters with merge/exclude/keep controls, split buttons,
+ * re-cluster presets, and cluster highlight overlay. Renders when
+ * cvMatchDialog.clusterReview is present.
+ */
+
+import {
+  Box,
+  Typography,
+  Button,
+  IconButton,
+  Select,
+  MenuItem,
+} from '@mui/material';
+import {
+  CallSplit as SplitIcon,
+  Block as BlockIcon,
+} from '@mui/icons-material';
+import {
+  respondToClusterReview,
+  clusterHighlightUrl,
+} from '../../api/admin/worldViewImport';
+import { authFetchBlob } from '../../api/fetchUtils';
+import { AuthImage } from '../shared/AuthImage';
+import type { CvMatchDialogState } from './useCvMatchPipeline';
+
+export interface CvClusterReviewSectionProps {
+  cvMatchDialog: CvMatchDialogState;
+  setCVMatchDialog: React.Dispatch<React.SetStateAction<CvMatchDialogState | null>>;
+}
+
+/** Fetch the highlight overlay image for a cluster label and store it in dialog state. */
+function loadClusterHighlight(
+  reviewId: string,
+  label: number,
+  setCVMatchDialog: React.Dispatch<React.SetStateAction<CvMatchDialogState | null>>,
+): void {
+  const hlUrl = clusterHighlightUrl(reviewId, label);
+  authFetchBlob(hlUrl)
+    .then((blob) => {
+      const objUrl = URL.createObjectURL(blob);
+      setCVMatchDialog((prev) =>
+        applyHighlightOverlay(prev, label, objUrl),
+      );
+    })
+    .catch(() => {});
+}
+
+/** Pure state update: set the overlay URL only if the label still matches. */
+function applyHighlightOverlay(
+  prev: CvMatchDialogState | null,
+  label: number,
+  objUrl: string,
+): CvMatchDialogState | null {
+  if (!prev?.clusterReview || prev.clusterReview.highlightedLabel !== label) {
+    URL.revokeObjectURL(objUrl);
+    return prev;
+  }
+  return {
+    ...prev,
+    clusterReview: { ...prev.clusterReview, highlightOverlay: objUrl },
+  };
+}
+
+export function CvClusterReviewSection({ cvMatchDialog, setCVMatchDialog }: CvClusterReviewSectionProps) {
+  const cr = cvMatchDialog.clusterReview!;
+  const sorted = [...cr.clusters].sort((a, b) => b.pct - a.pct);
+  // Targets for "merge into" = any non-excluded cluster
+  // Merge targets: only clusters that are "kept" (not excluded or merged into something else)
+  const mergeTargets = sorted.filter(c => !cr.excludes.has(c.label) && !cr.merges.has(c.label));
+  // Helper: look up assigned region name for a cluster label
+  const regionNameForLabel = (label: number): string | null => {
+    const regionId = cr.regionAssignments.get(label);
+    if (regionId == null) return null;
+    return cvMatchDialog.childRegions.find(r => r.id === regionId)?.name ?? null;
+  };
+  const setAction = (label: number, value: string) => {
+    setCVMatchDialog(prev => {
+      if (!prev?.clusterReview) return prev;
+      const nextMerges = new Map(prev.clusterReview.merges);
+      const nextExcludes = new Set(prev.clusterReview.excludes);
+      nextMerges.delete(label);
+      nextExcludes.delete(label);
+      if (value === 'exclude') {
+        nextExcludes.add(label);
+      } else if (value !== '' && value !== 'keep') {
+        nextMerges.set(label, Number(value));
+      }
+      return { ...prev, clusterReview: { ...prev.clusterReview, merges: nextMerges, excludes: nextExcludes } };
+    });
+  };
+  const getAction = (label: number): string => {
+    if (cr.excludes.has(label)) return 'exclude';
+    const m = cr.merges.get(label);
+    return m !== undefined ? String(m) : 'keep';
+  };
+  return (
+    <Box sx={{ p: 1.5, mb: 2, border: '2px solid', borderColor: 'info.main', borderRadius: 1, bgcolor: 'info.50' }}>
+      <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 0.5, color: 'info.dark' }}>
+        Cluster Review
+      </Typography>
+      <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
+        Review detected color clusters. Exclude artifacts (gray/noise), merge small leftovers into real regions, or keep as-is.
+      </Typography>
+      {/* Side-by-side: region map + cluster preview — sticky, max 40vh so cluster list is always visible */}
+      <Box sx={{ display: 'flex', gap: 1, mb: 1.5, position: 'sticky', top: 0, zIndex: 10, bgcolor: 'info.50', pb: 1 }}>
+        {cvMatchDialog.regionMapUrl && (
+          <Box sx={{ flex: '1 1 45%', textAlign: 'center', display: 'flex', flexDirection: 'column' }}>
+            <Typography variant="caption" color="text.secondary">Region map</Typography>
+            <img src={cvMatchDialog.regionMapUrl} style={{ maxWidth: '100%', maxHeight: '35vh', objectFit: 'contain', borderRadius: 4 }} />
+          </Box>
+        )}
+        {cr.previewImage && (
+          <Box sx={{ flex: '1 1 45%', textAlign: 'center', display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+            <Typography variant="caption" color="text.secondary">Detected clusters {cr.highlightedLabel != null ? '(click color circle to highlight)' : '(click a color circle to highlight)'}</Typography>
+            <Box sx={{ position: 'relative', display: 'inline-flex', maxHeight: '35vh' }}>
+              <AuthImage src={cr.previewImage} style={{ maxWidth: '100%', maxHeight: '35vh', objectFit: 'contain', borderRadius: 4, display: 'block' }} />
+              {cr.highlightOverlay && (
+                <img src={cr.highlightOverlay} style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', objectFit: 'contain', borderRadius: 4, pointerEvents: 'none' }} />
+              )}
+            </Box>
+          </Box>
+        )}
+      </Box>
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75 }}>
+        {sorted.map(c => {
+          const action = getAction(c.label);
+          const isExcluded = action === 'exclude';
+          const isMerged = action !== 'keep' && action !== 'exclude';
+          const isKept = action === 'keep';
+          // Already-assigned region IDs (by other clusters)
+          const usedRegionIds = new Set<number>();
+          for (const [lbl, rid] of cr.regionAssignments) {
+            if (lbl !== c.label) usedRegionIds.add(rid);
+          }
+          return (
+            <Box key={c.label} sx={{ display: 'flex', alignItems: 'center', gap: 1, opacity: isExcluded || isMerged ? 0.5 : 1 }}>
+              <Box
+                sx={{
+                  width: 20, height: 20, bgcolor: c.color, borderRadius: '50%', flexShrink: 0, cursor: 'pointer',
+                  border: cr.highlightedLabel === c.label ? '3px solid red' : '1px solid #999',
+                }}
+                onClick={() => {
+                  const isDeselect = cr.highlightedLabel === c.label;
+                  setCVMatchDialog(prev => {
+                    if (!prev?.clusterReview) return prev;
+                    // Revoke the previous overlay's object URL so the blob can be GC'd
+                    // — otherwise rapid cluster switching leaks one blob per click.
+                    if (prev.clusterReview.highlightOverlay) URL.revokeObjectURL(prev.clusterReview.highlightOverlay);
+                    if (isDeselect) return { ...prev, clusterReview: { ...prev.clusterReview, highlightedLabel: undefined, highlightOverlay: undefined } };
+                    return { ...prev, clusterReview: { ...prev.clusterReview, highlightedLabel: c.label, highlightOverlay: undefined } };
+                  });
+                  if (!isDeselect) {
+                    loadClusterHighlight(cr.reviewId, c.label, setCVMatchDialog);
+                  }
+                }}
+                title="Click to highlight this cluster on the map"
+              />
+              <Typography variant="body2" sx={{ minWidth: 55, fontWeight: c.isSmall ? 400 : 600 }}>
+                {c.pct.toFixed(1)}%
+              </Typography>
+              <Select
+                size="small"
+                value={action}
+                onChange={(e) => setAction(c.label, e.target.value)}
+                sx={{ minWidth: 160, fontSize: '0.8rem', height: 30 }}
+              >
+                <MenuItem value="keep">Keep as region</MenuItem>
+                <MenuItem value="exclude" sx={{ color: 'error.main' }}>Exclude (not a region)</MenuItem>
+                {mergeTargets.filter(t => t.label !== c.label).map(t => {
+                  const rName = regionNameForLabel(t.label);
+                  return (
+                    <MenuItem key={t.label} value={String(t.label)}>
+                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+                        <Box sx={{ width: 12, height: 12, bgcolor: t.color, borderRadius: '50%', border: '1px solid #ccc' }} />
+                        <span>Merge into {rName ?? `${t.pct.toFixed(1)}%`}</span>
+                      </Box>
+                    </MenuItem>
+                  );
+                })}
+              </Select>
+              {!isExcluded && (
+                <IconButton
+                  size="small"
+                  title="Exclude (not a region)"
+                  color="error"
+                  onClick={() => setAction(c.label, 'exclude')}
+                  sx={{ p: 0.25 }}
+                >
+                  <BlockIcon fontSize="small" />
+                </IconButton>
+              )}
+              {isKept && cvMatchDialog.childRegions.length > 0 && (
+                <Select
+                  size="small"
+                  displayEmpty
+                  value={cr.regionAssignments.get(c.label) ?? ''}
+                  onChange={(e) => {
+                    const val = e.target.value;
+                    setCVMatchDialog(prev => {
+                      if (!prev?.clusterReview) return prev;
+                      const next = new Map(prev.clusterReview.regionAssignments);
+                      if (val === '') next.delete(c.label);
+                      else next.set(c.label, Number(val));
+                      return { ...prev, clusterReview: { ...prev.clusterReview, regionAssignments: next } };
+                    });
+                  }}
+                  sx={{ minWidth: 140, flex: 1, fontSize: '0.8rem', height: 30 }}
+                >
+                  <MenuItem value=""><em>Region...</em></MenuItem>
+                  {cvMatchDialog.childRegions.map(r => (
+                    <MenuItem key={r.id} value={r.id} disabled={usedRegionIds.has(r.id)}>
+                      {r.name}
+                    </MenuItem>
+                  ))}
+                </Select>
+              )}
+              {isKept && c.componentCount > 1 && (
+                <IconButton
+                  size="small"
+                  title={`Split into ${c.componentCount} disconnected parts`}
+                  color="warning"
+                  onClick={async () => {
+                    setCVMatchDialog(prev => prev ? {
+                      ...prev,
+                      clusterReview: undefined,
+                      savedRegionAssignments: cr.regionAssignments.size > 0 ? new Map(cr.regionAssignments) : undefined,
+                      savedMerges: cr.merges.size > 0 ? new Map(cr.merges) : undefined,
+                      savedExcludes: cr.excludes.size > 0 ? new Set(cr.excludes) : undefined,
+                      progressText: `Splitting cluster into ${c.componentCount} parts...`,
+                    } : prev);
+                    try {
+                      await respondToClusterReview(cr.reviewId, {
+                        merges: {},
+                        split: [c.label],
+                      });
+                    } catch (e) {
+                      console.error('[Split] POST failed:', e);
+                    }
+                  }}
+                >
+                  <SplitIcon fontSize="small" />
+                </IconButton>
+              )}
+            </Box>
+          );
+        })}
+      </Box>
+      <Button
+        size="small" variant="contained" color="info"
+        sx={{ mt: 1.5 }}
+        onClick={async () => {
+          const merges: Record<number, number> = {};
+          // eslint-disable-next-line security/detect-object-injection -- from/to are integer cluster IDs from the internal Map<number,number>
+          for (const [from, to] of cr.merges) merges[from] = to;
+          const excludes = [...cr.excludes];
+          setCVMatchDialog(prev => prev ? {
+            ...prev,
+            clusterReview: undefined,
+            savedRegionAssignments: cr.regionAssignments.size > 0 ? new Map(cr.regionAssignments) : undefined,
+            progressText: 'Applying cluster decisions...',
+          } : prev);
+          try {
+            await respondToClusterReview(cr.reviewId, { merges, excludes });
+          } catch (e) {
+            console.error('[Cluster Review] POST failed:', e);
+          }
+        }}
+      >
+        Confirm clusters
+      </Button>
+      {/* Split all disconnected + Re-cluster options */}
+      <Box sx={{ display: 'flex', gap: 0.5, mt: 0.5, flexWrap: 'wrap' }}>
+        {sorted.some(c => c.componentCount > 1 && getAction(c.label) === 'keep' && !cr.regionAssignments.has(c.label)) && (
+          <Button
+            size="small"
+            variant="outlined"
+            color="warning"
+            startIcon={<SplitIcon />}
+            sx={{ fontSize: '0.7rem', py: 0.25, px: 0.75 }}
+            title="Split unhandled clusters that have disconnected parts"
+            onClick={async () => {
+              const splitLabels = sorted.filter(c => c.componentCount > 1 && getAction(c.label) === 'keep' && !cr.regionAssignments.has(c.label)).map(c => c.label);
+              setCVMatchDialog(prev => prev ? {
+                ...prev,
+                clusterReview: undefined,
+                savedRegionAssignments: cr.regionAssignments.size > 0 ? new Map(cr.regionAssignments) : undefined,
+                savedMerges: cr.merges.size > 0 ? new Map(cr.merges) : undefined,
+                savedExcludes: cr.excludes.size > 0 ? new Set(cr.excludes) : undefined,
+                progressText: `Splitting ${splitLabels.length} cluster(s) into components...`,
+              } : prev);
+              try {
+                await respondToClusterReview(cr.reviewId, { merges: {}, split: splitLabels });
+              } catch (e) {
+                console.error('[Split All] POST failed:', e);
+              }
+            }}
+          >
+            Split disconnected
+          </Button>
+        )}
+        {([
+          { preset: 'more_clusters' as const, label: 'More clusters' },
+          { preset: 'different_seed' as const, label: 'Different seed' },
+          { preset: 'boost_chroma' as const, label: 'Boost colors' },
+          { preset: 'remove_roads' as const, label: 'Remove roads' },
+          { preset: 'fill_holes' as const, label: 'Fill holes' },
+          { preset: 'clean_light' as const, label: 'Clean noise' },
+          { preset: 'clean_heavy' as const, label: 'Clean noise+' },
+        ]).map(opt => (
+          <Button
+            key={opt.preset}
+            size="small"
+            variant="outlined"
+            color="warning"
+            sx={{ fontSize: '0.7rem', py: 0.25, px: 0.75 }}
+            title={opt.label}
+            onClick={async () => {
+              setCVMatchDialog(prev => prev ? {
+                ...prev,
+                clusterReview: undefined,
+                progressText: `Re-clustering (${opt.label.toLowerCase()})...`,
+              } : prev);
+              try {
+                await respondToClusterReview(cr.reviewId, {
+                  merges: {},
+                  recluster: { preset: opt.preset },
+                });
+              } catch (e) {
+                console.error('[Recluster] POST failed:', e);
+              }
+            }}
+          >
+            {opt.label}
+          </Button>
+        ))}
+      </Box>
+    </Box>
+  );
+}

--- a/frontend/src/components/admin/CvGeoPreviewSection.tsx
+++ b/frontend/src/components/admin/CvGeoPreviewSection.tsx
@@ -1,0 +1,909 @@
+/**
+ * CvGeoPreviewSection — Geo preview + cluster suggestions sub-section of CvMatchDialog.
+ *
+ * Shows side-by-side source map / MapLibre division map with cluster-to-region
+ * suggestions, AI matching, model picker, and accept/reject actions.
+ * Renders when cvMatchDialog.done is true.
+ */
+
+import { useCallback, useMemo } from 'react';
+import {
+  Alert,
+  Box,
+  Typography,
+  Button,
+  IconButton,
+  Chip,
+  Select,
+  MenuItem,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+} from '@mui/material';
+import {
+  Visibility,
+  Settings as SettingsIcon,
+} from '@mui/icons-material';
+import MapGL, { NavigationControl, Source, Layer } from 'react-map-gl/maplibre';
+import * as turf from '@turf/turf';
+import {
+  acceptBatchMatches,
+  aiSuggestClusterRegions,
+  type ColorMatchCluster,
+  type ClusterGeoInfo,
+} from '../../api/admin/worldViewImport';
+import { CvMatchMap, CV_MAP_STYLE } from './CvMatchMap';
+import type { CvMatchDialogState } from './useCvMatchPipeline';
+import { detectSpatialAnomaliesClient } from '../../utils/spatialAnomalyDetector';
+import type { AdjacencyEdge as ClientAdjEdge, DivisionAssignment as ClientDivAssignment } from '../../utils/spatialAnomalyDetector';
+
+// ─── Geo Preview (map + source image) ───────────────────────────────────────
+
+export interface CvGeoPreviewSectionProps {
+  cvMatchDialog: CvMatchDialogState;
+  setCVMatchDialog: React.Dispatch<React.SetStateAction<CvMatchDialogState | null>>;
+  highlightClusterId: number | null;
+  worldViewId: number;
+  invalidateTree: (regionId?: number) => void;
+}
+
+// Collect every [lng,lat] coordinate pair from a GeoJSON FeatureCollection
+// (Polygon + MultiPolygon only). Used for fitBounds calculations.
+function collectCoordinates(fc: GeoJSON.FeatureCollection): [number, number][] {
+  const coords: [number, number][] = [];
+  const addRing = (ring: GeoJSON.Position[]) => {
+    for (const pt of ring) coords.push(pt as [number, number]);
+  };
+  for (const f of fc.features) {
+    if (f.geometry.type === 'Polygon') {
+      for (const ring of (f.geometry as GeoJSON.Polygon).coordinates) addRing(ring);
+    } else if (f.geometry.type === 'MultiPolygon') {
+      for (const poly of (f.geometry as GeoJSON.MultiPolygon).coordinates) {
+        for (const ring of poly) addRing(ring);
+      }
+    }
+  }
+  return coords;
+}
+
+// Given the Wikivoyage mapshape preview, fit the map bounds around all features.
+function fitMapToPreview(map: maplibregl.Map, wvPreview: GeoJSON.FeatureCollection) {
+  try {
+    const coords = collectCoordinates(wvPreview);
+    if (coords.length === 0) return;
+    const lngs = coords.map(c => c[0]);
+    const lats = coords.map(c => c[1]);
+    map.fitBounds(
+      [[Math.min(...lngs), Math.min(...lats)], [Math.max(...lngs), Math.max(...lats)]],
+      { padding: 30, duration: 0 },
+    );
+  } catch { /* ignore */ }
+}
+
+// Build a FeatureCollection of centroid points with title properties for
+// labeling the Wikivoyage mapshape regions.
+function buildWvLabelData(wvPreview: GeoJSON.FeatureCollection): GeoJSON.FeatureCollection {
+  const labelFeatures: GeoJSON.Feature[] = [];
+  for (const f of wvPreview.features) {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const centroid = turf.centroid(f as any);
+      labelFeatures.push({
+        type: 'Feature',
+        geometry: centroid.geometry,
+        properties: { title: f.properties?.title ?? '' },
+      });
+    } catch { /* skip */ }
+  }
+  return { type: 'FeatureCollection', features: labelFeatures };
+}
+
+// Strip a division (by id) from a single cluster's divisions + unsplittable lists.
+function stripDivisionFromCluster(divisionId: number) {
+  return (c: ColorMatchCluster): ColorMatchCluster => ({
+    ...c,
+    divisions: c.divisions.filter(d => d.id !== divisionId),
+    unsplittable: c.unsplittable.filter(d => d.id !== divisionId),
+  });
+}
+
+// Remove a division (by id) from every cluster's divisions + unsplittable lists
+// and drop clusters that end up empty.
+function removeDivisionFromClusters(
+  clusters: readonly ColorMatchCluster[],
+  divisionId: number,
+): ColorMatchCluster[] {
+  const hasMembers = (c: ColorMatchCluster) => c.divisions.length > 0 || c.unsplittable.length > 0;
+  return clusters.map(stripDivisionFromCluster(divisionId)).filter(hasMembers);
+}
+
+// Update a single feature (matched by divisionId) via the provided property patcher.
+function updateFeatureForDivision(
+  features: GeoJSON.Feature[],
+  divisionId: number,
+  patchProps: (props: NonNullable<GeoJSON.Feature['properties']>) => GeoJSON.Feature['properties'],
+): GeoJSON.Feature[] {
+  return features.map(f => {
+    if (f.properties?.divisionId !== divisionId) return f;
+    const nextProps = patchProps(f.properties);
+    return { ...f, properties: nextProps };
+  });
+}
+
+// Lookup a division's info from clusters, falling back to the feature properties.
+function lookupDivisionInfo(
+  clusters: readonly ColorMatchCluster[],
+  features: GeoJSON.Feature[],
+  divisionId: number,
+): { id: number; name: string; confidence: number; depth: number; parentDivisionId?: number } | null {
+  for (const c of clusters) {
+    const found = c.divisions.find(d => d.id === divisionId) ?? c.unsplittable.find(d => d.id === divisionId);
+    if (found) {
+      return {
+        id: found.id,
+        name: found.name,
+        confidence: found.confidence,
+        depth: 'depth' in found ? (found as { depth: number }).depth : 0,
+      };
+    }
+  }
+  const feat = features.find(f => f.properties?.divisionId === divisionId);
+  if (feat?.properties) {
+    return {
+      id: divisionId,
+      name: feat.properties.name ?? `#${divisionId}`,
+      confidence: feat.properties.confidence ?? 0.5,
+      depth: 0,
+    };
+  }
+  return null;
+}
+
+// Recompute client-side spatial anomalies after a cluster reassignment.
+function recomputeAnomalies(
+  features: GeoJSON.Feature[],
+  adjacencyEdges: ClientAdjEdge[],
+) {
+  const assignments: ClientDivAssignment[] = [];
+  for (const f of features) {
+    const p = f.properties;
+    if (p?.divisionId && p?.regionId) {
+      assignments.push({
+        divisionId: p.divisionId,
+        regionId: p.regionId,
+        regionName: p.regionName ?? 'Unknown',
+      });
+    }
+  }
+  const clientAnomalies = detectSpatialAnomaliesClient(assignments, adjacencyEdges);
+  return clientAnomalies.map(a => ({
+    divisions: a.fragmentDivisionIds.map(id => ({
+      divisionId: id,
+      name: `Division ${id}`,
+      memberRowId: null,
+      sourceRegionId: a.sourceRegionId,
+      sourceRegionName: a.sourceRegionName,
+    })),
+    suggestedTargetRegionId: a.suggestedTargetRegionId,
+    suggestedTargetRegionName: a.suggestedTargetRegionName,
+    fragmentSize: a.fragmentSize,
+    totalRegionSize: a.totalRegionSize,
+    score: a.score,
+  }));
+}
+
+export function CvGeoPreviewSection({ cvMatchDialog, setCVMatchDialog, highlightClusterId, worldViewId, invalidateTree }: CvGeoPreviewSectionProps) {
+  const sourceImg = cvMatchDialog.debugImages.find(img => img.label === '__source_map__');
+  const wvPreview = cvMatchDialog.wikivoyagePreview;
+  const geo = cvMatchDialog.geoPreview;
+
+  const anomalousDivisionIds = useMemo(() => {
+    const ids = new Set<number>();
+    for (const a of cvMatchDialog.spatialAnomalies ?? []) {
+      for (const d of a.divisions) ids.add(d.divisionId);
+    }
+    return ids;
+  }, [cvMatchDialog.spatialAnomalies]);
+
+  const handleMapAccept = useCallback(async (divisionId: number, regionId: number, regionName: string) => {
+    try {
+      await acceptBatchMatches(worldViewId, [{ regionId, divisionId }]);
+      const targetCluster = cvMatchDialog.clusters.find(c => c.suggestedRegion?.id === regionId);
+      const targetColor = targetCluster?.color ?? '#999';
+      const patchAcceptedProps = (featureProps: NonNullable<GeoJSON.Feature['properties']>) => ({
+        ...featureProps,
+        regionId,
+        regionName,
+        color: targetColor,
+        isUnsplittable: false,
+        clusterId: targetCluster?.clusterId ?? featureProps.clusterId,
+        confidence: 1,
+        accepted: true,
+      });
+      setCVMatchDialog(prev => {
+        if (!prev) return prev;
+        const newClusters = removeDivisionFromClusters(prev.clusters, divisionId);
+        const newGeo = prev.geoPreview
+          ? {
+            ...prev.geoPreview,
+            featureCollection: {
+              ...prev.geoPreview.featureCollection,
+              features: updateFeatureForDivision(prev.geoPreview.featureCollection.features, divisionId, patchAcceptedProps),
+            },
+          }
+          : prev.geoPreview;
+        return { ...prev, clusters: newClusters, geoPreview: newGeo };
+      });
+      invalidateTree(cvMatchDialog.regionId);
+    } catch (err) {
+      console.error('Accept from map failed:', err);
+    }
+  }, [worldViewId, cvMatchDialog, setCVMatchDialog, invalidateTree]);
+
+  const handleMapReject = useCallback((divisionId: number) => {
+    const patchDismissedProps = (props: NonNullable<GeoJSON.Feature['properties']>) => ({
+      ...props,
+      dismissed: true,
+      color: '#999',
+    });
+    setCVMatchDialog(prev => {
+      if (!prev) return prev;
+      const newClusters = removeDivisionFromClusters(prev.clusters, divisionId);
+      const newGeo = prev.geoPreview
+        ? {
+          ...prev.geoPreview,
+          featureCollection: {
+            ...prev.geoPreview.featureCollection,
+            features: updateFeatureForDivision(prev.geoPreview.featureCollection.features, divisionId, patchDismissedProps),
+          },
+        }
+        : prev.geoPreview;
+      return { ...prev, clusters: newClusters, geoPreview: newGeo };
+    });
+  }, [setCVMatchDialog]);
+
+  const handleMapClusterReassign = useCallback((divisionId: number, clusterId: number, color: string) => {
+    setCVMatchDialog(prev => {
+      if (!prev?.geoPreview) return prev;
+      const ci = prev.geoPreview.clusterInfos.find(c => c.clusterId === clusterId);
+      const divInfo = lookupDivisionInfo(prev.clusters, prev.geoPreview.featureCollection.features, divisionId);
+
+      // Strip division from all clusters first (keep empty clusters — we may push a new one below)
+      let newClusters: ColorMatchCluster[] = prev.clusters.map(stripDivisionFromCluster(divisionId));
+      if (divInfo) {
+        const targetIdx = newClusters.findIndex(c => c.clusterId === clusterId);
+        if (targetIdx >= 0) {
+          const appendToTarget = (c: ColorMatchCluster, i: number): ColorMatchCluster =>
+            i === targetIdx ? { ...c, divisions: [...c.divisions, divInfo] } : c;
+          newClusters = newClusters.map(appendToTarget);
+        } else {
+          newClusters.push({
+            clusterId,
+            color,
+            pixelShare: 0,
+            suggestedRegion: ci?.regionId != null && ci.regionName ? { id: ci.regionId, name: ci.regionName } : null,
+            divisions: [divInfo],
+            unsplittable: [],
+          });
+        }
+      }
+      newClusters = newClusters.filter(c => c.divisions.length > 0 || c.unsplittable.length > 0);
+
+      const patchReassignedProps = (props: NonNullable<GeoJSON.Feature['properties']>) => ({
+        ...props,
+        clusterId,
+        color,
+        painted: true,
+      });
+      const updatedFeatures = updateFeatureForDivision(
+        prev.geoPreview.featureCollection.features,
+        divisionId,
+        patchReassignedProps,
+      );
+
+      const updatedGeoPreview = {
+        ...prev.geoPreview,
+        featureCollection: { ...prev.geoPreview.featureCollection, features: updatedFeatures },
+      };
+
+      const updatedAnomalies = prev.adjacencyEdges
+        ? recomputeAnomalies(updatedFeatures, prev.adjacencyEdges as ClientAdjEdge[])
+        : prev.spatialAnomalies;
+
+      return {
+        ...prev,
+        clusters: newClusters,
+        geoPreview: updatedGeoPreview,
+        spatialAnomalies: updatedAnomalies,
+      };
+    });
+  }, [setCVMatchDialog]);
+
+  if (!geo || geo.featureCollection.features.length === 0) return null;
+
+  return (
+    <Box sx={{ mb: 3 }}>
+      <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: 1 }}>Region Assignment Preview</Typography>
+      {cvMatchDialog.spatialAnomalies && cvMatchDialog.spatialAnomalies.length > 0 && (
+        <Alert severity="warning" sx={{ mb: 1, py: 0, fontSize: '0.8rem' }}>
+          {cvMatchDialog.spatialAnomalies.length} potential exclave{cvMatchDialog.spatialAnomalies.length > 1 ? 's' : ''} detected
+          — divisions that would be disconnected from their region. Review assignments before accepting.
+        </Alert>
+      )}
+      <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', position: 'sticky', top: 0, zIndex: 10, bgcolor: 'background.paper', pb: 1, maxHeight: '42vh', overflow: 'hidden' }}>
+        {/* Wikivoyage mapshape preview (Kartographer geoshapes) */}
+        {wvPreview && wvPreview.features.length > 0 && (
+          <Box sx={{ flex: '1 1 48%', minWidth: 250, height: 400 }}>
+            <Typography variant="caption" color="text.secondary">Wikivoyage map (Kartographer regions)</Typography>
+            <MapGL
+              initialViewState={{ longitude: 0, latitude: 0, zoom: 1 }}
+              style={{ width: '100%', height: '100%', borderRadius: 4 }}
+              mapStyle={CV_MAP_STYLE}
+              onLoad={(e) => fitMapToPreview(e.target, wvPreview)}
+            >
+              <NavigationControl position="top-right" showCompass={false} />
+              <Source id="wv-mapshapes" type="geojson" data={wvPreview}>
+                <Layer
+                  id="wv-mapshapes-fill"
+                  type="fill"
+                  paint={{
+                    'fill-color': ['get', 'color'] as unknown as string,
+                    'fill-opacity': 0.45,
+                  }}
+                />
+                <Layer
+                  id="wv-mapshapes-outline"
+                  type="line"
+                  paint={{
+                    'line-color': '#333',
+                    'line-width': 1.5,
+                  }}
+                />
+              </Source>
+              {/* Region name labels */}
+              <Source id="wv-labels-src" type="geojson" data={buildWvLabelData(wvPreview)}>
+                <Layer
+                  id="wv-labels"
+                  type="symbol"
+                  layout={{
+                    'text-field': ['get', 'title'],
+                    'text-size': 12,
+                    'text-font': ['Open Sans Semibold'],
+                    'text-allow-overlap': true,
+                  }}
+                  paint={{
+                    'text-color': '#222',
+                    'text-halo-color': '#fff',
+                    'text-halo-width': 1.5,
+                  }}
+                />
+              </Source>
+            </MapGL>
+          </Box>
+        )}
+        {/* CV source map image — always shown when available so curator can
+            compare the original map against the assigned regions side by side. */}
+        {sourceImg && (
+          <Box sx={{ flex: '1 1 48%', minWidth: 250, maxHeight: '40vh', display: 'flex', flexDirection: 'column' }}>
+            <Typography variant="caption" color="text.secondary">Source map</Typography>
+            <img src={sourceImg.dataUrl} style={{ maxWidth: '100%', maxHeight: 'calc(40vh - 20px)', objectFit: 'contain', borderRadius: 4 }} />
+          </Box>
+        )}
+        <Box sx={{ flex: '1 1 48%', minWidth: 250, height: Math.min(400, window.innerHeight * 0.4) }}>
+          <Typography variant="caption" color="text.secondary">{wvPreview ? 'GADM division assignment' : 'CV region assignment'} (hover for details)</Typography>
+          <CvMatchMap
+            geoPreview={geo}
+            highlightClusterId={highlightClusterId}
+            anomalousDivisionIds={anomalousDivisionIds}
+            onAccept={handleMapAccept}
+            onReject={handleMapReject}
+            onClusterReassign={handleMapClusterReassign}
+          />
+        </Box>
+      </Box>
+    </Box>
+  );
+}
+
+// ─── Cluster Suggestions ────────────────────────────────────────────────────
+
+export interface CvClusterSuggestionsSectionProps {
+  cvMatchDialog: CvMatchDialogState;
+  setCVMatchDialog: React.Dispatch<React.SetStateAction<CvMatchDialogState | null>>;
+  highlightClusterId: number | null;
+  setHighlightClusterId: React.Dispatch<React.SetStateAction<number | null>>;
+  worldViewId: number;
+  invalidateTree: (regionId?: number) => void;
+  aiModelOverride: string | null;
+  setAiModelOverride: React.Dispatch<React.SetStateAction<string | null>>;
+  modelPickerOpen: boolean;
+  setModelPickerOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  modelPickerModels: Array<{ id: string }>;
+  setModelPickerModels: React.Dispatch<React.SetStateAction<Array<{ id: string }>>>;
+  modelPickerGlobal: string;
+  setModelPickerGlobal: React.Dispatch<React.SetStateAction<string>>;
+  modelPickerSelected: string;
+  setModelPickerSelected: React.Dispatch<React.SetStateAction<string>>;
+}
+
+// Apply AI cluster-to-region match results to the dialog state.
+function applyAISuggestionsToState(
+  prev: CvMatchDialogState,
+  matches: Array<{ clusterId: number; regionId: number | null }>,
+  totalCost: number,
+): CvMatchDialogState {
+  const matchMap = new Map<number, number>();
+  for (const m of matches) {
+    if (m.regionId) matchMap.set(m.clusterId, m.regionId);
+  }
+  const findRegionForCluster = (clusterId: number) => {
+    const regionId = matchMap.get(clusterId);
+    if (!regionId) return null;
+    return prev.childRegions.find(r => r.id === regionId) ?? null;
+  };
+  const applyToCluster = (c: ColorMatchCluster): ColorMatchCluster => {
+    const region = findRegionForCluster(c.clusterId);
+    return region ? { ...c, suggestedRegion: region } : c;
+  };
+  const applyToClusterInfo = (ci: ClusterGeoInfo): ClusterGeoInfo => {
+    const region = findRegionForCluster(ci.clusterId);
+    return region ? { ...ci, regionId: region.id, regionName: region.name } : ci;
+  };
+  const applyToFeature = (f: GeoJSON.Feature): GeoJSON.Feature => {
+    if (!f.properties?.clusterId) return f;
+    const region = findRegionForCluster(f.properties.clusterId);
+    if (!region) return f;
+    return { ...f, properties: { ...f.properties, regionId: region.id, regionName: region.name } };
+  };
+  const newClusters = prev.clusters.map(applyToCluster);
+  const newGeo = prev.geoPreview ? {
+    ...prev.geoPreview,
+    clusterInfos: prev.geoPreview.clusterInfos.map(applyToClusterInfo),
+    featureCollection: {
+      ...prev.geoPreview.featureCollection,
+      features: prev.geoPreview.featureCollection.features.map(applyToFeature),
+    },
+  } : prev.geoPreview;
+  return {
+    ...prev,
+    clusters: newClusters,
+    geoPreview: newGeo,
+    progressText: `AI matched ${matchMap.size}/${prev.clusters.length} clusters ($${totalCost.toFixed(3)})`,
+  };
+}
+
+export function CvClusterSuggestionsSection({
+  cvMatchDialog, setCVMatchDialog,
+  highlightClusterId, setHighlightClusterId,
+  worldViewId, invalidateTree,
+  aiModelOverride, setAiModelOverride,
+  modelPickerOpen, setModelPickerOpen,
+  modelPickerModels, setModelPickerModels,
+  modelPickerGlobal, setModelPickerGlobal,
+  modelPickerSelected, setModelPickerSelected,
+}: CvClusterSuggestionsSectionProps) {
+  const handleAISuggest = useCallback(async () => {
+    const prevText = cvMatchDialog.progressText;
+    setCVMatchDialog(prev => prev ? { ...prev, progressText: 'AI suggesting region matches...' } : prev);
+    try {
+      const clusterData = cvMatchDialog.clusters.map(c => ({
+        clusterId: c.clusterId,
+        color: c.color,
+        pixelShare: c.pixelShare,
+        divisionNames: [
+          ...c.divisions.map(d => d.name),
+          ...c.unsplittable.map(d => d.name),
+        ],
+      }));
+      const result = await aiSuggestClusterRegions(
+        worldViewId, clusterData, cvMatchDialog.childRegions, aiModelOverride || undefined,
+      );
+      setCVMatchDialog(prev => prev ? applyAISuggestionsToState(prev, result.matches, result.stats.cost) : prev);
+    } catch (err) {
+      console.error('AI suggest failed:', err);
+      setCVMatchDialog(prev => prev ? { ...prev, progressText: prevText } : prev);
+    }
+  }, [cvMatchDialog, worldViewId, aiModelOverride, setCVMatchDialog]);
+
+  const handleOpenModelPicker = useCallback(async () => {
+    try {
+      const { getAISettings } = await import('../../api/admin/ai');
+      const { settings, models } = await getAISettings();
+      const current = settings['model.cv_cluster_match'] || 'o4-mini';
+      setModelPickerModels(models);
+      setModelPickerGlobal(current);
+      setModelPickerSelected(aiModelOverride || current);
+      setModelPickerOpen(true);
+    } catch (err) {
+      console.error('Failed to load AI models:', err);
+    }
+  }, [aiModelOverride, setModelPickerModels, setModelPickerGlobal, setModelPickerSelected, setModelPickerOpen]);
+
+  const handleSaveGlobalModel = useCallback(async () => {
+    try {
+      const { updateAISetting } = await import('../../api/admin/ai');
+      await updateAISetting('model.cv_cluster_match', modelPickerSelected);
+      setAiModelOverride(null);
+      setModelPickerOpen(false);
+      setCVMatchDialog(prev => prev ? { ...prev, progressText: `Global model → ${modelPickerSelected}` } : prev);
+    } catch (err) {
+      console.error('Failed to save:', err);
+    }
+  }, [modelPickerSelected, setAiModelOverride, setModelPickerOpen, setCVMatchDialog]);
+
+  return (
+    <Box sx={{ mb: 3 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5 }}>
+        <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+          Suggested Assignments ({cvMatchDialog.clusters.reduce((s, c) => s + c.divisions.length, 0)} divisions → {cvMatchDialog.clusters.length} regions)
+        </Typography>
+        <Button
+          size="small"
+          variant="outlined"
+          sx={{ fontSize: '0.7rem', py: 0.25, px: 0.75, textTransform: 'none' }}
+          disabled={!cvMatchDialog.sourceUrl}
+          onClick={() => cvMatchDialog.sourceUrl && window.open(cvMatchDialog.sourceUrl, '_blank')}
+          title={cvMatchDialog.sourceUrl ? 'Open Wikivoyage page to see region names' : 'No source URL available'}
+        >
+          View source page
+        </Button>
+        <Button
+          size="small"
+          variant="outlined"
+          color="primary"
+          sx={{ fontSize: '0.7rem', py: 0.25, px: 0.75, textTransform: 'none' }}
+          disabled={cvMatchDialog.clusters.length === 0 || cvMatchDialog.childRegions.length === 0}
+          title="Use AI to match clusters to region names based on division geography"
+          onClick={handleAISuggest}
+        >
+          AI Suggest
+        </Button>
+        <IconButton
+          size="small"
+          title={aiModelOverride ? `Model: ${aiModelOverride} (local override)` : 'Change AI model'}
+          sx={{ width: 24, height: 24 }}
+          onClick={handleOpenModelPicker}
+        >
+          <SettingsIcon sx={{ fontSize: 14, color: aiModelOverride ? 'primary.main' : 'text.secondary' }} />
+        </IconButton>
+        <Dialog open={modelPickerOpen} onClose={() => setModelPickerOpen(false)} maxWidth="xs" fullWidth>
+          <DialogTitle sx={{ pb: 1, fontSize: '1rem' }}>AI Model — Cluster Match</DialogTitle>
+          <DialogContent sx={{ pt: 1 }}>
+            <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1.5 }}>
+              Global: {modelPickerGlobal}{aiModelOverride ? ` · Local override: ${aiModelOverride}` : ''}
+            </Typography>
+            <Select
+              size="small"
+              fullWidth
+              value={modelPickerSelected}
+              onChange={e => setModelPickerSelected(e.target.value)}
+              sx={{ fontSize: '0.85rem' }}
+            >
+              {modelPickerModels.map(m => (
+                <MenuItem key={m.id} value={m.id}>{m.id}</MenuItem>
+              ))}
+            </Select>
+          </DialogContent>
+          <DialogActions>
+            {aiModelOverride && (
+              <Button size="small" color="warning" onClick={() => { setAiModelOverride(null); setModelPickerOpen(false); }}>
+                Clear override
+              </Button>
+            )}
+            <Box sx={{ flex: 1 }} />
+            <Button size="small" onClick={() => setModelPickerOpen(false)}>Cancel</Button>
+            <Button
+              size="small"
+              variant="outlined"
+              onClick={() => { setAiModelOverride(modelPickerSelected); setModelPickerOpen(false); }}
+            >
+              Use locally
+            </Button>
+            <Button
+              size="small"
+              variant="contained"
+              onClick={handleSaveGlobalModel}
+            >
+              Save global
+            </Button>
+          </DialogActions>
+        </Dialog>
+      </Box>
+      {cvMatchDialog.clusters.map(cluster => (
+        <ClusterCard
+          key={cluster.clusterId}
+          cluster={cluster}
+          cvMatchDialog={cvMatchDialog}
+          setCVMatchDialog={setCVMatchDialog}
+          highlightClusterId={highlightClusterId}
+          setHighlightClusterId={setHighlightClusterId}
+          worldViewId={worldViewId}
+          invalidateTree={invalidateTree}
+        />
+      ))}
+      {/* Unmatched child regions — no cluster found for these */}
+      {(() => {
+        const matchedRegionIds = new Set(cvMatchDialog.clusters.map(c => c.suggestedRegion?.id).filter(Boolean));
+        const unmatched = cvMatchDialog.childRegions.filter(r => !matchedRegionIds.has(r.id));
+        if (unmatched.length === 0) return null;
+        return (
+          <Box sx={{ mb: 2, p: 1.5, border: '1px dashed', borderColor: 'warning.main', borderRadius: 1, bgcolor: 'warning.50' }}>
+            <Typography variant="subtitle2" color="warning.main" sx={{ mb: 0.5 }}>
+              Unmatched regions ({unmatched.length}) — reassign a cluster above using its dropdown
+            </Typography>
+            <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.75 }}>
+              Each cluster has a region dropdown — pick one of these unmatched regions to assign its divisions.
+            </Typography>
+            <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
+              {unmatched.map(r => (
+                <Chip key={r.id} label={r.name} size="small" variant="outlined" color="warning" />
+              ))}
+            </Box>
+          </Box>
+        );
+      })()}
+      {/* Out-of-bounds divisions — centroids outside source map coverage */}
+      {(cvMatchDialog.outOfBounds?.length ?? 0) > 0 && (
+        <Box sx={{ mb: 2, p: 1.5, border: '1px dashed', borderColor: 'info.main', borderRadius: 1, bgcolor: 'info.50' }}>
+          <Typography variant="subtitle2" color="info.main" sx={{ mb: 0.5 }}>
+            Outside map coverage ({cvMatchDialog.outOfBounds.length} divisions)
+          </Typography>
+          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.75 }}>
+            These divisions fall outside the source map image. Assign them manually in the tree.
+          </Typography>
+          <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
+            {cvMatchDialog.outOfBounds.map(d => (
+              <Chip key={d.id} label={d.name} size="small" variant="outlined" color="info" />
+            ))}
+          </Box>
+        </Box>
+      )}
+      {/* Action buttons */}
+      <AcceptActionButtons
+        cvMatchDialog={cvMatchDialog}
+        setCVMatchDialog={setCVMatchDialog}
+        worldViewId={worldViewId}
+        invalidateTree={invalidateTree}
+      />
+    </Box>
+  );
+}
+
+// ─── ClusterCard ────────────────────────────────────────────────────────────
+
+function ClusterCard({
+  cluster, cvMatchDialog, setCVMatchDialog,
+  highlightClusterId, setHighlightClusterId,
+  worldViewId, invalidateTree,
+}: {
+  cluster: ColorMatchCluster;
+  cvMatchDialog: CvMatchDialogState;
+  setCVMatchDialog: React.Dispatch<React.SetStateAction<CvMatchDialogState | null>>;
+  highlightClusterId: number | null;
+  setHighlightClusterId: React.Dispatch<React.SetStateAction<number | null>>;
+  worldViewId: number;
+  invalidateTree: (regionId?: number) => void;
+}) {
+  return (
+    <Box
+      sx={{ mb: 2, p: 1.5, border: '1px solid', borderColor: 'divider', borderRadius: 1, borderLeft: `4px solid ${cluster.color}` }}
+    >
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1, flexWrap: 'wrap', gap: 1 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <Box sx={{ width: 16, height: 16, bgcolor: cluster.color, borderRadius: '2px', border: '1px solid rgba(0,0,0,0.2)', flexShrink: 0 }} />
+          <Select
+            size="small"
+            displayEmpty
+            value={cluster.suggestedRegion?.id ?? ''}
+            sx={{ minWidth: 150, fontSize: '0.85rem', height: 28 }}
+            onChange={(e) => {
+              const rid = Number(e.target.value);
+              const region = cvMatchDialog.childRegions.find(r => r.id === rid);
+              if (!region) return;
+              const cid = cluster.clusterId;
+              setCVMatchDialog(prev => {
+                if (!prev) return prev;
+                const newClusters = prev.clusters.map(c =>
+                  c.clusterId === cid ? { ...c, suggestedRegion: region } : c
+                );
+                // Propagate mapping to geoPreview so the map reflects it immediately
+                const newGeo = prev.geoPreview ? {
+                  ...prev.geoPreview,
+                  clusterInfos: prev.geoPreview.clusterInfos.map(ci =>
+                    ci.clusterId === cid ? { ...ci, regionId: rid, regionName: region.name } : ci
+                  ),
+                  featureCollection: {
+                    ...prev.geoPreview.featureCollection,
+                    features: prev.geoPreview.featureCollection.features.map(f =>
+                      f.properties?.clusterId === cid
+                        ? { ...f, properties: { ...f.properties, regionId: rid, regionName: region.name } }
+                        : f
+                    ),
+                  },
+                } : prev.geoPreview;
+                return { ...prev, clusters: newClusters, geoPreview: newGeo };
+              });
+            }}
+          >
+            <MenuItem value="" disabled>
+              Assign to region...
+            </MenuItem>
+            {(cvMatchDialog.childRegions ?? []).map(r => (
+              <MenuItem key={r.id} value={r.id}>{r.name}</MenuItem>
+            ))}
+          </Select>
+          <Typography variant="body2" color="text.secondary">
+            {Math.round(cluster.pixelShare * 100)}% · {cluster.divisions.length} div
+            {cluster.unsplittable.length > 0 && ` · ${cluster.unsplittable.length} unsplittable`}
+          </Typography>
+          <IconButton
+            size="small"
+            title="Highlight on map"
+            onClick={() => setHighlightClusterId(prev => prev === cluster.clusterId ? null : cluster.clusterId)}
+            sx={{
+              bgcolor: highlightClusterId === cluster.clusterId ? cluster.color : 'transparent',
+              color: highlightClusterId === cluster.clusterId ? '#fff' : 'text.secondary',
+              border: '1px solid',
+              borderColor: highlightClusterId === cluster.clusterId ? cluster.color : 'divider',
+              width: 26, height: 26,
+              '&:hover': { bgcolor: cluster.color, color: '#fff' },
+            }}
+          >
+            <Visibility sx={{ fontSize: 16 }} />
+          </IconButton>
+        </Box>
+        {(cluster.divisions.length > 0 || cluster.unsplittable.length > 0) && (
+          <Button
+            size="small"
+            variant="contained"
+            color="success"
+            disabled={!cluster.suggestedRegion}
+            title={!cluster.suggestedRegion ? 'Select a region from the dropdown first' : `Accept all ${cluster.divisions.length + cluster.unsplittable.length} divisions into ${cluster.suggestedRegion.name}`}
+            onClick={async () => {
+              if (!cluster.suggestedRegion) return;
+              const regionId = cluster.suggestedRegion!.id;
+              const assignments = [
+                ...cluster.divisions.map(d => ({ regionId, divisionId: d.id })),
+                ...cluster.unsplittable.map(d => ({ regionId, divisionId: d.id })),
+              ];
+              try {
+                await acceptBatchMatches(worldViewId, assignments);
+                setCVMatchDialog(prev => prev ? {
+                  ...prev,
+                  clusters: prev.clusters.filter(c => c.clusterId !== cluster.clusterId),
+                } : prev);
+                invalidateTree(cvMatchDialog.regionId);
+              } catch (err) {
+                console.error('Accept batch failed:', err);
+              }
+            }}
+          >
+            Accept all ({cluster.divisions.length + cluster.unsplittable.length})
+          </Button>
+        )}
+      </Box>
+      {/* Division list */}
+      <Box sx={{ pl: 1 }}>
+        {cluster.divisions.map(div => (
+          <Typography key={div.id} variant="body2" sx={{ fontSize: '0.8rem', lineHeight: 1.6 }}>
+            {div.name || `#${div.id}`}
+            <Typography component="span" variant="body2" color="text.secondary" sx={{ fontSize: '0.75rem' }}>
+              {' '}({Math.round(div.confidence * 100)}%{div.depth > 0 ? `, depth ${div.depth}` : ''})
+            </Typography>
+          </Typography>
+        ))}
+        {cluster.unsplittable.map(div => (
+          <Typography key={div.id} variant="body2" sx={{ fontSize: '0.8rem', lineHeight: 1.6, color: 'warning.main' }}>
+            {div.name || `#${div.id}`}
+            <Typography component="span" variant="body2" sx={{ fontSize: '0.75rem' }}>
+              {' '}({Math.round(div.confidence * 100)}%, unsplittable)
+            </Typography>
+          </Typography>
+        ))}
+      </Box>
+    </Box>
+  );
+}
+
+// ─── Accept Action Buttons ──────────────────────────────────────────────────
+
+function AcceptActionButtons({
+  cvMatchDialog, setCVMatchDialog,
+  worldViewId, invalidateTree,
+}: {
+  cvMatchDialog: CvMatchDialogState;
+  setCVMatchDialog: React.Dispatch<React.SetStateAction<CvMatchDialogState | null>>;
+  worldViewId: number;
+  invalidateTree: (regionId?: number) => void;
+}) {
+  const MIN_CONFIDENCE = 0.95;
+
+  const wellFittingDivs = useMemo(() => {
+    return cvMatchDialog.clusters
+      .filter(c => c.suggestedRegion && c.divisions.length > 0)
+      .flatMap(c => c.divisions
+        .filter(d => d.confidence >= MIN_CONFIDENCE)
+        .map(d => ({ regionId: c.suggestedRegion!.id, divisionId: d.id })));
+  }, [cvMatchDialog.clusters]);
+
+  const totalMatchedCount = useMemo(() => {
+    return cvMatchDialog.clusters
+      .filter(c => c.suggestedRegion)
+      .reduce((s, c) => s + c.divisions.length + c.unsplittable.length, 0);
+  }, [cvMatchDialog.clusters]);
+
+  const hasAnyMatched = cvMatchDialog.clusters.some(
+    c => c.suggestedRegion && (c.divisions.length > 0 || c.unsplittable.length > 0),
+  );
+  const showWellFittingButton = wellFittingDivs.length > 0 && wellFittingDivs.length !== totalMatchedCount;
+
+  const handleAcceptWellFitting = useCallback(async () => {
+    if (wellFittingDivs.length === 0) return;
+    try {
+      const acceptedIds = new Set(wellFittingDivs.map(a => a.divisionId));
+      await acceptBatchMatches(worldViewId, wellFittingDivs);
+      const stripAccepted = (c: ColorMatchCluster): ColorMatchCluster => ({
+        ...c,
+        divisions: c.divisions.filter(d => !acceptedIds.has(d.id)),
+      });
+      const hasMembers = (c: ColorMatchCluster) => c.divisions.length > 0 || c.unsplittable.length > 0;
+      setCVMatchDialog(prev => prev ? {
+        ...prev,
+        clusters: prev.clusters.map(stripAccepted).filter(hasMembers),
+      } : prev);
+      invalidateTree(cvMatchDialog.regionId);
+    } catch (err) {
+      console.error('Accept well-fitting failed:', err);
+    }
+  }, [wellFittingDivs, worldViewId, setCVMatchDialog, invalidateTree, cvMatchDialog.regionId]);
+
+  const handleAcceptAllMatched = useCallback(async () => {
+    const allAssignments: Array<{ regionId: number; divisionId: number }> = [];
+    for (const cluster of cvMatchDialog.clusters) {
+      if (!cluster.suggestedRegion) continue;
+      for (const div of cluster.divisions) {
+        allAssignments.push({ regionId: cluster.suggestedRegion.id, divisionId: div.id });
+      }
+      for (const div of cluster.unsplittable) {
+        allAssignments.push({ regionId: cluster.suggestedRegion.id, divisionId: div.id });
+      }
+    }
+    if (allAssignments.length === 0) return;
+    try {
+      await acceptBatchMatches(worldViewId, allAssignments);
+      setCVMatchDialog(prev => prev ? {
+        ...prev,
+        clusters: prev.clusters.filter(c => !c.suggestedRegion),
+      } : prev);
+      invalidateTree(cvMatchDialog.regionId);
+    } catch (err) {
+      console.error('Accept all failed:', err);
+    }
+  }, [cvMatchDialog.clusters, cvMatchDialog.regionId, worldViewId, setCVMatchDialog, invalidateTree]);
+
+  return (
+    <Box sx={{ display: 'flex', gap: 1, mt: 1, flexWrap: 'wrap' }}>
+      {showWellFittingButton && (
+        <Button
+          variant="contained"
+          color="success"
+          sx={{ flex: 1 }}
+          onClick={handleAcceptWellFitting}
+        >
+          Accept well-fitting ({wellFittingDivs.length} divisions, &gt;95%)
+        </Button>
+      )}
+      {hasAnyMatched && (
+        <Button
+          variant="contained"
+          color="success"
+          sx={{ flex: 1 }}
+          onClick={handleAcceptAllMatched}
+        >
+          Accept all matched ({totalMatchedCount} divisions)
+        </Button>
+      )}
+    </Box>
+  );
+}

--- a/frontend/src/components/admin/CvMatchDialog.tsx
+++ b/frontend/src/components/admin/CvMatchDialog.tsx
@@ -1,7 +1,7 @@
 /**
  * CvMatchDialog — Full-screen dialog for CV color-match / mapshape-match workflow.
  *
- * Orchestrates water review, cluster review, ICP adjustment, geo preview,
+ * Orchestrates water review, park review, cluster review, geo preview,
  * cluster suggestions, and debug images. Each major review section is
  * extracted into its own component file.
  */
@@ -26,6 +26,8 @@ import {
 } from '../../api/admin/worldViewImport';
 import type { CvMatchDialogState } from './useCvMatchPipeline';
 import { CvWaterReviewSection } from './CvWaterReviewSection';
+import { CvClusterReviewSection } from './CvClusterReviewSection';
+import { CvGeoPreviewSection, CvClusterSuggestionsSection } from './CvGeoPreviewSection';
 import { CvIcpAdjustmentSection } from './CvIcpAdjustmentSection';
 
 export interface CvMatchDialogProps {
@@ -33,12 +35,42 @@ export interface CvMatchDialogProps {
   setCVMatchDialog: React.Dispatch<React.SetStateAction<CvMatchDialogState | null>>;
   /** Called when user clicks Close to dismiss the dialog */
   onClose: () => void;
+  highlightClusterId: number | null;
+  setHighlightClusterId: React.Dispatch<React.SetStateAction<number | null>>;
+  worldViewId: number;
+  invalidateTree: (regionId?: number) => void;
+
+  // Settings
+  aiModelOverride: string | null;
+  setAiModelOverride: React.Dispatch<React.SetStateAction<string | null>>;
+  modelPickerOpen: boolean;
+  setModelPickerOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  modelPickerModels: Array<{ id: string }>;
+  setModelPickerModels: React.Dispatch<React.SetStateAction<Array<{ id: string }>>>;
+  modelPickerGlobal: string;
+  setModelPickerGlobal: React.Dispatch<React.SetStateAction<string>>;
+  modelPickerSelected: string;
+  setModelPickerSelected: React.Dispatch<React.SetStateAction<string>>;
 }
 
 export function CvMatchDialog({
   cvMatchDialog,
   setCVMatchDialog,
   onClose,
+  highlightClusterId,
+  setHighlightClusterId,
+  worldViewId,
+  invalidateTree,
+  aiModelOverride,
+  setAiModelOverride,
+  modelPickerOpen,
+  setModelPickerOpen,
+  modelPickerModels,
+  setModelPickerModels,
+  modelPickerGlobal,
+  setModelPickerGlobal,
+  modelPickerSelected,
+  setModelPickerSelected,
 }: CvMatchDialogProps) {
   return (
     <Dialog
@@ -64,25 +96,45 @@ export function CvMatchDialog({
               </Typography>
             </Box>
             {/* Interactive per-component water review — pipeline paused waiting for user approval */}
-            {cvMatchDialog.waterReview && (
-              <CvWaterReviewSection cvMatchDialog={cvMatchDialog} setCVMatchDialog={setCVMatchDialog} />
-            )}
-            {/* Cluster review — merge small artifact clusters before final assignment */}
+            {cvMatchDialog.waterReview && <CvWaterReviewSection cvMatchDialog={cvMatchDialog} setCVMatchDialog={setCVMatchDialog} />}
             {cvMatchDialog.clusterReview && (
-              <Box sx={{ mb: 2, p: 2, bgcolor: 'info.50', borderRadius: 1, border: '1px solid', borderColor: 'info.200' }}>
-                <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
-                  Cluster review — reviewId: {cvMatchDialog.clusterReview.reviewId}
-                </Typography>
-                <Typography variant="caption" color="text.secondary">
-                  {cvMatchDialog.clusterReview.clusters.length} clusters detected.
-                  Full cluster review UI is available in the feat branch.
-                </Typography>
-              </Box>
+              <CvClusterReviewSection cvMatchDialog={cvMatchDialog} setCVMatchDialog={setCVMatchDialog} />
             )}
             {cvMatchDialog.icpAdjustment && (
               <CvIcpAdjustmentSection
                 cvMatchDialog={cvMatchDialog}
                 setCVMatchDialog={setCVMatchDialog}
+              />
+            )}
+            {/* Interactive geo preview: side-by-side source map + MapLibre division map */}
+            {cvMatchDialog.done && (
+              <CvGeoPreviewSection
+                cvMatchDialog={cvMatchDialog}
+                setCVMatchDialog={setCVMatchDialog}
+                highlightClusterId={highlightClusterId}
+                worldViewId={worldViewId}
+                invalidateTree={invalidateTree}
+              />
+            )}
+            {/* Cluster suggestions (shown when complete) */}
+            {cvMatchDialog.done && cvMatchDialog.clusters.length > 0 && (
+              <CvClusterSuggestionsSection
+                cvMatchDialog={cvMatchDialog}
+                setCVMatchDialog={setCVMatchDialog}
+                highlightClusterId={highlightClusterId}
+                setHighlightClusterId={setHighlightClusterId}
+                worldViewId={worldViewId}
+                invalidateTree={invalidateTree}
+                aiModelOverride={aiModelOverride}
+                setAiModelOverride={setAiModelOverride}
+                modelPickerOpen={modelPickerOpen}
+                setModelPickerOpen={setModelPickerOpen}
+                modelPickerModels={modelPickerModels}
+                setModelPickerModels={setModelPickerModels}
+                modelPickerGlobal={modelPickerGlobal}
+                setModelPickerGlobal={setModelPickerGlobal}
+                modelPickerSelected={modelPickerSelected}
+                setModelPickerSelected={setModelPickerSelected}
               />
             )}
             {/* Latest pipeline image — always visible */}

--- a/frontend/src/components/admin/CvMatchMap.tsx
+++ b/frontend/src/components/admin/CvMatchMap.tsx
@@ -1,0 +1,516 @@
+/**
+ * CvMatchMap — Interactive MapLibre map for CV color-match division assignments.
+ *
+ * Extracted from WorldViewImportTree.tsx to isolate the self-contained map component
+ * with paint mode, hover tooltips, and click-to-accept/reject.
+ */
+
+import { useCallback, useState, useRef, useMemo } from 'react';
+import { Box, Typography, Button } from '@mui/material';
+import maplibregl from 'maplibre-gl';
+import MapGL, { NavigationControl, Source, Layer, type MapRef } from 'react-map-gl/maplibre';
+import * as turf from '@turf/turf';
+import type { ClusterGeoInfo, SiblingRegionGeometry } from '../../api/admin/worldViewImport';
+
+/** Merge multiple geometries into one using turf.union. Returns null if no valid geometries. */
+export function mergeGeometries(geoms: GeoJSON.Geometry[]): GeoJSON.Geometry | null {
+  if (geoms.length === 0) return null;
+  try {
+    let result = turf.feature(geoms[0] as GeoJSON.Polygon | GeoJSON.MultiPolygon);
+    for (let i = 1; i < geoms.length; i++) {
+      // eslint-disable-next-line security/detect-object-injection -- loop-counter index into typed GeoJSON.Geometry[]
+      const merged = turf.union(turf.featureCollection([result, turf.feature(geoms[i] as GeoJSON.Polygon | GeoJSON.MultiPolygon)]));
+      if (merged) result = merged;
+    }
+    return result.geometry;
+  } catch {
+    // Fallback: return GeometryCollection
+    return { type: 'GeometryCollection', geometries: geoms };
+  }
+}
+
+/** Merge gap geometries into an existing sibling region, returning updated array */
+export function mergeGeomsIntoSibling(
+  siblings: SiblingRegionGeometry[],
+  targetRegionId: number,
+  gapGeoms: GeoJSON.Geometry[],
+): SiblingRegionGeometry[] {
+  if (gapGeoms.length === 0) return siblings;
+  return siblings.map(s => {
+    if (s.regionId !== targetRegionId) return s;
+    const merged = mergeGeometries([s.geometry, ...gapGeoms]);
+    return merged ? { ...s, geometry: merged } : s;
+  });
+}
+
+// Blank map style for CV preview — no basemap tiles that blend with colored divisions
+export const CV_MAP_STYLE: maplibregl.StyleSpecification = {
+  version: 8,
+  glyphs: 'https://fonts.openmaptiles.org/{fontstack}/{range}.pbf',
+  sources: {},
+  layers: [{ id: 'background', type: 'background', paint: { 'background-color': '#f5f5f5' } }],
+};
+
+export interface CvMatchMapProps {
+  geoPreview: { featureCollection: GeoJSON.FeatureCollection; clusterInfos: ClusterGeoInfo[] };
+  /** Accept a division: (divisionId, regionId) — persists via API */
+  onAccept?: (divisionId: number, regionId: number, regionName: string) => void;
+  /** Reject/dismiss a division from the suggestion */
+  onReject?: (divisionId: number) => void;
+  /** Reassign a division to a different color cluster (local only, no API call) */
+  onClusterReassign?: (divisionId: number, clusterId: number, color: string) => void;
+  /** Highlight all divisions belonging to this cluster (dim everything else) */
+  highlightClusterId?: number | null;
+  /** Division IDs flagged as spatial anomalies (exclaves) */
+  anomalousDivisionIds?: Set<number>;
+}
+
+/** Describe the hovered feature's status for the hover tooltip line. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function describeHoveredFeature(f: any): string {
+  if (f.preAssigned) return `Already assigned to ${f.regionName ?? 'parent region'}`;
+  if (f.dismissed) return 'Dismissed';
+  if (f.isUnsplittable) {
+    const suggest = f.regionName ? ` — suggests ${f.regionName}` : '';
+    return `Unsplittable${suggest} — click to assign`;
+  }
+  if (f.clusterId === -1) return 'Unassigned';
+  const region = f.regionName ?? 'Unmatched cluster';
+  const pct = Math.round((f.confidence ?? 0) * 100);
+  return `${region} — ${pct}% confidence`;
+}
+
+/** Pick the border style for a paint-mode swatch based on selection + region mapping. */
+function swatchBorder(isActive: boolean, hasRegionName: boolean): string {
+  if (isActive) return '3px solid #000';
+  return hasRegionName ? '2px solid rgba(0,0,0,0.2)' : '2px dashed rgba(0,0,0,0.25)';
+}
+
+/** Pick the "Reassign/Assign" label for the selected feature action panel. */
+function assignLabel(isDismissed: boolean, needsManualAssign: boolean): string {
+  if (isDismissed || !needsManualAssign) return 'Reassign to:';
+  return 'Assign to:';
+}
+
+/** Selected-feature action panel with accept/reject/reassign controls (extracted to reduce CvMatchMap complexity). */
+function SelectedFeaturePanel({
+  selectedFeature, geoPreview, onAccept, onReject, onClusterReassign, setSelectedId,
+}: {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  selectedFeature: any;
+  geoPreview: CvMatchMapProps['geoPreview'];
+  onAccept?: CvMatchMapProps['onAccept'];
+  onReject?: CvMatchMapProps['onReject'];
+  onClusterReassign?: CvMatchMapProps['onClusterReassign'];
+  setSelectedId: React.Dispatch<React.SetStateAction<number | null>>;
+}) {
+  const isDismissed = !!selectedFeature.dismissed;
+  const needsManualAssign = isDismissed || selectedFeature.isUnsplittable || selectedFeature.clusterId === -1 || selectedFeature.regionId == null;
+
+  // Build cluster options for assignment — show ALL clusters (even unmapped) so user can assign by color
+  const clusterOptions: Array<{ clusterId: number; regionId: number | null; regionName: string | null; color: string }> = [];
+  if (onAccept || onClusterReassign) {
+    for (const ci of geoPreview.clusterInfos) {
+      if (ci.clusterId === selectedFeature.clusterId) continue; // skip division's own cluster
+      if (ci.clusterId === -1) continue;
+      clusterOptions.push(ci);
+    }
+  }
+
+  const hasAcceptSuggested = onAccept && selectedFeature.regionId != null && selectedFeature.clusterId !== -1 && !selectedFeature.isUnsplittable && !isDismissed;
+
+  let statusContent: React.ReactNode;
+  if (isDismissed) {
+    statusContent = 'Dismissed';
+  } else if (selectedFeature.isUnsplittable) {
+    statusContent = (
+      <>
+        Unsplittable
+        {selectedFeature.regionName && (
+          <>
+            {' — suggests '}
+            <Box component="span" sx={{ display: 'inline-block', width: 10, height: 10, bgcolor: selectedFeature.color, borderRadius: '2px', border: '1px solid rgba(0,0,0,0.2)', verticalAlign: 'middle' }} />
+            {' '}{selectedFeature.regionName}
+          </>
+        )}
+      </>
+    );
+  } else if (selectedFeature.clusterId === -1) {
+    statusContent = 'Unassigned';
+  } else {
+    const region = selectedFeature.regionName ?? 'Unmatched';
+    const pct = Math.round((selectedFeature.confidence ?? 0) * 100);
+    statusContent = `→ ${region} · ${pct}%`;
+  }
+
+  return (
+    <Box sx={{
+      position: 'absolute', bottom: 28, left: 8, right: 8, zIndex: 1,
+      bgcolor: 'rgba(255,255,255,0.97)', px: 2, py: 1,
+      borderRadius: 1, boxShadow: 2,
+    }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, flexWrap: 'wrap' }}>
+        <Box sx={{ flex: 1, minWidth: 150 }}>
+          <Typography variant="body2" sx={{ fontWeight: 600 }}>{selectedFeature.name}</Typography>
+          <Typography variant="caption" color="text.secondary" component="span" sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+            {statusContent}
+          </Typography>
+        </Box>
+        {hasAcceptSuggested && (
+          <Button
+            size="small" variant="contained" color="success"
+            onClick={() => {
+              onAccept!(selectedFeature.divisionId, selectedFeature.regionId, selectedFeature.regionName);
+              setSelectedId(null);
+            }}
+          >
+            Accept
+          </Button>
+        )}
+        {onReject && !isDismissed && selectedFeature.clusterId !== -1 && (
+          <Button
+            size="small" variant="outlined" color="error"
+            onClick={() => {
+              onReject(selectedFeature.divisionId);
+              setSelectedId(null);
+            }}
+          >
+            Dismiss
+          </Button>
+        )}
+        <Button size="small" variant="text" onClick={() => setSelectedId(null)}>
+          ✕
+        </Button>
+      </Box>
+      {/* Color cluster swatches for assignment/reassignment */}
+      {clusterOptions.length > 0 && (
+        <Box sx={{ mt: 1, pt: 1, borderTop: '1px solid', borderColor: 'divider' }}>
+          <Typography variant="caption" color="text.secondary" sx={{ mb: 0.5, display: 'block' }}>
+            {assignLabel(isDismissed, needsManualAssign)}
+          </Typography>
+          <Box sx={{ display: 'flex', gap: 0.75, flexWrap: 'wrap' }}>
+            {clusterOptions.map(c => (
+              <Box
+                key={c.clusterId}
+                onClick={() => {
+                  if (c.regionId != null && c.regionName && onAccept) {
+                    onAccept(selectedFeature.divisionId, c.regionId, c.regionName);
+                  } else if (onClusterReassign) {
+                    onClusterReassign(selectedFeature.divisionId, c.clusterId, c.color);
+                  }
+                  setSelectedId(null);
+                }}
+                title={c.regionName ?? `Cluster ${c.clusterId}`}
+                sx={{
+                  width: 28, height: 28,
+                  bgcolor: c.color,
+                  borderRadius: '4px',
+                  border: c.regionName ? '2px solid rgba(0,0,0,0.3)' : '2px dashed rgba(0,0,0,0.3)',
+                  cursor: 'pointer',
+                  transition: 'transform 0.1s, box-shadow 0.1s',
+                  '&:hover': {
+                    transform: 'scale(1.2)',
+                    boxShadow: `0 0 0 2px ${c.color}`,
+                    border: c.regionName ? '2px solid rgba(0,0,0,0.5)' : '2px dashed rgba(0,0,0,0.5)',
+                  },
+                }}
+              />
+            ))}
+          </Box>
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+/** Interactive MapLibre map showing CV color-match division assignments with click-to-accept/reject */
+export function CvMatchMap({ geoPreview, onAccept, onReject, onClusterReassign, highlightClusterId, anomalousDivisionIds }: CvMatchMapProps) {
+  const mapRef = useRef<MapRef>(null);
+  const [hoveredId, setHoveredId] = useState<number | null>(null);
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+
+  // Track featureCollection identity — increment key to force Source remount
+  // so MapLibre renders fresh tiles from the updated GeoJSON (no stale tile cache).
+  const srcKeyRef = useRef({ data: geoPreview.featureCollection, key: 0 });
+  if (srcKeyRef.current.data !== geoPreview.featureCollection) {
+    srcKeyRef.current = { data: geoPreview.featureCollection, key: srcKeyRef.current.key + 1 };
+  }
+
+  // Paint mode: pick a cluster, then click divisions to assign them
+  const [paintClusterId, setPaintClusterId] = useState<number | null>(null);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const fillColorExpr: any = ['get', 'color'];
+
+  // Region label points: one per cluster at the centroid of that cluster's divisions
+  const regionLabelPoints: GeoJSON.FeatureCollection = useMemo(() => {
+    const clusterFeatures = new Map<number, GeoJSON.Feature[]>();
+    for (const f of geoPreview.featureCollection.features) {
+      const cid = f.properties?.clusterId as number;
+      if (cid === -1) continue;
+      if (!clusterFeatures.has(cid)) clusterFeatures.set(cid, []);
+      clusterFeatures.get(cid)!.push(f);
+    }
+    const points: GeoJSON.Feature[] = [];
+    for (const c of geoPreview.clusterInfos) {
+      if (!c.regionName) continue;
+      const features = clusterFeatures.get(c.clusterId);
+      if (!features || features.length === 0) continue;
+      try {
+        const fc = turf.featureCollection(features);
+        const centroid = turf.centroid(fc);
+        centroid.properties = { regionName: c.regionName };
+        points.push(centroid);
+      } catch { /* skip */ }
+    }
+    return { type: 'FeatureCollection', features: points };
+  }, [geoPreview]);
+
+  // Selected feature details
+  const selectedFeature = useMemo(() => {
+    if (selectedId == null) return null;
+    return geoPreview.featureCollection.features.find(
+      f => f.properties?.divisionId === selectedId
+    )?.properties ?? null;
+  }, [selectedId, geoPreview.featureCollection]);
+
+  // Hovered feature info for tooltip (only when no selection)
+  const hoveredFeature = useMemo(() => {
+    if (selectedId != null || hoveredId == null) return null;
+    return geoPreview.featureCollection.features.find(
+      f => f.properties?.divisionId === hoveredId
+    )?.properties ?? null;
+  }, [hoveredId, selectedId, geoPreview.featureCollection]);
+
+  // Extract click handler to reduce cognitive complexity of CvMatchMap body
+  const handleMapClick = useCallback((e: {
+    features?: Array<{ properties?: Record<string, unknown> | null }>;
+    point: { x: number; y: number };
+  }) => {
+    let f = e.features?.[0];
+    if (!f && mapRef.current) {
+      const { x, y } = e.point;
+      const bbox: [[number, number], [number, number]] = [[x - 5, y - 5], [x + 5, y + 5]];
+      const hits = mapRef.current.queryRenderedFeatures(bbox, { layers: ['cv-divisions-fill'] });
+      if (hits.length > 0) f = hits[0];
+    }
+    const divId = (f?.properties?.divisionId as number | undefined) ?? null;
+    const isPreAssigned = f?.properties?.preAssigned === true;
+    if (isPreAssigned) return;
+    if (paintClusterId != null && divId != null) {
+      const ci = geoPreview.clusterInfos.find(c => c.clusterId === paintClusterId);
+      if (ci && onClusterReassign) {
+        onClusterReassign(divId, ci.clusterId, ci.color);
+      }
+      return;
+    }
+    setSelectedId(prev => prev === divId ? null : divId);
+  }, [paintClusterId, geoPreview.clusterInfos, onClusterReassign]);
+
+  const outlineStyle = paintClusterId != null
+    ? `3px solid ${geoPreview.clusterInfos.find(c => c.clusterId === paintClusterId)?.color ?? '#000'}`
+    : undefined;
+
+  return (
+    <Box sx={{ position: 'relative', height: '100%', minHeight: 350 }}>
+      <MapGL
+        ref={mapRef}
+        initialViewState={{ longitude: 0, latitude: 0, zoom: 1 }}
+        style={{ width: '100%', height: '100%', borderRadius: 4, outline: outlineStyle }}
+        mapStyle={CV_MAP_STYLE}
+        interactiveLayerIds={['cv-divisions-fill']}
+        onMouseMove={(e) => {
+          const f = e.features?.[0];
+          setHoveredId(f?.properties?.divisionId ?? null);
+        }}
+        onMouseLeave={() => setHoveredId(null)}
+        onClick={handleMapClick}
+        cursor={paintClusterId != null ? 'crosshair' : undefined}
+        onLoad={() => {
+          if (mapRef.current && geoPreview.featureCollection.features.length > 0) {
+            try {
+              const bbox = turf.bbox(geoPreview.featureCollection) as [number, number, number, number];
+              mapRef.current.fitBounds([[bbox[0], bbox[1]], [bbox[2], bbox[3]]], { padding: 30, duration: 0 });
+            } catch (e) {
+              console.error('Failed to fit CV preview bounds:', e);
+            }
+          }
+        }}
+      >
+        <NavigationControl position="top-right" showCompass={false} />
+        <Source key={srcKeyRef.current.key} id="cv-divisions" type="geojson" data={geoPreview.featureCollection}>
+          <Layer
+            id="cv-divisions-fill"
+            type="fill"
+            paint={{
+              'fill-color': fillColorExpr,
+              'fill-opacity': highlightClusterId != null
+                ? ['case',
+                    ['==', ['get', 'clusterId'], highlightClusterId], 0.75,
+                    ['==', ['get', 'divisionId'], selectedId ?? -999], 0.7,
+                    ['==', ['get', 'isOutOfBounds'], true], 0.08,
+                    ['==', ['get', 'preAssigned'], true], 0.25,
+                    0.08,
+                  ]
+                : ['case',
+                    ['==', ['get', 'divisionId'], selectedId ?? -999], 0.95,
+                    ['==', ['get', 'preAssigned'], true], 0.25,
+                    ['==', ['get', 'dismissed'], true], 0.15,
+                    ['==', ['get', 'isOutOfBounds'], true], 0.08,
+                    ['==', ['get', 'clusterId'], -1], 0.1,
+                    0.9,
+                  ],
+            }}
+          />
+          <Layer
+            id="cv-divisions-outline"
+            type="line"
+            paint={{
+              'line-color': ['case',
+                ['==', ['get', 'divisionId'], selectedId ?? -999], '#1565c0',
+                ['==', ['get', 'preAssigned'], true], '#999',
+                ['==', ['get', 'dismissed'], true], '#999',
+                ['==', ['get', 'isOutOfBounds'], true], '#aaa',
+                '#333',
+              ],
+              'line-width': highlightClusterId != null
+                ? ['case',
+                    ['==', ['get', 'clusterId'], highlightClusterId], 2,
+                    ['==', ['get', 'divisionId'], selectedId ?? -999], 3,
+                    ['==', ['get', 'preAssigned'], true], 0.3,
+                    ['==', ['get', 'isOutOfBounds'], true], 0.3,
+                    0.3,
+                  ]
+                : ['case',
+                    ['==', ['get', 'divisionId'], selectedId ?? -999], 3,
+                    ['==', ['get', 'preAssigned'], true], 0.4,
+                    ['==', ['get', 'dismissed'], true], 0.5,
+                    ['==', ['get', 'isOutOfBounds'], true], 0.5,
+                    ['==', ['get', 'isUnsplittable'], true], 1.5,
+                    0.8,
+                  ],
+            }}
+          />
+          {/* Dashed overlay for unsplittable divisions */}
+          <Layer
+            id="cv-divisions-unsplittable"
+            type="line"
+            filter={['==', ['get', 'isUnsplittable'], true]}
+            paint={{
+              'line-color': '#d32f2f',
+              'line-width': 2,
+              'line-dasharray': [3, 3],
+            }}
+          />
+          {/* Dashed overlay for out-of-bounds divisions */}
+          <Layer
+            id="cv-divisions-oob"
+            type="line"
+            filter={['==', ['get', 'isOutOfBounds'], true]}
+            paint={{
+              'line-color': '#ff9800',
+              'line-width': 1.5,
+              'line-dasharray': [4, 4],
+            }}
+          />
+          {/* Spatial anomaly overlay (dashed magenta) */}
+          <Layer
+            id="cv-divisions-anomaly"
+            type="line"
+            source="cv-divisions"
+            filter={anomalousDivisionIds && anomalousDivisionIds.size > 0
+              ? ['in', ['get', 'divisionId'], ['literal', [...anomalousDivisionIds]]]
+              : ['==', ['get', 'divisionId'], -1]
+            }
+            paint={{
+              'line-color': '#e040fb',
+              'line-width': 2.5,
+              'line-dasharray': [4, 3],
+            }}
+          />
+        </Source>
+        {/* Region name labels (one point per cluster, placed at geographic centroid) */}
+        <Source id="cv-region-labels-src" type="geojson" data={regionLabelPoints}>
+          <Layer
+            id="cv-region-labels"
+            type="symbol"
+            layout={{
+              'text-field': ['get', 'regionName'],
+              'text-size': 13,
+              'text-font': ['Open Sans Semibold'],
+              'text-allow-overlap': true,
+            }}
+            paint={{
+              'text-color': '#000',
+              'text-halo-color': '#fff',
+              'text-halo-width': 2,
+            }}
+          />
+        </Source>
+      </MapGL>
+      {/* Paint mode toolbar — pick a cluster, then click divisions to assign */}
+      {(onAccept || onClusterReassign) && geoPreview.clusterInfos.filter(c => c.clusterId !== -1).length > 1 && (
+        <Box sx={{
+          position: 'absolute', top: 8, right: 8, zIndex: 2,
+          bgcolor: 'rgba(255,255,255,0.95)', px: 1, py: 0.75,
+          borderRadius: 1, boxShadow: 1,
+          display: 'flex', alignItems: 'center', gap: 0.75, flexWrap: 'wrap', maxWidth: 220,
+        }}>
+          <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 600, fontSize: '0.7rem', width: '100%' }}>
+            Paint mode {paintClusterId != null && '(active)'}
+          </Typography>
+          {geoPreview.clusterInfos.filter(c => c.clusterId !== -1).map(c => (
+            <Box
+              key={c.clusterId}
+              onClick={() => setPaintClusterId(prev => prev === c.clusterId ? null : c.clusterId)}
+              title={c.regionName ?? `Cluster ${c.clusterId}`}
+              sx={{
+                width: 22, height: 22,
+                bgcolor: c.color,
+                borderRadius: '3px',
+                border: swatchBorder(paintClusterId === c.clusterId, !!c.regionName),
+                cursor: 'pointer',
+                transition: 'transform 0.1s',
+                transform: paintClusterId === c.clusterId ? 'scale(1.25)' : 'none',
+                '&:hover': { transform: 'scale(1.15)' },
+              }}
+            />
+          ))}
+          {paintClusterId != null && (
+            <Typography
+              variant="caption"
+              sx={{ cursor: 'pointer', color: 'text.secondary', textDecoration: 'underline', fontSize: '0.7rem' }}
+              onClick={() => setPaintClusterId(null)}
+            >
+              cancel
+            </Typography>
+          )}
+        </Box>
+      )}
+      {/* Hover tooltip (when nothing selected) */}
+      {hoveredFeature && (
+        <Box sx={{
+          position: 'absolute', top: 8, left: 8,
+          bgcolor: 'rgba(255,255,255,0.95)', px: 1.5, py: 0.75,
+          borderRadius: 1, boxShadow: 1, pointerEvents: 'none', maxWidth: 280,
+        }}>
+          <Typography variant="body2" sx={{ fontWeight: 600 }}>{hoveredFeature.name}</Typography>
+          <Typography variant="caption" color="text.secondary">
+            {describeHoveredFeature(hoveredFeature)}
+          </Typography>
+        </Box>
+      )}
+      {/* Selected division action panel */}
+      {selectedFeature && (
+        <SelectedFeaturePanel
+          selectedFeature={selectedFeature}
+          geoPreview={geoPreview}
+          onAccept={onAccept}
+          onReject={onReject}
+          onClusterReassign={onClusterReassign}
+          setSelectedId={setSelectedId}
+        />
+      )}
+    </Box>
+  );
+}

--- a/frontend/src/components/admin/GapAnalysis.tsx
+++ b/frontend/src/components/admin/GapAnalysis.tsx
@@ -1,0 +1,647 @@
+import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
+import {
+  Box,
+  Typography,
+  Button,
+  IconButton,
+  TextField,
+  CircularProgress,
+} from '@mui/material';
+import {
+  NavigateBefore as PrevIcon,
+  NavigateNext as NextIcon,
+  Close as CloseNavIcon,
+  Check as CheckIcon,
+  Close as CloseIcon,
+} from '@mui/icons-material';
+import type maplibregl from 'maplibre-gl';
+import MapGL, { NavigationControl, Source, Layer, type MapRef } from 'react-map-gl/maplibre';
+import * as turf from '@turf/turf';
+import { useQuery } from '@tanstack/react-query';
+import {
+  getChildrenRegionGeometry,
+  type CoverageGapDivision,
+  type SiblingRegionGeometry,
+} from '../../api/admin/worldViewImport';
+import { searchRegions } from '../../api/regions';
+import { Tooltip, type ShadowInsertion } from './treeNodeShared';
+
+// Inlined here instead of importing from ImportTreeDialogs — that module
+// re-imports GapDivisionTree + GapContextMap from this file, so sharing the
+// constant via import would form a circular dependency.
+const COVERAGE_MAP_STYLE = 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json';
+
+/** Shadow create_region row — rendered as a synthetic child in the flat list */
+export function ShadowCreateRow({ shadow, depth, onApproveShadow, onRejectShadow, isMutating }: {
+  shadow: ShadowInsertion;
+  depth: number;
+  onApproveShadow?: (insertion: ShadowInsertion) => void;
+  onRejectShadow?: (insertion: ShadowInsertion) => void;
+  isMutating: boolean;
+}) {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 0.75,
+        pl: depth * 3,
+        py: 0.3,
+        borderBottom: '1px solid',
+        borderColor: 'divider',
+        borderLeft: '2px dashed',
+        borderLeftColor: 'warning.main',
+        bgcolor: 'rgba(237, 108, 2, 0.06)',
+        minHeight: 32,
+      }}
+    >
+      <Box sx={{ width: 28, flexShrink: 0 }} />
+      <Typography variant="body2" sx={{ fontStyle: 'italic' }}>
+        + {shadow.gapDivisionName}
+      </Typography>
+      <Typography variant="caption" color="text.secondary">
+        (new region)
+      </Typography>
+      <Tooltip title="Approve — create region and add member">
+        <IconButton size="small" color="success" onClick={() => onApproveShadow?.(shadow)} disabled={isMutating} sx={{ p: 0.25 }}>
+          <CheckIcon sx={{ fontSize: 16 }} />
+        </IconButton>
+      </Tooltip>
+      <Tooltip title="Reject">
+        <IconButton size="small" color="error" onClick={() => onRejectShadow?.(shadow)} sx={{ p: 0.25 }}>
+          <CloseIcon sx={{ fontSize: 16 }} />
+        </IconButton>
+      </Tooltip>
+    </Box>
+  );
+}
+
+/** Reusable prev/counter/next/close controls for category navigation */
+export function NavControls({ label, idx, total, onPrev, onNext, onClose }: {
+  label: string; idx: number; total: number;
+  onPrev: () => void; onNext: () => void; onClose: () => void;
+}) {
+  return (
+    <>
+      <Button size="small" startIcon={<PrevIcon />} onClick={onPrev} disabled={idx <= 0}>
+        Prev
+      </Button>
+      <Typography variant="body2" sx={{ mx: 0.5, whiteSpace: 'nowrap' }}>
+        {idx + 1} / {total} {label}
+      </Typography>
+      <Button size="small" endIcon={<NextIcon />} onClick={onNext} disabled={idx >= total - 1}>
+        Next
+      </Button>
+      <IconButton size="small" onClick={onClose} sx={{ p: 0.25 }}>
+        <CloseNavIcon fontSize="small" />
+      </IconButton>
+    </>
+  );
+}
+
+/** Inline select for assigning a gap division to an existing region in the subtree */
+export function GapAssignSelect({ subtreeRegions, defaultRegionId, mapSelectedRegionId, isMutating, hasGapChildren, onSelect, parentRegionName }: {
+  subtreeRegions: Array<{ id: number; name: string; depth: number; isLast?: boolean }>;
+  /** Pre-select the suggested target if available */
+  defaultRegionId?: number;
+  /** Region selected from the map — overrides local selection */
+  mapSelectedRegionId?: number | null;
+  isMutating: boolean;
+  hasGapChildren: boolean;
+  onSelect: (regionId: number) => void;
+  /** Parent region name for building hierarchy paths in tooltips */
+  parentRegionName?: string;
+}) {
+  const [selected, setSelected] = useState<number | ''>(defaultRegionId ?? '');
+
+  // Sync from map selection — only when it changes and is a valid subtree region
+  useEffect(() => {
+    if (mapSelectedRegionId != null && subtreeRegions.some(r => r.id === mapSelectedRegionId)) {
+      setSelected(mapSelectedRegionId);
+    }
+  }, [mapSelectedRegionId, subtreeRegions]);
+
+  // Build hierarchy path tooltips (e.g. "Europe → Western Europe → France")
+  const regionPaths = useMemo(() => {
+    const stack: string[] = [];
+    return subtreeRegions.map(r => {
+      stack.length = r.depth;
+      stack.push(r.name);
+      return parentRegionName ? [parentRegionName, ...stack].join(' \u2192 ') : stack.join(' \u2192 ');
+    });
+  }, [subtreeRegions, parentRegionName]);
+
+  // Build tree indent prefix: "├─ " or "└─ " with "│  " or "   " for ancestors
+  const treeLabels = useMemo(() => {
+    return subtreeRegions.map((r, i) => {
+      if (r.depth === 0) {
+        // Check if last at root level
+        const isLastRoot = !subtreeRegions.slice(i + 1).some(s => s.depth === 0);
+        return `${isLastRoot ? '└' : '├'}\u2009${r.name}`;
+      }
+      // Find if this is the last item before next same-or-shallower depth
+      let isLast = true;
+      for (let j = i + 1; j < subtreeRegions.length; j++) {
+        // eslint-disable-next-line security/detect-object-injection -- loop-counter index into typed subtreeRegions[] array
+        if (subtreeRegions[j].depth <= r.depth) {
+          // eslint-disable-next-line security/detect-object-injection -- same loop-counter index
+          isLast = subtreeRegions[j].depth < r.depth;
+          break;
+        }
+      }
+      const prefix = '\u2003'.repeat(r.depth) + (isLast ? '└' : '├');
+      return `${prefix}\u2009${r.name}`;
+    });
+  }, [subtreeRegions]);
+
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+      <TextField
+        select
+        size="small"
+        value={selected}
+        onChange={(e) => setSelected(Number(e.target.value))}
+        slotProps={{ select: { native: true } }}
+        sx={{ minWidth: 140, '& .MuiInputBase-input': { fontSize: '0.75rem', py: 0.5 } }}
+      >
+        <option value="">Assign to...</option>
+        {subtreeRegions.map((r, i) => (
+          // eslint-disable-next-line security/detect-object-injection -- i is .map() callback index into parallel arrays regionPaths and treeLabels
+          <option key={r.id} value={r.id} title={regionPaths[i]}>{treeLabels[i]}</option>
+        ))}
+      </TextField>
+      <Button
+        size="small"
+        variant="outlined"
+        color="success"
+        onClick={() => { if (selected) onSelect(selected); }}
+        disabled={isMutating || !selected}
+        sx={{ fontSize: '0.7rem', py: 0.25, minHeight: 0 }}
+      >
+        Assign{hasGapChildren ? ' all' : ''}
+      </Button>
+    </Box>
+  );
+}
+
+/** Inline search for moving a gap to a region outside the current subtree */
+function MoveToSearch({ worldViewId, isMutating, hasGapChildren, onSelect, onClose }: {
+  worldViewId: number;
+  isMutating: boolean;
+  hasGapChildren: boolean;
+  onSelect: (regionId: number) => void;
+  onClose: () => void;
+}) {
+  const [query, setQuery] = useState('');
+  const [selected, setSelected] = useState<number | ''>('');
+
+  const { data: results, isFetching } = useQuery({
+    queryKey: ['admin', 'gapMoveSearch', worldViewId, query],
+    queryFn: () => searchRegions(worldViewId, query),
+    enabled: query.length >= 2,
+  });
+
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+      <TextField
+        size="small"
+        placeholder="Search region..."
+        value={query}
+        onChange={(e) => { setQuery(e.target.value); setSelected(''); }}
+        autoFocus
+        sx={{ minWidth: 120, '& .MuiInputBase-input': { fontSize: '0.75rem', py: 0.5 } }}
+      />
+      {query.length >= 2 && results && results.length > 0 && (
+        <TextField
+          select
+          size="small"
+          value={selected}
+          onChange={(e) => setSelected(Number(e.target.value))}
+          slotProps={{ select: { native: true } }}
+          sx={{ minWidth: 160, '& .MuiInputBase-input': { fontSize: '0.75rem', py: 0.5 } }}
+        >
+          <option value="">{isFetching ? 'Searching...' : 'Pick region...'}</option>
+          {results.map((r) => (
+            <option key={r.id} value={r.id} title={r.path}>{r.name} ({r.path})</option>
+          ))}
+        </TextField>
+      )}
+      <Button
+        size="small"
+        variant="outlined"
+        color="warning"
+        onClick={() => { if (selected) onSelect(selected as number); }}
+        disabled={isMutating || !selected}
+        sx={{ fontSize: '0.7rem', py: 0.25, minHeight: 0 }}
+      >
+        Move{hasGapChildren ? ' all' : ''}
+      </Button>
+      <IconButton size="small" onClick={onClose} sx={{ p: 0.25 }}>
+        <CloseIcon sx={{ fontSize: 16 }} />
+      </IconButton>
+    </Box>
+  );
+}
+
+// Distinct colors for sibling regions (up to 8, then cycle)
+const SIBLING_COLORS = ['#3388ff', '#33aa55', '#9955cc', '#cc7733', '#5599dd', '#aa3366', '#55bb88', '#8866cc'];
+
+/** Map showing gap divisions in context of existing sibling regions, with drill-down */
+export function GapContextMap({ gapDivisions, siblingRegions, worldViewId, highlightedGapId, onHighlight, onRegionSelect, selectedRegionId }: {
+  gapDivisions: CoverageGapDivision[];
+  siblingRegions: SiblingRegionGeometry[];
+  worldViewId: number;
+  highlightedGapId: number | null;
+  onHighlight: (id: number | null) => void;
+  /** Called when a leaf region is clicked on the map — sets assign target */
+  onRegionSelect: (regionId: number, regionName: string) => void;
+  /** Currently selected assign-target region — highlighted on map */
+  selectedRegionId: number | null;
+}) {
+  const mapRef = useRef<MapRef>(null);
+  // Drill-down state: stack of { regionId, regionName, regions }
+  const [drillStack, setDrillStack] = useState<Array<{ regionId: number; regionName: string; regions: SiblingRegionGeometry[] }>>([]);
+  const [drillLoading, setDrillLoading] = useState(false);
+
+  // Active regions: either the original siblings or the drill-down level
+  const activeRegions = drillStack.length > 0 ? drillStack[drillStack.length - 1].regions : siblingRegions;
+
+  // Build a FeatureCollection for all gap divisions
+  const gapFeatures = useMemo<GeoJSON.FeatureCollection>(() => ({
+    type: 'FeatureCollection',
+    features: gapDivisions
+      .filter(g => g.geometry)
+      .map(g => ({ type: 'Feature' as const, properties: { id: g.divisionId, name: g.name }, geometry: g.geometry! })),
+  }), [gapDivisions]);
+
+  // Highlighted gap feature
+  const highlightFeature = useMemo<GeoJSON.FeatureCollection>(() => {
+    const gap = highlightedGapId != null ? gapDivisions.find(g => g.divisionId === highlightedGapId) : null;
+    if (!gap?.geometry) return { type: 'FeatureCollection', features: [] };
+    return { type: 'FeatureCollection', features: [{ type: 'Feature', properties: { name: gap.name }, geometry: gap.geometry }] };
+  }, [highlightedGapId, gapDivisions]);
+
+  // Per-sibling FeatureCollections with label points
+  const siblingFeatures = useMemo(() =>
+    activeRegions.map((s, i) => ({
+      ...s,
+      color: SIBLING_COLORS[i % SIBLING_COLORS.length],
+      isSelected: s.regionId === selectedRegionId,
+      fc: {
+        type: 'FeatureCollection' as const,
+        features: [{ type: 'Feature' as const, properties: { name: s.name, regionId: s.regionId }, geometry: s.geometry }],
+      },
+      labelPoint: (() => {
+        try {
+          const center = turf.centerOfMass({ type: 'Feature', properties: {}, geometry: s.geometry });
+          return center.geometry;
+        } catch { return null; }
+      })(),
+    })),
+  [activeRegions, selectedRegionId]);
+
+  // Compute bounds from all geometries
+  const combinedBbox = useMemo(() => {
+    const geoms: GeoJSON.Geometry[] = [];
+    for (const s of activeRegions) geoms.push(s.geometry);
+    for (const g of gapDivisions) if (g.geometry) geoms.push(g.geometry);
+    if (geoms.length === 0) return null;
+    const fc: GeoJSON.FeatureCollection = {
+      type: 'FeatureCollection',
+      features: geoms.map(g => ({ type: 'Feature' as const, properties: {}, geometry: g })),
+    };
+    return turf.bbox(fc) as [number, number, number, number];
+  }, [activeRegions, gapDivisions]);
+
+  const fitToBounds = useCallback((bbox: [number, number, number, number] | null) => {
+    if (!mapRef.current || !bbox) return;
+    mapRef.current.fitBounds([[bbox[0], bbox[1]], [bbox[2], bbox[3]]], { padding: 30, duration: 300 });
+  }, []);
+
+  const fitMap = useCallback(() => fitToBounds(combinedBbox), [fitToBounds, combinedBbox]);
+
+  // Refit when drill level changes
+  useEffect(() => { fitToBounds(combinedBbox); }, [combinedBbox, fitToBounds]);
+
+  // Drill down into a sibling region — if it has children, drill; otherwise select as target
+  const handleRegionClick = useCallback(async (regionId: number) => {
+    const region = activeRegions.find(r => r.regionId === regionId);
+    if (!region) return;
+    setDrillLoading(true);
+    try {
+      const result = await getChildrenRegionGeometry(worldViewId, regionId);
+      if (result.childRegions.length > 0) {
+        // Has children → drill down
+        setDrillStack(prev => [...prev, { regionId, regionName: region.name, regions: result.childRegions }]);
+      } else {
+        // Leaf region → select as assign target
+        onRegionSelect(regionId, region.name);
+      }
+    } finally {
+      setDrillLoading(false);
+    }
+  }, [activeRegions, worldViewId, onRegionSelect]);
+
+  // Click handler: sibling regions take priority over gap fills
+  const interactiveIds = useMemo(() => {
+    const ids: string[] = [];
+    // Sibling fills first so they get priority in hit-testing
+    for (let i = 0; i < siblingFeatures.length; i++) ids.push(`sib-fill-${i}`);
+    ids.push('gap-fill');
+    return ids;
+  }, [siblingFeatures.length]);
+
+  const handleClick = useCallback((e: maplibregl.MapLayerMouseEvent) => {
+    const feature = e.features?.[0];
+    if (!feature?.properties) return;
+    // Check if it's a sibling region click (regionId property exists on sibling features)
+    if (feature.properties.regionId) {
+      handleRegionClick(Number(feature.properties.regionId));
+      return;
+    }
+    // Gap division click
+    if (feature.properties.id) {
+      const id = Number(feature.properties.id);
+      onHighlight(id === highlightedGapId ? null : id);
+    }
+  }, [highlightedGapId, onHighlight, handleRegionClick]);
+
+  return (
+    <Box sx={{ height: 300, borderRadius: 1, overflow: 'hidden', position: 'relative' }}>
+      <MapGL
+        ref={mapRef}
+        initialViewState={{ longitude: 0, latitude: 0, zoom: 1 }}
+        style={{ width: '100%', height: '100%' }}
+        mapStyle={COVERAGE_MAP_STYLE}
+        onLoad={fitMap}
+        interactiveLayerIds={interactiveIds}
+        onClick={handleClick}
+        cursor="pointer"
+      >
+        <NavigationControl position="top-right" showCompass={false} />
+        {/* Individual sibling regions with distinct colors and labels */}
+        {siblingFeatures.map((s, i) => (
+          <Source key={`sib-${s.regionId}`} id={`sib-${i}`} type="geojson" data={s.fc}>
+            <Layer id={`sib-fill-${i}`} type="fill" paint={{
+              'fill-color': s.isSelected ? '#1976d2' : s.color,
+              'fill-opacity': s.isSelected ? 0.4 : 0.2,
+            }} />
+            <Layer id={`sib-outline-${i}`} type="line" paint={{
+              'line-color': s.isSelected ? '#1976d2' : s.color,
+              'line-width': s.isSelected ? 3 : 1.5,
+            }} />
+          </Source>
+        ))}
+        {/* Sibling labels as a single source */}
+        {siblingFeatures.some(s => s.labelPoint) && (
+          <Source
+            id="sib-labels"
+            type="geojson"
+            data={{
+              type: 'FeatureCollection',
+              features: siblingFeatures
+                .filter(s => s.labelPoint)
+                .map(s => ({ type: 'Feature' as const, properties: { name: s.name }, geometry: s.labelPoint! })),
+            }}
+          >
+            <Layer
+              id="sib-label-text"
+              type="symbol"
+              layout={{
+                'text-field': ['get', 'name'],
+                'text-size': 11,
+                'text-allow-overlap': false,
+                'text-font': ['Open Sans Semibold'],
+              }}
+              paint={{
+                'text-color': '#333',
+                'text-halo-color': '#fff',
+                'text-halo-width': 1.5,
+              }}
+            />
+          </Source>
+        )}
+        {/* All gap divisions (orange) */}
+        <Source id="gaps" type="geojson" data={gapFeatures}>
+          <Layer id="gap-fill" type="fill" paint={{ 'fill-color': '#ff8833', 'fill-opacity': 0.35 }} />
+          <Layer id="gap-outline" type="line" paint={{ 'line-color': '#ff8833', 'line-width': 1.5 }} />
+        </Source>
+        {/* Highlighted gap (red) */}
+        <Source id="gap-highlight" type="geojson" data={highlightFeature}>
+          <Layer id="gap-hl-fill" type="fill" paint={{ 'fill-color': '#e53935', 'fill-opacity': 0.5 }} />
+          <Layer id="gap-hl-outline" type="line" paint={{ 'line-color': '#e53935', 'line-width': 2.5 }} />
+        </Source>
+      </MapGL>
+      {/* Breadcrumb / drill-down navigation */}
+      {drillStack.length > 0 && (
+        <Box sx={{ position: 'absolute', top: 8, left: 8, bgcolor: 'rgba(255,255,255,0.92)', borderRadius: 1, px: 1, py: 0.3, fontSize: '0.7rem', display: 'flex', alignItems: 'center', gap: 0.5, maxWidth: '80%' }}>
+          <Button
+            size="small"
+            onClick={() => setDrillStack(prev => prev.slice(0, -1))}
+            sx={{ fontSize: '0.65rem', minWidth: 0, py: 0, px: 0.5, textTransform: 'none' }}
+          >
+            ‹ Back
+          </Button>
+          <Typography variant="caption" color="text.secondary" sx={{ mx: 0.3 }}>|</Typography>
+          <Button
+            size="small"
+            onClick={() => setDrillStack([])}
+            sx={{ fontSize: '0.65rem', minWidth: 0, py: 0, px: 0.5, textTransform: 'none' }}
+          >
+            Top
+          </Button>
+          {drillStack.map((level, i) => (
+            <Box key={i} sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+              <Typography variant="caption" color="text.secondary">›</Typography>
+              <Button
+                size="small"
+                onClick={() => setDrillStack(prev => prev.slice(0, i + 1))}
+                disabled={i === drillStack.length - 1}
+                sx={{ fontSize: '0.65rem', minWidth: 0, py: 0, px: 0.5, textTransform: 'none' }}
+              >
+                {level.regionName}
+              </Button>
+            </Box>
+          ))}
+        </Box>
+      )}
+      {/* Loading overlay */}
+      {drillLoading && (
+        <Box sx={{ position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%, -50%)', bgcolor: 'rgba(255,255,255,0.8)', borderRadius: 1, p: 1 }}>
+          <CircularProgress size={24} />
+        </Box>
+      )}
+      {/* Legend */}
+      <Box sx={{ position: 'absolute', bottom: 8, left: 8, bgcolor: 'rgba(255,255,255,0.9)', borderRadius: 1, px: 1, py: 0.5, fontSize: '0.7rem', display: 'flex', gap: 1.5, flexWrap: 'wrap' }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          <Box sx={{ width: 12, height: 12, bgcolor: '#ff8833', opacity: 0.6, borderRadius: '2px' }} />
+          Gap
+        </Box>
+        {siblingFeatures.slice(0, 6).map(s => (
+          <Box key={s.regionId} sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+            <Box sx={{ width: 12, height: 12, bgcolor: s.isSelected ? '#1976d2' : s.color, opacity: 0.5, borderRadius: '2px' }} />
+            {s.name}{s.isSelected ? ' \u2713' : ''}
+          </Box>
+        ))}
+        {siblingFeatures.length > 6 && <Box>+{siblingFeatures.length - 6} more</Box>}
+      </Box>
+      {/* Hint */}
+      {drillStack.length === 0 && siblingFeatures.length > 0 && (
+        <Box sx={{ position: 'absolute', top: 8, left: 8, bgcolor: 'rgba(255,255,255,0.85)', borderRadius: 1, px: 1, py: 0.3, fontSize: '0.65rem', color: 'text.secondary' }}>
+          Click a region to drill down or select as target
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+/** Tree-structured display of gap divisions. Groups children under their GADM parents. */
+export function GapDivisionTree({ gapDivisions, parentRegionId: _parentRegionId, parentRegionName, subtreeRegions, highlightedGapId, onHighlight, isMutating, onAssign, onNewRegion, mapSelectedRegionId, worldViewId }: {
+  gapDivisions: CoverageGapDivision[];
+  parentRegionId: number;
+  /** Parent region name — used for building hierarchy path tooltips */
+  parentRegionName: string;
+  /** All regions in the parent's subtree — shown as assign targets */
+  subtreeRegions: Array<{ id: number; name: string; depth: number }>;
+  /** Currently highlighted gap division ID */
+  highlightedGapId: number | null;
+  onHighlight: (id: number | null) => void;
+  isMutating: boolean;
+  onAssign: (gap: CoverageGapDivision, descendantIds: number[], targetRegionId: number) => void;
+  onNewRegion: (gap: CoverageGapDivision, descendantIds: number[]) => void;
+  /** Region selected from the map — synced to all assign dropdowns */
+  mapSelectedRegionId?: number | null;
+  /** World view ID — used for searching regions outside the subtree */
+  worldViewId: number;
+}) {
+  // Track which gap row has the "Move to..." search open
+  const [moveSearchOpenFor, setMoveSearchOpenFor] = useState<number | null>(null);
+
+  // Build tree: find which gap divisions are children of other gap divisions
+  const gapIdSet = new Set(gapDivisions.map(g => g.divisionId));
+  const childrenOf = new Map<number, CoverageGapDivision[]>();
+  const roots: CoverageGapDivision[] = [];
+
+  for (const gap of gapDivisions) {
+    if (gap.gadmParentId != null && gapIdSet.has(gap.gadmParentId)) {
+      const siblings = childrenOf.get(gap.gadmParentId) ?? [];
+      siblings.push(gap);
+      childrenOf.set(gap.gadmParentId, siblings);
+    } else {
+      roots.push(gap);
+    }
+  }
+
+  // Collect all descendant IDs within the gap set for a given division
+  function collectDescendantIds(divId: number): number[] {
+    const children = childrenOf.get(divId) ?? [];
+    const result: number[] = [];
+    for (const child of children) {
+      result.push(child.divisionId);
+      result.push(...collectDescendantIds(child.divisionId));
+    }
+    return result;
+  }
+
+  function renderGapRow(gap: CoverageGapDivision, depth: number) {
+    const children = childrenOf.get(gap.divisionId) ?? [];
+    const descendantIds = collectDescendantIds(gap.divisionId);
+    const hasGapChildren = children.length > 0;
+    const isHighlighted = highlightedGapId === gap.divisionId;
+
+    return (
+      <Box key={gap.divisionId}>
+        <Box
+          onMouseEnter={() => onHighlight(gap.divisionId)}
+          onMouseLeave={() => onHighlight(null)}
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            py: 0.75,
+            pl: depth * 2.5,
+            borderBottom: '1px solid',
+            borderColor: 'divider',
+            flexWrap: 'wrap',
+            bgcolor: isHighlighted ? 'action.selected' : undefined,
+            cursor: 'pointer',
+          }}
+        >
+          <Box sx={{ flex: 1, minWidth: 200 }}>
+            <Typography variant="body2" fontWeight={500}>
+              {gap.name}
+              {hasGapChildren && (
+                <Typography component="span" variant="caption" color="text.secondary" sx={{ ml: 0.5 }}>
+                  (+{descendantIds.length} sub)
+                </Typography>
+              )}
+            </Typography>
+            <Typography variant="caption" color="text.secondary">{gap.path}</Typography>
+            <Typography variant="caption" color="text.secondary" sx={{ ml: 1 }}>
+              {gap.areaKm2.toLocaleString()} km²
+            </Typography>
+          </Box>
+          {subtreeRegions.length > 0 && (
+            <GapAssignSelect
+              subtreeRegions={subtreeRegions}
+              defaultRegionId={gap.suggestedTarget?.regionId}
+              mapSelectedRegionId={mapSelectedRegionId}
+              isMutating={isMutating}
+              hasGapChildren={hasGapChildren}
+              onSelect={(regionId) => onAssign(gap, descendantIds, regionId)}
+              parentRegionName={parentRegionName}
+            />
+          )}
+          <Button
+            size="small"
+            variant="outlined"
+            color="info"
+            onClick={() => onNewRegion(gap, descendantIds)}
+            disabled={isMutating}
+            sx={{ fontSize: '0.7rem', py: 0.25, minHeight: 0 }}
+          >
+            New Region
+          </Button>
+          <Button
+            size="small"
+            variant="outlined"
+            color="warning"
+            onClick={() => setMoveSearchOpenFor(moveSearchOpenFor === gap.divisionId ? null : gap.divisionId)}
+            disabled={isMutating}
+            sx={{ fontSize: '0.7rem', py: 0.25, minHeight: 0 }}
+          >
+            Move...
+          </Button>
+        </Box>
+        {moveSearchOpenFor === gap.divisionId && (
+          <Box sx={{ pl: depth * 2.5 + 1, py: 0.5 }}>
+            <MoveToSearch
+              worldViewId={worldViewId}
+              isMutating={isMutating}
+              hasGapChildren={hasGapChildren}
+              onSelect={(regionId) => {
+                setMoveSearchOpenFor(null);
+                onAssign(gap, descendantIds, regionId);
+              }}
+              onClose={() => setMoveSearchOpenFor(null)}
+            />
+          </Box>
+        )}
+        {children.map(child => renderGapRow(child, depth + 1))}
+      </Box>
+    );
+  }
+
+  // Sort roots by area descending
+  roots.sort((a, b) => b.areaKm2 - a.areaKm2);
+
+  return (
+    <>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+        {gapDivisions.length} gap division{gapDivisions.length === 1 ? '' : 's'}.
+        Assigning a parent also handles its children.
+      </Typography>
+      {roots.map(gap => renderGapRow(gap, 0))}
+    </>
+  );
+}

--- a/frontend/src/components/admin/ImportTreeDialogs.tsx
+++ b/frontend/src/components/admin/ImportTreeDialogs.tsx
@@ -1,0 +1,921 @@
+import { useState, useRef, useMemo, useCallback, useEffect } from 'react';
+import {
+  Box,
+  Typography,
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  Autocomplete,
+  Checkbox,
+  CircularProgress,
+  Link as MuiLink,
+} from '@mui/material';
+import LinkIcon from '@mui/icons-material/Link';
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+import MapGL, { NavigationControl, Source, Layer, type MapRef } from 'react-map-gl/maplibre';
+import * as turf from '@turf/turf';
+import { type searchDivisions } from '../../api/divisions';
+import type {
+  RenameDialogState,
+  ReparentDialogState,
+  SuggestChildrenState,
+  DivisionSearchDialogState,
+  GapAnalysisState,
+  FlatRegionItem,
+} from './useImportTreeDialogs';
+import { GapDivisionTree, GapContextMap } from './GapAnalysis';
+import { mergeGeometries, mergeGeomsIntoSibling } from './CvMatchMap';
+import { type MatchTreeNode, type ReviewChildAction, getChildrenRegionGeometry } from '../../api/admin/worldViewImport';
+
+// COVERAGE_MAP_STYLE is duplicated in GapAnalysis.tsx to break the circular
+// import between these two modules (they mutually import component helpers).
+const COVERAGE_MAP_STYLE = 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json';
+
+/** Extracted to avoid re-rendering the entire tree on every keystroke */
+export function ManualFixDialog({ state, onClose, onSubmit, isPending }: {
+  state: { regionId: number; regionName: string } | null;
+  onClose: () => void;
+  onSubmit: (regionId: number, fixNote: string | undefined) => void;
+  isPending: boolean;
+}) {
+  const [fixNote, setFixNote] = useState('');
+
+  // Reset note when dialog opens with a new region
+  const prevRegionId = state?.regionId;
+  const [lastRegionId, setLastRegionId] = useState<number | undefined>();
+  if (prevRegionId !== lastRegionId) {
+    setLastRegionId(prevRegionId);
+    if (prevRegionId != null) setFixNote('');
+  }
+
+  return (
+    <Dialog open={!!state} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Mark as Needing Manual Fix</DialogTitle>
+      <DialogContent>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          {state?.regionName}
+        </Typography>
+        <TextField
+          autoFocus
+          fullWidth
+          multiline
+          minRows={2}
+          maxRows={4}
+          label="What needs to be fixed?"
+          placeholder="e.g., Borders don't match GADM, need to split into sub-regions..."
+          value={fixNote}
+          onChange={(e) => setFixNote(e.target.value)}
+          slotProps={{ htmlInput: { maxLength: 500 } }}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button
+          variant="contained"
+          color="warning"
+          onClick={() => {
+            if (state) {
+              onSubmit(state.regionId, fixNote || undefined);
+              onClose();
+            }
+          }}
+          disabled={isPending}
+        >
+          Mark for Fix
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+/** Confirmation dialog for removing a region from the import tree */
+export function RemoveRegionDialog({ state, onClose, onConfirm, isPending }: {
+  state: { regionId: number; regionName: string; hasChildren: boolean; hasDivisions: boolean } | null;
+  onClose: () => void;
+  onConfirm: (regionId: number, reparentChildren: boolean, reparentDivisions: boolean) => void;
+  isPending: boolean;
+}) {
+  const hasChildren = state?.hasChildren ?? false;
+  const hasDivisions = state?.hasDivisions ?? false;
+
+  let message: string;
+  if (hasChildren && hasDivisions) {
+    message = 'This region has children and assigned divisions. Choose what to keep:';
+  } else if (hasChildren) {
+    message = 'This region has children. Choose what to do with them:';
+  } else if (hasDivisions) {
+    message = 'This region has assigned GADM divisions. Move them to the parent?';
+  } else {
+    message = 'Remove this region from the import tree?';
+  }
+
+  let actions: React.ReactNode;
+  if (hasChildren) {
+    actions = (
+      <>
+        <Button
+          variant="outlined"
+          color="error"
+          onClick={() => { if (state) onConfirm(state.regionId, false, false); }}
+          disabled={isPending}
+        >
+          Remove entire branch
+        </Button>
+        <Button
+          variant="contained"
+          color="warning"
+          onClick={() => { if (state) onConfirm(state.regionId, true, hasDivisions); }}
+          disabled={isPending}
+        >
+          Move children{hasDivisions ? ' & divisions' : ''} up
+        </Button>
+      </>
+    );
+  } else if (hasDivisions) {
+    actions = (
+      <>
+        <Button
+          variant="outlined"
+          color="error"
+          onClick={() => { if (state) onConfirm(state.regionId, false, false); }}
+          disabled={isPending}
+        >
+          Remove with divisions
+        </Button>
+        <Button
+          variant="contained"
+          color="warning"
+          onClick={() => { if (state) onConfirm(state.regionId, false, true); }}
+          disabled={isPending}
+        >
+          Move divisions to parent
+        </Button>
+      </>
+    );
+  } else {
+    actions = (
+      <Button
+        variant="contained"
+        color="error"
+        onClick={() => { if (state) onConfirm(state.regionId, false, false); }}
+        disabled={isPending}
+      >
+        Remove
+      </Button>
+    );
+  }
+
+  return (
+    <Dialog open={!!state} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>Remove Region</DialogTitle>
+      <DialogContent>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+          {state?.regionName}
+        </Typography>
+        <Typography variant="body2">{message}</Typography>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        {actions}
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+const CHILD_COLORS = ['#3388ff', '#33aa55', '#9955cc', '#cc7733', '#5599dd', '#aa3366', '#55bb88', '#8866cc', '#dd5555', '#44bbaa', '#7766bb', '#bb8844'];
+
+/** Right-side panel: children's divisions (unified or color-coded) or geoshape */
+function CoverageRightPanel({ data, fitToAll }: {
+  data: {
+    regionId: number;
+    worldViewId: number;
+    childrenGeometry: GeoJSON.Geometry | null;
+    geoshapeGeometry?: GeoJSON.Geometry | null;
+  };
+  fitToAll: (mapRef: React.RefObject<MapRef | null>) => void;
+}) {
+  const mapRef = useRef<MapRef>(null);
+  const hasGeoshape = data.geoshapeGeometry != null;
+  const hasChildren = data.childrenGeometry != null;
+
+  // Color-coded children view
+  const [rightMode, setRightMode] = useState<'unified' | 'colored'>('unified');
+  const [childRegions, setChildRegions] = useState<Array<{ regionId: number; name: string; geometry: GeoJSON.Geometry }> | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  // Reset when region changes
+  useEffect(() => { setRightMode('unified'); setChildRegions(null); }, [data.regionId]);
+
+  const handleToggle = useCallback(async () => {
+    setRightMode(prev => prev === 'colored' ? 'unified' : 'colored');
+    if (rightMode !== 'unified' || childRegions) return; // toggling off, or already loaded
+    setLoading(true);
+    try {
+      const result = await getChildrenRegionGeometry(data.worldViewId, data.regionId);
+      setChildRegions(result.childRegions);
+    } finally {
+      setLoading(false);
+    }
+  }, [rightMode, childRegions, data.worldViewId, data.regionId]);
+
+  const coloredChildren = useMemo(() =>
+    (childRegions ?? []).map((c, i) => ({
+      ...c,
+      color: CHILD_COLORS[i % CHILD_COLORS.length],
+      fc: {
+        type: 'FeatureCollection' as const,
+        features: [{ type: 'Feature' as const, properties: { name: c.name }, geometry: c.geometry }],
+      },
+    })),
+  [childRegions]);
+
+  let rightLabel = 'Wikidata geoshape (expected shape)';
+  if (rightMode === 'colored') rightLabel = 'Subregions (color-coded)';
+  else if (hasChildren) rightLabel = "Children's divisions (all descendants)";
+
+  let buttonLabel = 'Color by subregion';
+  if (loading) buttonLabel = 'Loading...';
+  else if (rightMode === 'colored') buttonLabel = 'Show unified';
+
+  if (!hasChildren && !hasGeoshape) {
+    return (
+      <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+        <Typography variant="subtitle2" sx={{ mb: 0.5 }}>{rightLabel}</Typography>
+        <Box sx={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', bgcolor: 'action.hover', borderRadius: 1 }}>
+          <Typography color="text.secondary">No data to compare</Typography>
+        </Box>
+      </Box>
+    );
+  }
+
+  const geojsonData = hasChildren
+    ? { type: 'Feature' as const, properties: {}, geometry: data.childrenGeometry! }
+    : { type: 'Feature' as const, properties: {}, geometry: data.geoshapeGeometry! };
+  const fillColor = hasChildren ? '#ff8833' : '#22c55e';
+  const showColored = rightMode === 'colored' && hasChildren;
+
+  return (
+    <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>
+        <Typography variant="subtitle2" sx={{ flex: 1 }}>{rightLabel}</Typography>
+        {hasChildren && (
+          <Button
+            size="small"
+            variant={rightMode === 'colored' ? 'contained' : 'outlined'}
+            onClick={handleToggle}
+            disabled={loading}
+            sx={{ fontSize: '0.7rem', py: 0.25, px: 1, minWidth: 0 }}
+          >
+            {buttonLabel}
+          </Button>
+        )}
+      </Box>
+      <MapGL
+        ref={mapRef}
+        initialViewState={{ longitude: 0, latitude: 0, zoom: 1 }}
+        style={{ width: '100%', flex: 1, minHeight: showColored ? 280 : 350 }}
+        mapStyle={COVERAGE_MAP_STYLE}
+        onLoad={() => fitToAll(mapRef)}
+      >
+        <NavigationControl position="top-right" showCompass={false} />
+        {showColored ? (
+          coloredChildren.map((c, i) => (
+            <Source key={`child-${c.regionId}`} id={`child-${i}`} type="geojson" data={c.fc}>
+              <Layer id={`child-fill-${i}`} type="fill" paint={{ 'fill-color': c.color, 'fill-opacity': 0.45 }} />
+              <Layer id={`child-outline-${i}`} type="line" paint={{ 'line-color': c.color, 'line-width': 1.5 }} />
+            </Source>
+          ))
+        ) : (
+          <Source id="right-geo" type="geojson" data={geojsonData}>
+            <Layer id="right-fill" type="fill" paint={{ 'fill-color': fillColor, 'fill-opacity': 0.4 }} />
+            <Layer id="right-outline" type="line" paint={{ 'line-color': fillColor, 'line-width': 2 }} />
+          </Source>
+        )}
+      </MapGL>
+      {showColored && coloredChildren.length > 0 && (
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 0.5, maxHeight: 60, overflow: 'auto' }}>
+          {coloredChildren.map(c => (
+            <Box key={c.regionId} sx={{ display: 'flex', alignItems: 'center', gap: 0.5, px: 0.5 }}>
+              <Box sx={{ width: 10, height: 10, borderRadius: '50%', bgcolor: c.color, flexShrink: 0 }} />
+              <Typography variant="caption" noWrap sx={{ maxWidth: 120 }}>{c.name}</Typography>
+            </Box>
+          ))}
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+/** Side-by-side map dialog comparing parent's own divisions vs children's divisions */
+export function CoverageCompareDialog({ data, onClose, onAnalyzeGaps }: {
+  data: {
+    regionId: number;
+    regionName: string;
+    worldViewId: number;
+    loading: boolean;
+    parentGeometry: GeoJSON.Geometry | null;
+    childrenGeometry: GeoJSON.Geometry | null;
+    geoshapeGeometry?: GeoJSON.Geometry | null;
+  } | null;
+  onClose: () => void;
+  onAnalyzeGaps?: (regionId: number) => void;
+}) {
+  const leftMapRef = useRef<MapRef>(null);
+
+  const hasGeoshape = data?.geoshapeGeometry != null;
+  const hasChildren = data?.childrenGeometry != null;
+
+  // Fit both maps to the combined extent
+  const allGeometries = [data?.parentGeometry, data?.childrenGeometry, data?.geoshapeGeometry].filter(Boolean) as GeoJSON.Geometry[];
+  const combinedBbox = useMemo(() => {
+    if (allGeometries.length === 0) return null;
+    const fc: GeoJSON.FeatureCollection = {
+      type: 'FeatureCollection',
+      features: allGeometries.map(g => ({ type: 'Feature' as const, properties: {}, geometry: g })),
+    };
+    return turf.bbox(fc) as [number, number, number, number];
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data?.parentGeometry, data?.childrenGeometry, data?.geoshapeGeometry]);
+
+  const fitToAll = useCallback((mapRef: React.RefObject<MapRef | null>) => {
+    if (!mapRef.current || !combinedBbox) return;
+    mapRef.current.fitBounds([[combinedBbox[0], combinedBbox[1]], [combinedBbox[2], combinedBbox[3]]], { padding: 40, duration: 0 });
+  }, [combinedBbox]);
+
+  return (
+    <Dialog open={data != null} onClose={onClose} maxWidth="lg" fullWidth>
+      <DialogTitle>Coverage Comparison: {data?.regionName}</DialogTitle>
+      <DialogContent>
+        {data?.loading ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+            <CircularProgress />
+          </Box>
+        ) : (
+          <Box sx={{ display: 'flex', gap: 2, minHeight: 400 }}>
+            {/* Left: assigned divisions + geoshape overlay */}
+            <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+              <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
+                Assigned divisions{hasGeoshape && hasChildren ? ' + geoshape outline' : ''}
+              </Typography>
+              {data?.parentGeometry ? (
+                <MapGL
+                  ref={leftMapRef}
+                  initialViewState={{ longitude: 0, latitude: 0, zoom: 1 }}
+                  style={{ width: '100%', flex: 1, minHeight: 350 }}
+                  mapStyle={COVERAGE_MAP_STYLE}
+                  onLoad={() => fitToAll(leftMapRef)}
+                >
+                  <NavigationControl position="top-right" showCompass={false} />
+                  <Source id="parent-geo" type="geojson" data={{ type: 'Feature', properties: {}, geometry: data.parentGeometry }}>
+                    <Layer id="parent-fill" type="fill" paint={{ 'fill-color': '#3388ff', 'fill-opacity': 0.4 }} />
+                    <Layer id="parent-outline" type="line" paint={{ 'line-color': '#3388ff', 'line-width': 2 }} />
+                  </Source>
+                  {hasGeoshape && hasChildren && (
+                    <Source id="geoshape-overlay" type="geojson" data={{ type: 'Feature', properties: {}, geometry: data.geoshapeGeometry! }}>
+                      <Layer id="geoshape-overlay-outline" type="line" paint={{ 'line-color': '#22c55e', 'line-width': 2, 'line-dasharray': [4, 3] }} />
+                    </Source>
+                  )}
+                </MapGL>
+              ) : (
+                <Box sx={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', bgcolor: 'action.hover', borderRadius: 1 }}>
+                  <Typography color="text.secondary">No divisions assigned</Typography>
+                </Box>
+              )}
+            </Box>
+
+            {/* Right: children panel with unified/colored toggle */}
+            {data && (
+              <CoverageRightPanel data={data} fitToAll={fitToAll} />
+            )}
+          </Box>
+        )}
+      </DialogContent>
+      <DialogActions>
+        {onAnalyzeGaps && data && !data.loading && hasChildren && (
+          <Button
+            variant="outlined"
+            size="small"
+            onClick={() => { onAnalyzeGaps(data.regionId); onClose(); }}
+            sx={{ mr: 'auto' }}
+          >
+            Find Gap Divisions
+          </Button>
+        )}
+        <Button onClick={onClose}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+/** Simple text-field dialog for renaming a region */
+export function RenameRegionDialog({ state, onClose, onSubmit, onNameChange }: {
+  state: RenameDialogState | null;
+  onClose: () => void;
+  onSubmit: () => void;
+  onNameChange: (value: string) => void;
+}) {
+  return (
+    <Dialog open={state != null} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>Rename Region</DialogTitle>
+      <DialogContent>
+        <TextField
+          autoFocus
+          fullWidth
+          size="small"
+          label="Region name"
+          value={state?.newName ?? ''}
+          onChange={(e) => onNameChange(e.target.value)}
+          onKeyDown={(e) => { if (e.key === 'Enter') onSubmit(); }}
+          sx={{ mt: 1 }}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} size="small">Cancel</Button>
+        <Button onClick={onSubmit} variant="contained" size="small"
+          disabled={!state?.newName.trim() || state?.newName.trim() === state?.currentName}>
+          Rename
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+/** Autocomplete dialog for moving a region to a new parent */
+export function ReparentRegionDialog({ state, onClose, onSubmit, onParentChange, flatRegionList }: {
+  state: ReparentDialogState | null;
+  onClose: () => void;
+  onSubmit: () => void;
+  onParentChange: (parentId: number | null) => void;
+  flatRegionList: FlatRegionItem[];
+}) {
+  return (
+    <Dialog open={state != null} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>Move &quot;{state?.regionName}&quot;</DialogTitle>
+      <DialogContent>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+          Select new parent region:
+        </Typography>
+        <Autocomplete
+          size="small"
+          options={flatRegionList.filter(r => r.id !== state?.regionId)}
+          getOptionLabel={(opt) => '\u00A0'.repeat(opt.depth * 2) + opt.name}
+          value={flatRegionList.find(r => r.id === state?.selectedParentId) ?? null}
+          onChange={(_e, val) => onParentChange(val?.id ?? null)}
+          renderInput={(params) => <TextField {...params} label="Parent region" placeholder="Search regions..." />}
+          sx={{ mt: 1 }}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} size="small">Cancel</Button>
+        <Button onClick={onSubmit} variant="contained" size="small"
+          disabled={state?.selectedParentId == null}>
+          Move
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+/** Dialog for adding a new child region by name */
+export function AddChildDialog({ parentRegionId, name, onNameChange, onClose, onSubmit, isPending }: {
+  parentRegionId: number | null;
+  name: string;
+  onNameChange: (value: string) => void;
+  onClose: () => void;
+  onSubmit: () => void;
+  isPending: boolean;
+}) {
+  return (
+    <Dialog open={parentRegionId != null} onClose={onClose}>
+      <DialogTitle>Add Child Region</DialogTitle>
+      <DialogContent>
+        <TextField
+          autoFocus
+          fullWidth
+          label="Region name"
+          value={name}
+          onChange={(e) => onNameChange(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && name.trim() && parentRegionId) {
+              onSubmit();
+            }
+          }}
+          sx={{ mt: 1 }}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button
+          variant="contained"
+          onClick={onSubmit}
+          disabled={!name.trim() || isPending}
+        >
+          Add
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+/** Dialog showing AI-reviewed children actions grouped by type */
+export function AISuggestChildrenDialog({ state, onClose, onToggle, onSubmit, isPending }: {
+  state: SuggestChildrenState | null;
+  onClose: () => void;
+  onToggle: (key: string) => void;
+  onSubmit: () => void;
+  isPending: boolean;
+}) {
+  if (!state) return null;
+
+  const addActions = state.result.actions.filter(a => a.type === 'add');
+  const removeActions = state.result.actions.filter(a => a.type === 'remove');
+  const renameActions = state.result.actions.filter(a => a.type === 'rename');
+  const enrichActions = state.result.actions.filter(a => a.type === 'enrich');
+
+  const renderEnrichment = (action: ReviewChildAction) => {
+    if (action.type === 'remove' || !action.verified) return null;
+    return (
+      <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+        {action.sourceUrl && (
+          <Typography variant="caption" color="text.secondary">
+            <LinkIcon sx={{ fontSize: 12, mr: 0.25, verticalAlign: 'middle' }} />
+            <MuiLink href={action.sourceUrl} target="_blank" rel="noopener" sx={{ fontSize: 'inherit' }}>
+              {decodeURIComponent(action.sourceUrl.split('/wiki/')[1] ?? '')}
+            </MuiLink>
+          </Typography>
+        )}
+        {action.sourceExternalId && (
+          <Typography variant="caption" color="text.secondary">
+            <MuiLink
+              href={`https://www.wikidata.org/wiki/${action.sourceExternalId}`}
+              target="_blank"
+              rel="noopener"
+              sx={{ fontSize: 'inherit' }}
+            >
+              {action.sourceExternalId}
+            </MuiLink>
+          </Typography>
+        )}
+      </Box>
+    );
+  };
+
+  const renderSection = (
+    title: string,
+    actions: ReviewChildAction[],
+    color: string,
+  ) => {
+    if (actions.length === 0) return null;
+    return (
+      <Box sx={{ mb: 2 }}>
+        <Typography variant="subtitle2" color={color} sx={{ mb: 0.5 }}>
+          {title} ({actions.length})
+        </Typography>
+        {actions.map((a) => {
+          const key = `${a.type}:${a.name}`;
+          return (
+            <Box key={key} sx={{ display: 'flex', alignItems: 'flex-start', gap: 1, py: 0.5 }}>
+              <Checkbox
+                size="small"
+                checked={state.selected.has(key)}
+                onChange={() => onToggle(key)}
+                sx={{ p: 0.25, mt: 0.25 }}
+              />
+              <Box sx={{ flex: 1 }}>
+                <Typography variant="body2">
+                  {a.type === 'rename' ? (
+                    <>{a.name} <ArrowForwardIcon sx={{ fontSize: 14, verticalAlign: 'middle', mx: 0.5 }} /> {a.newName}</>
+                  ) : (
+                    a.name
+                  )}
+                </Typography>
+                <Typography variant="caption" color="text.secondary">{a.reason}</Typography>
+                {renderEnrichment(a)}
+              </Box>
+            </Box>
+          );
+        })}
+      </Box>
+    );
+  };
+
+  return (
+    <Dialog open onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Review Children for &quot;{state.regionName}&quot;</DialogTitle>
+      <DialogContent>
+        {state.result.analysis && (
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            {state.result.analysis}
+          </Typography>
+        )}
+        {state.result.actions.length === 0 && (
+          <Typography variant="body2">All children look correct — no changes suggested.</Typography>
+        )}
+        {renderSection('Add', addActions, 'success.main')}
+        {renderSection('Remove', removeActions, 'error.main')}
+        {renderSection('Rename', renameActions, 'warning.main')}
+        {renderSection('Enrich', enrichActions, 'info.main')}
+        {state.result.stats && (
+          <Typography variant="caption" color="text.secondary" sx={{ mt: 2, display: 'block' }}>
+            {(state.result.stats.inputTokens + state.result.stats.outputTokens).toLocaleString()} tokens
+            {' \u00b7 '}${state.result.stats.cost.toFixed(4)}
+          </Typography>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button
+          variant="contained"
+          disabled={!state.selected.size || isPending}
+          onClick={onSubmit}
+        >
+          Apply {state.selected.size} Selected
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+/** Autocomplete search dialog for manually assigning a GADM division to a region */
+export function DivisionSearchDialog({ state, onClose, onSelect, query, results, loading, onInputChange }: {
+  state: DivisionSearchDialogState | null;
+  onClose: () => void;
+  onSelect: (divisionId: number) => void;
+  query: string;
+  results: Awaited<ReturnType<typeof searchDivisions>>;
+  loading: boolean;
+  onInputChange: (_e: unknown, value: string) => void;
+}) {
+  return (
+    <Dialog
+      open={state != null}
+      onClose={onClose}
+      maxWidth="sm"
+      fullWidth
+    >
+      <DialogTitle>Assign Division to &quot;{state?.regionName}&quot;</DialogTitle>
+      <DialogContent>
+        <Autocomplete
+          size="small"
+          options={results}
+          getOptionLabel={(opt) => `${opt.name} (${opt.path})`}
+          filterOptions={(x) => x}
+          inputValue={query}
+          onInputChange={onInputChange}
+          loading={loading}
+          onChange={(_e, val) => {
+            if (val && state) {
+              onSelect(val.id);
+            }
+          }}
+          renderOption={(props, opt) => (
+            <li {...props} key={opt.id}>
+              <Box>
+                <Typography variant="body2">{opt.name}</Typography>
+                <Typography variant="caption" color="text.secondary">{opt.path}</Typography>
+              </Box>
+            </li>
+          )}
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              label="Search GADM divisions"
+              placeholder="Type at least 2 characters..."
+              autoFocus
+              sx={{ mt: 1 }}
+            />
+          )}
+          noOptionsText={query.length < 2 ? 'Type at least 2 characters' : 'No divisions found'}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} size="small">Cancel</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+/** Scrollable gap list content — inline helper split out of GapAnalysisDialog for complexity/nesting compliance */
+function GapDialogContent({ effectiveState, gapMapSelectedRegionId, subtreeRegions, worldViewId, highlightedGapId, setHighlightedGapId, isMutating, setLastMutatedRegionId, acceptAllMutation, addChildMutation, localModified, setLocalState }: {
+  effectiveState: GapAnalysisState;
+  gapMapSelectedRegionId: number | null;
+  subtreeRegions: Array<{ id: number; name: string; depth: number }>;
+  worldViewId: number;
+  highlightedGapId: number | null;
+  setHighlightedGapId: React.Dispatch<React.SetStateAction<number | null>>;
+  isMutating: boolean;
+  setLastMutatedRegionId: (id: number) => void;
+  acceptAllMutation: { mutate: (assignments: Array<{ regionId: number; divisionId: number }>) => void };
+  addChildMutation: { mutate: (args: { parentRegionId: number; name: string }, opts?: { onSuccess?: (result: { regionId: number } | undefined) => void }) => void; isPending: boolean };
+  localModified: React.MutableRefObject<boolean>;
+  setLocalState: React.Dispatch<React.SetStateAction<GapAnalysisState | null>>;
+}) {
+  // Remove resolved gaps from local state and optionally fold their geometry into a sibling region
+  const removeGapsFromLocalState = useCallback((
+    gap: { divisionId: number; name: string; geometry?: GeoJSON.Geometry | null },
+    descendantIds: number[],
+    apply: (prev: GapAnalysisState, removeIds: Set<number>, removedGeoms: GeoJSON.Geometry[]) => GapAnalysisState,
+  ) => {
+    const removeIds = new Set([gap.divisionId, ...descendantIds]);
+    const removedGeoms = effectiveState.gapDivisions
+      .filter(d => removeIds.has(d.divisionId) && d.geometry)
+      .map(d => d.geometry!);
+    setLocalState(prev => prev ? apply(prev, removeIds, removedGeoms) : prev);
+  }, [effectiveState, setLocalState]);
+
+  const handleAssign = useCallback((
+    gap: { divisionId: number; name: string; geometry?: GeoJSON.Geometry | null },
+    descendantIds: number[],
+    targetRegionId: number,
+  ) => {
+    setLastMutatedRegionId(targetRegionId);
+    acceptAllMutation.mutate([{ regionId: targetRegionId, divisionId: gap.divisionId }]);
+    localModified.current = true;
+    removeGapsFromLocalState(gap, descendantIds, (prev, removeIds, removedGeoms) => ({
+      ...prev,
+      gapDivisions: prev.gapDivisions.filter(d => !removeIds.has(d.divisionId)),
+      siblingRegions: mergeGeomsIntoSibling(prev.siblingRegions, targetRegionId, removedGeoms),
+    }));
+  }, [acceptAllMutation, localModified, removeGapsFromLocalState, setLastMutatedRegionId]);
+
+  const handleNewRegionSuccess = useCallback((
+    gap: { divisionId: number; name: string; geometry?: GeoJSON.Geometry | null },
+    descendantIds: number[],
+    newRegion: { regionId: number } | undefined,
+  ) => {
+    if (newRegion?.regionId) {
+      setLastMutatedRegionId(newRegion.regionId);
+      acceptAllMutation.mutate([{ regionId: newRegion.regionId, divisionId: gap.divisionId }]);
+    }
+    removeGapsFromLocalState(gap, descendantIds, (prev, removeIds, removedGeoms) => {
+      const mergedGeom = mergeGeometries(removedGeoms);
+      const newSiblings = mergedGeom && newRegion?.regionId
+        ? [...prev.siblingRegions, { regionId: newRegion.regionId, name: gap.name, geometry: mergedGeom }]
+        : prev.siblingRegions;
+      return {
+        ...prev,
+        gapDivisions: prev.gapDivisions.filter(d => !removeIds.has(d.divisionId)),
+        siblingRegions: newSiblings,
+      };
+    });
+  }, [acceptAllMutation, removeGapsFromLocalState, setLastMutatedRegionId]);
+
+  const handleNewRegion = useCallback((
+    gap: { divisionId: number; name: string; geometry?: GeoJSON.Geometry | null },
+    descendantIds: number[],
+  ) => {
+    addChildMutation.mutate(
+      { parentRegionId: effectiveState.regionId, name: gap.name },
+      { onSuccess: (newRegion) => handleNewRegionSuccess(gap, descendantIds, newRegion) },
+    );
+  }, [addChildMutation, effectiveState.regionId, handleNewRegionSuccess]);
+
+  if (effectiveState.loading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+  if (effectiveState.gapDivisions.length === 0) {
+    return (
+      <Typography color="text.secondary" sx={{ py: 2 }}>
+        No gap divisions found.
+      </Typography>
+    );
+  }
+  return (
+    <GapDivisionTree
+      gapDivisions={effectiveState.gapDivisions}
+      parentRegionId={effectiveState.regionId}
+      parentRegionName={effectiveState.regionName}
+      mapSelectedRegionId={gapMapSelectedRegionId}
+      subtreeRegions={subtreeRegions}
+      worldViewId={worldViewId}
+      highlightedGapId={highlightedGapId}
+      onHighlight={setHighlightedGapId}
+      isMutating={isMutating}
+      onAssign={handleAssign}
+      onNewRegion={handleNewRegion}
+    />
+  );
+}
+
+/** Full-screen dialog for coverage gap analysis with map and division tree */
+export function GapAnalysisDialog({ state, tree, worldViewId, highlightedGapId, setHighlightedGapId, gapMapSelectedRegionId, setGapMapSelectedRegionId, onClose, setLastMutatedRegionId, acceptAllMutation, addChildMutation, isMutating }: {
+  state: GapAnalysisState | null;
+  tree: MatchTreeNode[] | undefined;
+  worldViewId: number;
+  highlightedGapId: number | null;
+  setHighlightedGapId: React.Dispatch<React.SetStateAction<number | null>>;
+  gapMapSelectedRegionId: number | null;
+  setGapMapSelectedRegionId: React.Dispatch<React.SetStateAction<number | null>>;
+  onClose: () => void;
+  setLastMutatedRegionId: (id: number) => void;
+  acceptAllMutation: { mutate: (assignments: Array<{ regionId: number; divisionId: number }>) => void };
+  addChildMutation: { mutate: (args: { parentRegionId: number; name: string }, opts?: { onSuccess?: (result: { regionId: number } | undefined) => void }) => void; isPending: boolean };
+  isMutating: boolean;
+}) {
+  // Local state setter used from callbacks to remove gaps after assignment.
+  // Syncs from external state on open and when loading completes, but preserves
+  // local modifications (e.g. removed gaps) while not loading.
+  const [localState, setLocalState] = useState<GapAnalysisState | null>(null);
+  const localModified = useRef(false);
+
+  // Sync external state → local state when region changes or loading status changes
+  useEffect(() => {
+    if (!state) { setLocalState(null); localModified.current = false; return; }
+    // Always sync loading state and fresh results; only skip if user made local edits
+    if (state.loading || !localModified.current) {
+      setLocalState(state);
+    }
+  }, [state?.regionId, state?.loading]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const effectiveState = localState?.regionId === state?.regionId ? localState : state;
+
+  if (!effectiveState) return null;
+
+  const subtreeRegions = (() => {
+    if (!tree) return [];
+    const findNode = (nodes: MatchTreeNode[]): MatchTreeNode | null => {
+      for (const n of nodes) {
+        if (n.id === effectiveState.regionId) return n;
+        const found = findNode(n.children);
+        if (found) return found;
+      }
+      return null;
+    };
+    const parent = findNode(tree);
+    if (!parent) return [];
+    const result: Array<{ id: number; name: string; depth: number }> = [];
+    const walk = (nodes: MatchTreeNode[], depth: number) => {
+      for (const n of nodes) {
+        result.push({ id: n.id, name: n.name, depth });
+        walk(n.children, depth + 1);
+      }
+    };
+    walk(parent.children, 0);
+    return result;
+  })();
+
+  return (
+    <Dialog
+      open
+      onClose={onClose}
+      maxWidth="lg"
+      fullWidth
+      slotProps={{ paper: { sx: { height: '90vh', display: 'flex', flexDirection: 'column' } } }}
+    >
+      <DialogTitle sx={{ pb: 1, flexShrink: 0 }}>Coverage Gap Analysis: {effectiveState.regionName}</DialogTitle>
+      {/* Top: source image + context map side by side (sticky) */}
+      <Box sx={{ display: 'flex', gap: 1, px: 3, pb: 1, flexShrink: 0, minHeight: 0 }}>
+        {effectiveState.regionMapUrl && (
+          <Box sx={{ flex: 1, minWidth: 0 }}>
+            <Box
+              component="img"
+              src={`${effectiveState.regionMapUrl}?width=800`}
+              alt={`${effectiveState.regionName} region map`}
+              sx={{ width: '100%', maxHeight: 300, objectFit: 'contain', borderRadius: 1, border: 1, borderColor: 'divider' }}
+            />
+          </Box>
+        )}
+        {!effectiveState.loading && effectiveState.gapDivisions.length > 0 && (
+          <Box sx={{ flex: 1, minWidth: 0 }}>
+            <GapContextMap
+              gapDivisions={effectiveState.gapDivisions}
+              siblingRegions={effectiveState.siblingRegions}
+              worldViewId={worldViewId}
+              highlightedGapId={highlightedGapId}
+              onHighlight={setHighlightedGapId}
+              selectedRegionId={gapMapSelectedRegionId}
+              onRegionSelect={(regionId) => setGapMapSelectedRegionId(regionId)}
+            />
+          </Box>
+        )}
+      </Box>
+      {/* Bottom: scrollable gap list */}
+      <DialogContent sx={{ flex: 1, overflow: 'auto', pt: 1 }}>
+        <GapDialogContent
+          effectiveState={effectiveState}
+          gapMapSelectedRegionId={gapMapSelectedRegionId}
+          subtreeRegions={subtreeRegions}
+          worldViewId={worldViewId}
+          highlightedGapId={highlightedGapId}
+          setHighlightedGapId={setHighlightedGapId}
+          isMutating={isMutating}
+          setLastMutatedRegionId={setLastMutatedRegionId}
+          acceptAllMutation={acceptAllMutation}
+          addChildMutation={addChildMutation}
+          localModified={localModified}
+          setLocalState={setLocalState}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/admin/OverlapResolutionDialog.tsx
+++ b/frontend/src/components/admin/OverlapResolutionDialog.tsx
@@ -1,0 +1,649 @@
+/**
+ * OverlapResolutionDialog — Resolve division overlaps among child regions.
+ *
+ * Shows a side-by-side view: source region map image (left) and MapLibre map
+ * with color-coded child region geometries (right). Below the map, a scrollable
+ * list of overlapping divisions with Keep/Split resolution options.
+ */
+
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  Box,
+  Typography,
+  IconButton,
+  CircularProgress,
+  Button,
+  Chip,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+} from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import CheckIcon from '@mui/icons-material/Check';
+import SkipNextIcon from '@mui/icons-material/SkipNext';
+import MapGL, { NavigationControl, Source, Layer, type MapRef } from 'react-map-gl/maplibre';
+import * as turf from '@turf/turf';
+import {
+  type DivisionOverlapResult,
+  getOverlapDivisionChildren,
+  resolveOverlap,
+  type OverlapGadmChild,
+} from '../../api/admin/worldViewImport';
+import { getChildrenRegionGeometry } from '../../api/admin/wvImportCoverage';
+import type { SiblingRegionGeometry } from '../../api/admin/wvImportCoverage';
+import { fetchDivisionGeometry } from '../../api/divisions';
+import type { GeoJSONGeometry } from '../../types';
+
+const MAP_STYLE = 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json';
+
+const CHILD_COLORS = [
+  '#3388ff', '#33aa55', '#9955cc', '#cc7733', '#5599dd',
+  '#dd5577', '#55bb88', '#bb7744', '#7755cc', '#cc5533',
+];
+
+/** Placeholder text when the resolution panel has nothing selected. */
+function emptyStateMessage(resolvedCount: number, totalCount: number): string {
+  if (resolvedCount === totalCount) return 'All overlaps resolved!';
+  return 'No overlap selected';
+}
+
+/** Color for the chip in the overlap-list strip. */
+function chipColor(
+  index: number,
+  selectedIndex: number | null,
+  resolvedIndices: Set<number>,
+): 'success' | 'primary' | 'default' {
+  if (resolvedIndices.has(index)) return 'success';
+  if (index === selectedIndex) return 'primary';
+  return 'default';
+}
+
+interface SplitPreviewProps {
+  selectedRegions: DivisionOverlapResult['overlaps'][number]['regions'];
+  splitChildren: OverlapGadmChild[] | null;
+  splitLoading: boolean;
+  splitAssignments: Map<number, number>;
+  applying: boolean;
+  onLoadSplit: () => void;
+  onChangeAssignment: (gadmChildId: number, regionId: number | null) => void;
+  onApplySplit: () => void;
+}
+
+/** Right-hand "Split into GADM children" panel. */
+function SplitPreview({
+  selectedRegions,
+  splitChildren,
+  splitLoading,
+  splitAssignments,
+  applying,
+  onLoadSplit,
+  onChangeAssignment,
+  onApplySplit,
+}: SplitPreviewProps) {
+  if (!splitChildren) {
+    return (
+      <Button
+        variant="outlined"
+        size="small"
+        onClick={onLoadSplit}
+        disabled={splitLoading}
+        startIcon={splitLoading ? <CircularProgress size={14} /> : undefined}
+      >
+        {splitLoading ? 'Loading...' : 'Preview split'}
+      </Button>
+    );
+  }
+  if (splitChildren.length === 0) {
+    return <Typography variant="body2" color="text.secondary">No GADM children available</Typography>;
+  }
+  return (
+    <>
+      {splitChildren.map((c) => (
+        <Box key={c.divisionId} sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>
+          <Typography variant="body2" sx={{ flex: 1, minWidth: 0 }} noWrap title={c.name}>
+            {c.name}
+            {c.areaKm2 != null && (
+              <Typography component="span" variant="caption" color="text.secondary">
+                {' '}({c.areaKm2.toLocaleString()} km²)
+              </Typography>
+            )}
+          </Typography>
+          <FormControl size="small" sx={{ minWidth: 140 }}>
+            <Select
+              value={splitAssignments.get(c.divisionId) ?? ''}
+              displayEmpty
+              onChange={(e) => {
+                const value = e.target.value;
+                onChangeAssignment(c.divisionId, value === '' ? null : Number(value));
+              }}
+            >
+              <MenuItem value=""><em>Unassigned</em></MenuItem>
+              {selectedRegions.map((r) => (
+                <MenuItem key={r.regionId} value={r.regionId}>{r.regionName}</MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </Box>
+      ))}
+      <Button
+        variant="contained"
+        size="small"
+        startIcon={applying ? <CircularProgress size={14} /> : <CheckIcon />}
+        disabled={applying || splitAssignments.size === 0}
+        onClick={onApplySplit}
+        sx={{ mt: 1 }}
+      >
+        Apply split
+      </Button>
+    </>
+  );
+}
+
+interface OverlapResolutionDialogProps {
+  open: boolean;
+  onClose: () => void;
+  worldViewId: number;
+  parentRegionId: number;
+  parentRegionName: string;
+  regionMapUrl: string | null;
+  overlapData: DivisionOverlapResult;
+  onApplied: () => void;
+}
+
+export function OverlapResolutionDialog({
+  open,
+  onClose,
+  worldViewId,
+  parentRegionId,
+  parentRegionName,
+  regionMapUrl,
+  overlapData,
+  onApplied,
+}: OverlapResolutionDialogProps) {
+  const mapRef = useRef<MapRef>(null);
+
+  // Data state
+  const [childGeometries, setChildGeometries] = useState<SiblingRegionGeometry[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Per-division geometries (fetched on demand, cached)
+  const [divisionGeometries, setDivisionGeometries] = useState<Map<number, GeoJSONGeometry>>(new Map());
+  const [divGeoLoading, setDivGeoLoading] = useState(false);
+
+  // Interaction state
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+  const [resolvedIndices, setResolvedIndices] = useState<Set<number>>(new Set());
+  const [applying, setApplying] = useState(false);
+  const [applyError, setApplyError] = useState<string | null>(null);
+
+  // Resolution choice per overlap
+  const [keepChoice, setKeepChoice] = useState<Map<number, number>>(new Map()); // overlapIndex → regionId
+
+  // Split preview
+  const [splitChildren, setSplitChildren] = useState<OverlapGadmChild[] | null>(null);
+  const [splitLoading, setSplitLoading] = useState(false);
+  const [splitAssignments, setSplitAssignments] = useState<Map<number, number>>(new Map()); // gadmChildId → regionId
+
+  const overlaps = overlapData.overlaps;
+
+  // Load child geometries on open
+  useEffect(() => {
+    if (!open) return;
+    setLoading(true);
+    setError(null);
+    setChildGeometries(null);
+    setSelectedIndex(overlaps.length > 0 ? 0 : null);
+    setResolvedIndices(new Set());
+    setDivisionGeometries(new Map());
+    setKeepChoice(new Map());
+    setSplitChildren(null);
+    setSplitAssignments(new Map());
+
+    getChildrenRegionGeometry(worldViewId, parentRegionId)
+      .then((geoResult) => {
+        setChildGeometries(geoResult.childRegions);
+      })
+      .catch((err) => {
+        setError(err instanceof Error ? err.message : 'Failed to load geometries');
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, [open, worldViewId, parentRegionId, overlaps.length]);
+
+  // Selected overlap
+  // eslint-disable-next-line security/detect-object-injection -- selectedIndex is a typed number|null state; overlaps[] is the source of all valid indices
+  const selected = selectedIndex != null ? overlaps[selectedIndex] : null;
+
+  // Color map: regionId → color
+  const colorMap = useMemo(() => {
+    const map = new Map<number, string>();
+    if (!childGeometries) return map;
+    childGeometries.forEach((cg, i) => {
+      map.set(cg.regionId, CHILD_COLORS[i % CHILD_COLORS.length]);
+    });
+    return map;
+  }, [childGeometries]);
+
+  // Fetch division geometry when selection changes
+  useEffect(() => {
+    if (!selected) return;
+    // Fetch the overlapping division geometry + the "via" divisions
+    const idsToFetch = new Set<number>();
+    idsToFetch.add(selected.divisionId);
+    for (const r of selected.regions) {
+      if (r.viaDivisionId !== selected.divisionId) {
+        idsToFetch.add(r.viaDivisionId);
+      }
+    }
+    const missing = Array.from(idsToFetch).filter(id => !divisionGeometries.has(id));
+    if (missing.length === 0) return;
+
+    setDivGeoLoading(true);
+    Promise.all(
+      missing.map(id => fetchDivisionGeometry(id, worldViewId, { detail: 'medium' }).then(feat => ({ id, feat }))),
+    )
+      .then((results) => {
+        setDivisionGeometries(prev => {
+          const next = new Map(prev);
+          for (const { id, feat } of results) {
+            if (feat?.geometry) next.set(id, feat.geometry as GeoJSONGeometry);
+          }
+          return next;
+        });
+      })
+      .finally(() => setDivGeoLoading(false));
+  }, [selected, worldViewId, divisionGeometries]);
+
+  // Reset split state when selection changes
+  useEffect(() => {
+    setSplitChildren(null);
+    setSplitAssignments(new Map());
+  }, [selectedIndex]);
+
+  // Fit map bounds to selected division
+  useEffect(() => {
+    if (!selected || !mapRef.current) return;
+    const geo = divisionGeometries.get(selected.divisionId);
+    if (!geo) return;
+    try {
+      const [minLng, minLat, maxLng, maxLat] = turf.bbox(geo as GeoJSON.GeoJsonProperties as GeoJSON.Geometry);
+      mapRef.current.fitBounds([[minLng, minLat], [maxLng, maxLat]], { padding: 40, maxZoom: 10 });
+    } catch { /* ignore bbox errors */ }
+  }, [selected, divisionGeometries]);
+
+  // Build GeoJSON for child region backgrounds
+  const childrenGeoJson = useMemo((): GeoJSON.FeatureCollection => {
+    if (!childGeometries) return { type: 'FeatureCollection', features: [] };
+    return {
+      type: 'FeatureCollection',
+      features: childGeometries
+        .filter(cg => cg.geometry)
+        .map((cg, i) => ({
+          type: 'Feature' as const,
+          properties: {
+            regionId: cg.regionId,
+            color: CHILD_COLORS[i % CHILD_COLORS.length],
+            name: cg.name,
+          },
+          geometry: cg.geometry as GeoJSON.Geometry,
+        })),
+    };
+  }, [childGeometries]);
+
+  // Build GeoJSON for the overlapping division
+  const overlapGeoJson = useMemo((): GeoJSON.FeatureCollection => {
+    if (!selected) return { type: 'FeatureCollection', features: [] };
+    const features: GeoJSON.Feature[] = [];
+    const geo = divisionGeometries.get(selected.divisionId);
+    if (geo) {
+      features.push({
+        type: 'Feature',
+        properties: { id: selected.divisionId, type: 'overlap' },
+        geometry: geo as GeoJSON.Geometry,
+      });
+    }
+    // Also show "via" divisions that are different
+    for (const r of selected.regions) {
+      if (r.viaDivisionId !== selected.divisionId) {
+        const viaGeo = divisionGeometries.get(r.viaDivisionId);
+        if (viaGeo) {
+          features.push({
+            type: 'Feature',
+            properties: {
+              id: r.viaDivisionId,
+              type: 'via',
+              color: colorMap.get(r.regionId) ?? '#999',
+            },
+            geometry: viaGeo as GeoJSON.Geometry,
+          });
+        }
+      }
+    }
+    return { type: 'FeatureCollection', features };
+  }, [selected, divisionGeometries, colorMap]);
+
+  // Load GADM children for split preview
+  const handleLoadSplit = useCallback(async () => {
+    if (!selected) return;
+    setSplitLoading(true);
+    try {
+      const regionIds = selected.regions.map(r => r.regionId);
+      // The containment region's `viaDivisionId` points to the GADM ancestor whose
+      // children we need to enumerate. The direct region's `viaDivisionId` would be
+      // the overlap division itself, yielding the wrong children.
+      const containmentRegion = selected.regions.find(r => !r.isDirect);
+      if (!containmentRegion) {
+        throw new Error('Overlap split requires a containment region (non-direct)');
+      }
+      const result = await getOverlapDivisionChildren(worldViewId, containmentRegion.viaDivisionId, regionIds);
+      setSplitChildren(result.children);
+      // Auto-assign: if a child is already assigned, keep that; otherwise leave unassigned
+      const autoAssign = new Map<number, number>();
+      for (const c of result.children) {
+        if (c.assignedToRegionId) {
+          autoAssign.set(c.divisionId, c.assignedToRegionId);
+        }
+      }
+      setSplitAssignments(autoAssign);
+    } catch (err) {
+      setApplyError(err instanceof Error ? err.message : 'Failed to load GADM children');
+    } finally {
+      setSplitLoading(false);
+    }
+  }, [selected, worldViewId]);
+
+  // Advance to next unresolved overlap (declared before handlers that call it).
+  const advanceToNext = useCallback(() => {
+    const nextIdx = overlaps.findIndex((_, i) => i > (selectedIndex ?? -1) && !resolvedIndices.has(i));
+    if (nextIdx >= 0) {
+      setSelectedIndex(nextIdx);
+    } else {
+      // Try from beginning
+      const fromStart = overlaps.findIndex((_, i) => !resolvedIndices.has(i) && i !== selectedIndex);
+      setSelectedIndex(fromStart >= 0 ? fromStart : null);
+    }
+  }, [overlaps, selectedIndex, resolvedIndices]);
+
+  // Apply "keep" resolution
+  const handleKeep = useCallback(async () => {
+    if (!selected || selectedIndex == null) return;
+    const keepRegionId = keepChoice.get(selectedIndex);
+    if (keepRegionId == null) return;
+
+    setApplying(true);
+    setApplyError(null);
+    try {
+      const removeFrom = selected.regions
+        .filter(r => r.regionId !== keepRegionId)
+        .map(r => r.regionId);
+
+      // For containment overlaps: remove the overlapping division from children
+      // that have it via a parent. For direct overlaps: remove from other children.
+      await resolveOverlap(worldViewId, {
+        action: 'keep',
+        divisionId: selected.divisionId,
+        keepInRegionId: keepRegionId,
+        removeFromRegionIds: removeFrom,
+      });
+      setResolvedIndices(prev => new Set(prev).add(selectedIndex));
+      onApplied();
+      advanceToNext();
+    } catch (err) {
+      setApplyError(err instanceof Error ? err.message : 'Failed to apply');
+    } finally {
+      setApplying(false);
+    }
+  }, [selected, selectedIndex, keepChoice, worldViewId, onApplied, advanceToNext]);
+
+  // Apply "split" resolution
+  const handleSplit = useCallback(async () => {
+    if (!selected || selectedIndex == null || !splitChildren) return;
+
+    // Find which region has the coarse parent (the one to split)
+    const splitRegion = selected.regions.find(r => !r.isDirect);
+    if (!splitRegion) return;
+
+    const assignments = splitChildren
+      .filter(c => splitAssignments.has(c.divisionId))
+      .map(c => ({
+        gadmChildId: c.divisionId,
+        targetRegionId: splitAssignments.get(c.divisionId)!,
+      }));
+
+    if (assignments.length === 0) {
+      setApplyError('Assign at least one GADM child to a region');
+      return;
+    }
+
+    setApplying(true);
+    setApplyError(null);
+    try {
+      await resolveOverlap(worldViewId, {
+        action: 'split',
+        divisionId: splitRegion.viaDivisionId,
+        splitRegionId: splitRegion.regionId,
+        assignments,
+      });
+      setResolvedIndices(prev => new Set(prev).add(selectedIndex));
+      onApplied();
+      advanceToNext();
+    } catch (err) {
+      setApplyError(err instanceof Error ? err.message : 'Failed to apply');
+    } finally {
+      setApplying(false);
+    }
+  }, [selected, selectedIndex, splitChildren, splitAssignments, worldViewId, onApplied, advanceToNext]);
+
+  const handleSkip = useCallback(() => advanceToNext(), [advanceToNext]);
+
+  // Check if all has "keep" option (containment overlaps have a split option)
+  const hasContainmentOverlap = selected?.regions.some(r => !r.isDirect) ?? false;
+
+  const resolvedCount = resolvedIndices.size;
+  const totalCount = overlaps.length;
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth={false} fullWidth sx={{ '& .MuiDialog-paper': { maxWidth: '95vw', height: '85vh' } }}>
+      <DialogTitle sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', py: 1 }}>
+        <Typography variant="h6" component="span">
+          Division Overlaps — {parentRegionName}
+          <Chip label={`${resolvedCount}/${totalCount} resolved`} size="small" color={resolvedCount === totalCount ? 'success' : 'default'} sx={{ ml: 1.5 }} />
+        </Typography>
+        <IconButton onClick={onClose} size="small"><CloseIcon /></IconButton>
+      </DialogTitle>
+
+      <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 1.5, p: 1.5, overflow: 'hidden' }}>
+        {loading && (
+          <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', flex: 1 }}>
+            <CircularProgress />
+          </Box>
+        )}
+        {!loading && error && <Typography color="error">{error}</Typography>}
+        {!loading && !error && (
+          <>
+            {/* Map panels */}
+            <Box sx={{ display: 'flex', gap: 1.5, flex: '1 1 60%', minHeight: 0 }}>
+              {/* Left: static region map */}
+              {regionMapUrl && (
+                <Box sx={{ flex: '0 0 42%', border: 1, borderColor: 'divider', borderRadius: 1, overflow: 'hidden', bgcolor: '#f5f5f5', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                  <img
+                    src={`${regionMapUrl}?width=500`}
+                    alt={parentRegionName}
+                    style={{ maxWidth: '100%', maxHeight: '100%', objectFit: 'contain' }}
+                  />
+                </Box>
+              )}
+
+              {/* Right: MapLibre interactive map */}
+              <Box sx={{ flex: 1, border: 1, borderColor: 'divider', borderRadius: 1, overflow: 'hidden', position: 'relative' }}>
+                {divGeoLoading && (
+                  <CircularProgress size={24} sx={{ position: 'absolute', top: 8, left: 8, zIndex: 10 }} />
+                )}
+                <MapGL
+                  ref={mapRef}
+                  style={{ width: '100%', height: '100%' }}
+                  mapStyle={MAP_STYLE}
+                  initialViewState={{ longitude: 0, latitude: 30, zoom: 2 }}
+                >
+                  <NavigationControl position="top-right" />
+
+                  {/* Child region backgrounds */}
+                  <Source id="children-bg" type="geojson" data={childrenGeoJson}>
+                    <Layer id="children-fill" type="fill" paint={{ 'fill-color': ['get', 'color'], 'fill-opacity': 0.15 }} />
+                    <Layer id="children-outline" type="line" paint={{ 'line-color': ['get', 'color'], 'line-width': 1.5, 'line-opacity': 0.5 }} />
+                  </Source>
+
+                  {/* Overlap division + via divisions */}
+                  <Source id="overlap-divs" type="geojson" data={overlapGeoJson}>
+                    <Layer
+                      id="overlap-fill"
+                      type="fill"
+                      filter={['==', ['get', 'type'], 'overlap']}
+                      paint={{ 'fill-color': '#ff5252', 'fill-opacity': 0.35 }}
+                    />
+                    <Layer
+                      id="overlap-border"
+                      type="line"
+                      filter={['==', ['get', 'type'], 'overlap']}
+                      paint={{ 'line-color': '#ff5252', 'line-width': 2.5, 'line-dasharray': [4, 3] }}
+                    />
+                    <Layer
+                      id="via-fill"
+                      type="fill"
+                      filter={['==', ['get', 'type'], 'via']}
+                      paint={{ 'fill-color': ['get', 'color'], 'fill-opacity': 0.25 }}
+                    />
+                    <Layer
+                      id="via-border"
+                      type="line"
+                      filter={['==', ['get', 'type'], 'via']}
+                      paint={{ 'line-color': ['get', 'color'], 'line-width': 2, 'line-dasharray': [6, 3] }}
+                    />
+                  </Source>
+                </MapGL>
+              </Box>
+            </Box>
+
+            {/* Conflict list + resolution panel */}
+            <Box sx={{ flex: '0 0 auto', maxHeight: '40%', overflow: 'auto', border: 1, borderColor: 'divider', borderRadius: 1, p: 1.5 }}>
+              {selected ? (
+                <Box>
+                  {/* Selected conflict info */}
+                  <Typography variant="subtitle1" fontWeight={600} gutterBottom>
+                    {selectedIndex != null ? `${selectedIndex + 1}/${totalCount}` : ''} — {selected.divisionPath}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
+                    Claimed by: {selected.regions.map(r => (
+                      <Chip
+                        key={r.regionId}
+                        label={r.isDirect ? r.regionName : `${r.regionName} (via ${r.viaDivisionName})`}
+                        size="small"
+                        sx={{ mr: 0.5, mb: 0.5, bgcolor: colorMap.get(r.regionId) ?? '#ccc', color: '#fff', fontWeight: 500 }}
+                      />
+                    ))}
+                  </Typography>
+
+                  {applyError && <Typography color="error" variant="body2" sx={{ mb: 1 }}>{applyError}</Typography>}
+
+                  {/* Resolution options */}
+                  <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', alignItems: 'flex-start' }}>
+                    {/* Option 1: Keep in one child */}
+                    <Box sx={{ flex: '1 1 300px', border: 1, borderColor: 'divider', borderRadius: 1, p: 1.5 }}>
+                      <Typography variant="subtitle2" gutterBottom>Keep in one region</Typography>
+                      <FormControl size="small" fullWidth sx={{ mb: 1 }}>
+                        <InputLabel>Assign to</InputLabel>
+                        <Select
+                          value={keepChoice.get(selectedIndex ?? -1) ?? ''}
+                          label="Assign to"
+                          onChange={(e) => {
+                            if (selectedIndex == null) return;
+                            setKeepChoice(prev => new Map(prev).set(selectedIndex, e.target.value as number));
+                          }}
+                        >
+                          {selected.regions.map(r => (
+                            <MenuItem key={r.regionId} value={r.regionId}>
+                              {r.regionName}
+                            </MenuItem>
+                          ))}
+                        </Select>
+                      </FormControl>
+                      <Button
+                        variant="contained"
+                        size="small"
+                        startIcon={applying ? <CircularProgress size={14} /> : <CheckIcon />}
+                        disabled={applying || keepChoice.get(selectedIndex ?? -1) == null}
+                        onClick={handleKeep}
+                      >
+                        Apply
+                      </Button>
+                    </Box>
+
+                    {/* Option 2: Split deeper (only for containment overlaps) */}
+                    {hasContainmentOverlap && (
+                      <Box sx={{ flex: '1 1 300px', border: 1, borderColor: 'divider', borderRadius: 1, p: 1.5 }}>
+                        <Typography variant="subtitle2" gutterBottom>Split into GADM children</Typography>
+                        <SplitPreview
+                          selectedRegions={selected.regions}
+                          splitChildren={splitChildren}
+                          splitLoading={splitLoading}
+                          splitAssignments={splitAssignments}
+                          applying={applying}
+                          onLoadSplit={handleLoadSplit}
+                          onChangeAssignment={(gadmChildId, regionId) => {
+                            setSplitAssignments(prev => {
+                              const next = new Map(prev);
+                              if (regionId == null) next.delete(gadmChildId);
+                              else next.set(gadmChildId, regionId);
+                              return next;
+                            });
+                          }}
+                          onApplySplit={handleSplit}
+                        />
+                      </Box>
+                    )}
+
+                    {/* Skip button */}
+                    <Box sx={{ display: 'flex', alignItems: 'flex-end' }}>
+                      <Button variant="text" size="small" startIcon={<SkipNextIcon />} onClick={handleSkip}>
+                        Skip
+                      </Button>
+                    </Box>
+                  </Box>
+                </Box>
+              ) : (
+                <Box sx={{ textAlign: 'center', py: 2 }}>
+                  <Typography variant="body1" color="text.secondary">
+                    {emptyStateMessage(resolvedCount, totalCount)}
+                  </Typography>
+                </Box>
+              )}
+
+              {/* Overlap list (clickable chips) */}
+              {overlaps.length > 1 && (
+                <Box sx={{ mt: 1.5, pt: 1, borderTop: 1, borderColor: 'divider', display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+                  {overlaps.map((o, i) => (
+                    <Chip
+                      key={o.divisionId}
+                      label={o.divisionPath.split(' > ').pop()}
+                      size="small"
+                      variant={i === selectedIndex ? 'filled' : 'outlined'}
+                      color={chipColor(i, selectedIndex, resolvedIndices)}
+                      onClick={() => setSelectedIndex(i)}
+                      sx={{ cursor: 'pointer' }}
+                    />
+                  ))}
+                </Box>
+              )}
+            </Box>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/admin/SmartFlattenPreviewDialog.tsx
+++ b/frontend/src/components/admin/SmartFlattenPreviewDialog.tsx
@@ -1,0 +1,178 @@
+import { useRef } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Box,
+  Typography,
+  CircularProgress,
+  IconButton,
+  Button,
+} from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import CheckIcon from '@mui/icons-material/Check';
+import MapGL, { NavigationControl, Source, Layer, MapRef } from 'react-map-gl/maplibre';
+import * as turf from '@turf/turf';
+
+const MAP_STYLE = 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json';
+
+interface SmartFlattenPreviewDialogProps {
+  open: boolean;
+  regionName: string;
+  geometry: GeoJSON.Geometry | null;
+  regionMapUrl: string | null;
+  descendants: number;
+  divisions: number;
+  onConfirm: () => void;
+  onCancel: () => void;
+  confirming: boolean;
+}
+
+export function SmartFlattenPreviewDialog({
+  open,
+  regionName,
+  geometry,
+  regionMapUrl,
+  descendants,
+  divisions,
+  onConfirm,
+  onCancel,
+  confirming,
+}: SmartFlattenPreviewDialogProps) {
+  const mapRef = useRef<MapRef>(null);
+  const hasSideBySide = !!regionMapUrl;
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onCancel}
+      maxWidth={hasSideBySide ? 'md' : 'sm'}
+      fullWidth
+    >
+      <DialogTitle sx={{ pb: 1 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <Box>
+            <Typography variant="h6">Smart Flatten: {regionName}</Typography>
+            <Typography variant="caption" color="text.secondary">
+              Will absorb {descendants} descendant{descendants !== 1 ? 's' : ''} ({divisions} division{divisions !== 1 ? 's' : ''})
+            </Typography>
+          </Box>
+          <IconButton onClick={onCancel} size="small">
+            <CloseIcon />
+          </IconButton>
+        </Box>
+      </DialogTitle>
+      <DialogContent sx={{ p: 0 }}>
+        <Box sx={{ display: 'flex', height: 400 }}>
+          {/* Region map image (left side) */}
+          {hasSideBySide && (
+            <Box sx={{
+              flex: 1,
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              justifyContent: 'center',
+              borderRight: 1,
+              borderColor: 'divider',
+              bgcolor: 'grey.50',
+              p: 1,
+            }}>
+              <Typography variant="caption" color="text.secondary" sx={{ mb: 0.5 }}>
+                Region map
+              </Typography>
+              <Box
+                component="img"
+                src={`${regionMapUrl}?width=500`}
+                alt="Region map"
+                sx={{
+                  maxWidth: '100%',
+                  maxHeight: 360,
+                  objectFit: 'contain',
+                }}
+              />
+            </Box>
+          )}
+
+          {/* Unified GADM geometry map (right side, or full width) */}
+          <Box sx={{ flex: 1, minWidth: 0 }}>
+            {geometry ? (
+              <>
+                {hasSideBySide && (
+                  <Typography variant="caption" color="text.secondary" sx={{ display: 'block', textAlign: 'center', pt: 0.5 }}>
+                    GADM divisions (unified)
+                  </Typography>
+                )}
+                <MapGL
+                  ref={mapRef}
+                  initialViewState={{ longitude: 0, latitude: 0, zoom: 1 }}
+                  style={{ width: '100%', height: hasSideBySide ? 'calc(100% - 20px)' : '100%' }}
+                  mapStyle={MAP_STYLE}
+                  onLoad={() => {
+                    if (mapRef.current && geometry) {
+                      try {
+                        const fc: GeoJSON.FeatureCollection = {
+                          type: 'FeatureCollection',
+                          features: [{ type: 'Feature', properties: {}, geometry }],
+                        };
+                        const bbox = turf.bbox(fc) as [number, number, number, number];
+                        mapRef.current.fitBounds(
+                          [[bbox[0], bbox[1]], [bbox[2], bbox[3]]],
+                          { padding: 40, duration: 500 },
+                        );
+                      } catch (e) {
+                        console.error('Failed to fit bounds:', e);
+                      }
+                    }
+                  }}
+                >
+                  <NavigationControl position="top-right" showCompass={false} />
+                  <Source
+                    id="flatten-preview"
+                    type="geojson"
+                    data={{ type: 'Feature', properties: {}, geometry }}
+                  >
+                    <Layer
+                      id="flatten-preview-fill"
+                      type="fill"
+                      paint={{ 'fill-color': '#3388ff', 'fill-opacity': 0.4 }}
+                    />
+                    <Layer
+                      id="flatten-preview-outline"
+                      type="line"
+                      paint={{ 'line-color': '#3388ff', 'line-width': 2 }}
+                    />
+                  </Source>
+                </MapGL>
+              </>
+            ) : (
+              <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
+                <Typography color="text.secondary">No geometry available</Typography>
+              </Box>
+            )}
+          </Box>
+        </Box>
+      </DialogContent>
+      <DialogActions sx={{ px: 2, py: 1.5 }}>
+        <Button
+          variant="outlined"
+          size="small"
+          onClick={onCancel}
+          disabled={confirming}
+        >
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          color="primary"
+          size="small"
+          startIcon={confirming ? <CircularProgress size={16} /> : <CheckIcon />}
+          onClick={onConfirm}
+          disabled={confirming}
+        >
+          Confirm Flatten
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/admin/SmartSimplifyDialog.tsx
+++ b/frontend/src/components/admin/SmartSimplifyDialog.tsx
@@ -33,11 +33,11 @@ import * as turf from '@turf/turf';
 import {
   detectSmartSimplify,
   applySmartSimplifyMove,
-  getChildrenRegionGeometry,
   type SmartSimplifyMove,
-  type SiblingRegionGeometry,
   type SpatialAnomaly,
 } from '../../api/admin/worldViewImport';
+import { getChildrenRegionGeometry } from '../../api/admin/wvImportCoverage';
+import type { SiblingRegionGeometry } from '../../api/admin/wvImportCoverage';
 import { fetchDivisionGeometry } from '../../api/divisions';
 import type { GeoJSONGeometry } from '../../types';
 
@@ -108,18 +108,18 @@ export function SmartSimplifyDialog({
   const [divisionGeometries, setDivisionGeometries] = useState<Map<number, GeoJSONGeometry>>(new Map());
   const [divGeoLoading, setDivGeoLoading] = useState(false);
 
+  // Spatial anomaly state
+  const [spatialAnomalies, setSpatialAnomalies] = useState<SpatialAnomaly[] | null>(null);
+  const [appliedAnomalyIndices, setAppliedAnomalyIndices] = useState<Set<number>>(new Set());
+  const [selectedAnomalyIndex, setSelectedAnomalyIndex] = useState<number | null>(null);
+  const [applyingAnomaly, setApplyingAnomaly] = useState(false);
+
   // Interaction state
   const [selectedMoveIndex, setSelectedMoveIndex] = useState<number | null>(null);
   const [appliedGadmParentIds, setAppliedGadmParentIds] = useState<Set<number>>(new Set());
   const [applying, setApplying] = useState(false);
   const [applyError, setApplyError] = useState<string | null>(null);
   const [viewMode, setViewMode] = useState<'current' | 'proposed'>('current');
-
-  // Spatial anomaly state
-  const [spatialAnomalies, setSpatialAnomalies] = useState<SpatialAnomaly[] | null>(null);
-  const [appliedAnomalyIndices, setAppliedAnomalyIndices] = useState<Set<number>>(new Set());
-  const [selectedAnomalyIndex, setSelectedAnomalyIndex] = useState<number | null>(null);
-  const [applyingAnomaly, setApplyingAnomaly] = useState(false);
 
   // Load data on open
   useEffect(() => {
@@ -156,9 +156,10 @@ export function SmartSimplifyDialog({
       });
   }, [open, worldViewId, parentRegionId]);
 
-  const selectedMove = moves && selectedMoveIndex != null ? moves[selectedMoveIndex] : null;
-
   // Derived: the active selection (either a GADM move or a spatial anomaly)
+  // eslint-disable-next-line security/detect-object-injection -- selectedMoveIndex is a typed number|null state; moves[] is the source of valid indices
+  const selectedMove = moves && selectedMoveIndex != null ? moves[selectedMoveIndex] : null;
+  // eslint-disable-next-line security/detect-object-injection -- selectedAnomalyIndex is a typed number|null state; spatialAnomalies[] is the source of valid indices
   const selectedAnomaly = spatialAnomalies && selectedAnomalyIndex != null ? spatialAnomalies[selectedAnomalyIndex] : null;
 
   // Active division IDs to show on the map (from whichever selection is active)
@@ -262,6 +263,7 @@ export function SmartSimplifyDialog({
   // Handle Apply
   const handleApply = useCallback(async () => {
     if (moves == null || selectedMoveIndex == null) return;
+    // eslint-disable-next-line security/detect-object-injection -- selectedMoveIndex is a typed number state, moves[] is the source of valid indices
     const move = moves[selectedMoveIndex];
     if (!move) return;
 
@@ -303,6 +305,7 @@ export function SmartSimplifyDialog({
   // Handle Apply Anomaly
   const handleApplyAnomaly = useCallback(async (index: number) => {
     if (!spatialAnomalies) return;
+    // eslint-disable-next-line security/detect-object-injection -- index is a typed number param from a click handler on spatialAnomalies[]
     const anomaly = spatialAnomalies[index];
     const memberRowIds = anomaly.divisions
       .map(d => d.memberRowId)
@@ -578,7 +581,7 @@ export function SmartSimplifyDialog({
               </Box>
             </Box>
 
-            {/* Bottom section: moves + anomalies list */}
+            {/* Bottom section: moves list */}
             {((moves && moves.length > 0) || (spatialAnomalies && spatialAnomalies.length > 0)) && (
               <Box sx={{
                 borderTop: 1,

--- a/frontend/src/components/admin/TreeNodeActions.tsx
+++ b/frontend/src/components/admin/TreeNodeActions.tsx
@@ -12,17 +12,33 @@ import {
   SyncAlt as SyncIcon,
   AccountTree as GroupingIcon,
   Place as GeocodeIcon,
+  Terrain as GeoshapeIcon,
   RestartAlt as ResetIcon,
   Build as ManualFixIcon,
+  CallMerge as MergeIcon,
+  Compress as SmartFlattenIcon,
+  CheckCircleOutline as DismissWarningsIcon,
+  AddCircleOutline as AddChildIcon,
+  DeleteOutline as RemoveRegionIcon,
+  VerticalAlignTop as CollapseToParentIcon,
+  AutoFixHigh as AutoResolveIcon,
+  Psychology as ReviewSubtreeIcon,
+  Edit as RenameIcon,
+  DriveFileMove as ReparentIcon,
+  AutoAwesome as SuggestChildrenIcon,
+  TravelExplore as DivisionSearchIcon,
+  ContentCut as PruneToLeavesIcon,
+  ScatterPlot as PointMatchIcon,
+  Map as ViewMapIcon,
+  Palette as CVMatchIcon,
+  Layers as MapshapeMatchIcon,
+  ClearAll as ClearAssignedIcon,
   LowPriority as SimplifyIcon,
   PlaylistAddCheck as SimplifyChildrenIcon,
   SwapHoriz as SmartSimplifyIcon,
-  Terrain as GeoshapeIcon,
-  ScatterPlot as PointMatchIcon,
-  RateReview as ReviewChildrenIcon,
-  Palette as CVMatchIcon,
-  Map as MapshapeMatchIcon,
+  JoinInner as OverlapCheckIcon,
 } from '@mui/icons-material';
+import type { ReactNode } from 'react';
 import type { MatchTreeNode } from '../../api/admin/worldViewImport';
 import { Tooltip } from './treeNodeShared';
 
@@ -49,17 +65,6 @@ interface TreeNodeActionsProps {
   onDBSearch: (regionId: number) => void;
   onAIMatch: (regionId: number) => void;
   onDismissChildren: (regionId: number) => void;
-  onSimplifyHierarchy?: (regionId: number) => void;
-  simplifyingRegionId?: number | null;
-  onSimplifyChildren?: (regionId: number) => void;
-  simplifyingChildrenRegionId?: number | null;
-  onSmartSimplify?: (regionId: number) => void;
-  onAISuggestChildren?: (regionId: number) => void;
-  aiSuggestingRegionId?: number | null;
-  onCVMatch?: (regionId: number) => void;
-  cvMatchingRegionId?: number | null;
-  onMapshapeMatch?: (regionId: number) => void;
-  mapshapeMatchingRegionId?: number | null;
   onSync: (regionId: number) => void;
   onHandleAsGrouping: (regionId: number) => void;
   onGeocodeMatch: (regionId: number) => void;
@@ -67,13 +72,51 @@ interface TreeNodeActionsProps {
   onPointMatch: (regionId: number, scopeAncestorId?: number) => void;
   onResetMatch: (regionId: number) => void;
   onManualFix: (regionId: number, needsManualFix: boolean) => void;
+  onMergeChild?: (regionId: number) => void;
+  mergingRegionId?: number | null;
+  onSmartFlatten?: (regionId: number) => void;
+  flatteningRegionId?: number | null;
+  onDismissHierarchyWarnings?: (regionId: number) => void;
+  onAddChild?: (parentRegionId: number) => void;
+  onRemoveRegion?: (regionId: number) => void;
+  removingRegionId?: number | null;
+  onCollapseToParent?: (regionId: number) => void;
+  collapsingRegionId?: number | null;
+  onAutoResolve?: (regionId: number) => void;
+  autoResolvingRegionId?: number | null;
+  onReviewSubtree?: (regionId: number) => void;
+  reviewingRegionId?: number | null;
+  onRename?: (regionId: number, currentName: string) => void;
+  renamingRegionId?: number | null;
+  onReparent?: (regionId: number, currentParentId: number | null) => void;
+  reparentingRegionId?: number | null;
+  onAISuggestChildren?: (regionId: number) => void;
+  aiSuggestingRegionId?: number | null;
+  onManualDivisionSearch?: (regionId: number) => void;
+  onPruneToLeaves?: (regionId: number) => void;
+  pruningRegionId?: number | null;
+  onViewMap?: (regionId: number) => void;
+  onCVMatch?: (regionId: number) => void;
+  cvMatchingRegionId?: number | null;
+  onMapshapeMatch?: (regionId: number) => void;
+  mapshapeMatchingRegionId?: number | null;
+  onClearMembers?: (regionId: number) => void;
+  clearingMembersRegionId?: number | null;
+  onSimplifyHierarchy?: (regionId: number) => void;
+  simplifyingRegionId?: number | null;
+  onSimplifyChildren?: (regionId: number) => void;
+  simplifyingChildrenRegionId?: number | null;
+  onSmartSimplify?: (regionId: number) => void;
+  onCheckOverlap?: (regionId: number) => void;
+  checkingOverlapRegionId?: number | null;
+  /** Whether this is a root node (depth 0) — remove button is hidden for root */
+  isRoot?: boolean;
 }
 
-/** Geocode + DB search + AI match + geoshape + point-match button group (shared across multiple status blocks) */
-function SearchActionButtons({ nodeId, wikidataId, geoAvailable, nodeGeocodeMsg, nodeGeocodeNextScope, nodeGeocodeRetryType, isMutating, geocodeMatchingRegionId, geoshapeMatchingRegionId, pointMatchingRegionId, dbSearchingRegionId, aiMatchingRegionId, onGeocodeMatch, onDBSearch, onAIMatch, onGeoshapeMatch, onPointMatch }: {
+/** Geocode + Geoshape + DB search + AI match button group (shared across multiple status blocks) */
+function SearchActionButtons({ nodeId, wikidataId, nodeGeocodeMsg, nodeGeocodeNextScope, nodeGeocodeRetryType, isMutating, geocodeMatchingRegionId, geoshapeMatchingRegionId, pointMatchingRegionId, dbSearchingRegionId, aiMatchingRegionId, onGeocodeMatch, onGeoshapeMatch, onPointMatch, onDBSearch, onAIMatch }: {
   nodeId: number;
   wikidataId: string | null;
-  geoAvailable: boolean | null;
   nodeGeocodeMsg: string | null;
   nodeGeocodeNextScope?: { ancestorId: number; ancestorName: string };
   nodeGeocodeRetryType?: 'geoshape' | 'point';
@@ -84,10 +127,10 @@ function SearchActionButtons({ nodeId, wikidataId, geoAvailable, nodeGeocodeMsg,
   dbSearchingRegionId: number | null;
   aiMatchingRegionId: number | null;
   onGeocodeMatch: (regionId: number) => void;
-  onDBSearch: (regionId: number) => void;
-  onAIMatch: (regionId: number) => void;
   onGeoshapeMatch: (regionId: number, scopeAncestorId?: number) => void;
   onPointMatch: (regionId: number, scopeAncestorId?: number) => void;
+  onDBSearch: (regionId: number) => void;
+  onAIMatch: (regionId: number) => void;
 }) {
   const anySearching = geocodeMatchingRegionId !== null || geoshapeMatchingRegionId !== null || pointMatchingRegionId !== null || dbSearchingRegionId !== null || aiMatchingRegionId !== null;
   return (
@@ -103,6 +146,36 @@ function SearchActionButtons({ nodeId, wikidataId, geoAvailable, nodeGeocodeMsg,
             {geocodeMatchingRegionId === nodeId
               ? <CircularProgress size={14} />
               : <GeocodeIcon sx={{ fontSize: 16 }} />
+            }
+          </IconButton>
+        </span>
+      </Tooltip>
+      <Tooltip title={!wikidataId ? 'No Wikidata ID' : 'Geoshape match (spatial)'}>
+        <span>
+          <IconButton
+            size="small"
+            onClick={() => onGeoshapeMatch(nodeId)}
+            disabled={isMutating || anySearching || !wikidataId}
+            sx={{ p: 0.25 }}
+          >
+            {geoshapeMatchingRegionId === nodeId
+              ? <CircularProgress size={14} />
+              : <GeoshapeIcon sx={{ fontSize: 16, color: wikidataId ? 'success.main' : undefined }} />
+            }
+          </IconButton>
+        </span>
+      </Tooltip>
+      <Tooltip title={!wikidataId ? 'No Wikidata ID' : 'Point match (Wikivoyage markers)'}>
+        <span>
+          <IconButton
+            size="small"
+            onClick={() => onPointMatch(nodeId)}
+            disabled={isMutating || anySearching || !wikidataId}
+            sx={{ p: 0.25 }}
+          >
+            {pointMatchingRegionId === nodeId
+              ? <CircularProgress size={14} />
+              : <PointMatchIcon sx={{ fontSize: 16, color: wikidataId ? 'warning.main' : undefined }} />
             }
           </IconButton>
         </span>
@@ -138,7 +211,7 @@ function SearchActionButtons({ nodeId, wikidataId, geoAvailable, nodeGeocodeMsg,
           <IconButton
             size="small"
             onClick={() => onDBSearch(nodeId)}
-            disabled={isMutating || dbSearchingRegionId !== null || aiMatchingRegionId !== null}
+            disabled={isMutating || anySearching}
             sx={{ p: 0.25 }}
           >
             {dbSearchingRegionId === nodeId
@@ -153,7 +226,7 @@ function SearchActionButtons({ nodeId, wikidataId, geoAvailable, nodeGeocodeMsg,
           <IconButton
             size="small"
             onClick={() => onAIMatch(nodeId)}
-            disabled={isMutating || aiMatchingRegionId !== null || dbSearchingRegionId !== null}
+            disabled={isMutating || anySearching}
             sx={{ p: 0.25 }}
           >
             {aiMatchingRegionId === nodeId
@@ -163,37 +236,136 @@ function SearchActionButtons({ nodeId, wikidataId, geoAvailable, nodeGeocodeMsg,
           </IconButton>
         </span>
       </Tooltip>
-      <Tooltip title="Geoshape match — union Wikidata geoshape with GADM divisions">
-        <span>
-          <IconButton
-            size="small"
-            onClick={() => onGeoshapeMatch(nodeId)}
-            disabled={isMutating || anySearching || !wikidataId}
-            sx={{ p: 0.25 }}
-          >
-            {geoshapeMatchingRegionId === nodeId
-              ? <CircularProgress size={14} />
-              : <GeoshapeIcon sx={{ fontSize: 16, color: wikidataId ? 'success.main' : undefined }} />
-            }
-          </IconButton>
-        </span>
-      </Tooltip>
-      <Tooltip title="Point match — extract Wikivoyage marker coords and find GADM divisions">
-        <span>
-          <IconButton
-            size="small"
-            onClick={() => onPointMatch(nodeId)}
-            disabled={isMutating || anySearching || !wikidataId || geoAvailable !== false}
-            sx={{ p: 0.25 }}
-          >
-            {pointMatchingRegionId === nodeId
-              ? <CircularProgress size={14} />
-              : <PointMatchIcon sx={{ fontSize: 16, color: (wikidataId && geoAvailable === false) ? 'warning.main' : undefined }} />
-            }
-          </IconButton>
-        </span>
-      </Tooltip>
     </>
+  );
+}
+
+/** Generic tooltip+icon-button action row used by many conditional buttons.
+ * Returning null lets the caller write `show && <ActionIconButton ... />` once. */
+function ActionIconButton({
+  show,
+  title,
+  onClick,
+  loading,
+  disabled,
+  icon,
+  loadingSize = 14,
+}: {
+  show: boolean;
+  title: string;
+  onClick: () => void;
+  loading: boolean;
+  disabled: boolean;
+  icon: ReactNode;
+  loadingSize?: number;
+}) {
+  if (!show) return null;
+  return (
+    <Tooltip title={title}>
+      <span>
+        <IconButton size="small" onClick={onClick} disabled={disabled} sx={{ p: 0.25 }}>
+          {loading ? <CircularProgress size={loadingSize} /> : icon}
+        </IconButton>
+      </span>
+    </Tooltip>
+  );
+}
+
+/** Sync-to-other-instances icon button with dynamic tooltip/disabled state. */
+function SyncToInstancesButton({
+  role,
+  hasDuplicate,
+  node,
+  syncedUrls,
+  isMutating,
+  syncingRegionId,
+  onSync,
+}: {
+  role: string;
+  hasDuplicate: boolean;
+  node: MatchTreeNode;
+  syncedUrls: Set<string>;
+  isMutating: boolean;
+  syncingRegionId: number | null;
+  onSync: (id: number) => void;
+}) {
+  const isMatched =
+    node.matchStatus === 'auto_matched' ||
+    node.matchStatus === 'manual_matched' ||
+    node.matchStatus === 'children_matched';
+  if (role !== 'country' || !hasDuplicate || !isMatched) return null;
+  const isSynced = !!(node.sourceUrl && syncedUrls.has(node.sourceUrl));
+  return (
+    <ActionIconButton
+      show={true}
+      title={isSynced ? 'Already in sync' : 'Sync to other instances'}
+      onClick={() => onSync(node.id)}
+      loading={syncingRegionId === node.id}
+      disabled={isMutating || syncingRegionId !== null || isSynced}
+      icon={<SyncIcon sx={{ fontSize: 16 }} />}
+    />
+  );
+}
+
+/** Toggle "needs manual fix" flag icon button. */
+function ManualFixButton({
+  node,
+  isMutating,
+  onManualFix,
+}: {
+  node: MatchTreeNode;
+  isMutating: boolean;
+  onManualFix: (regionId: number, needsManualFix: boolean, fixNote?: string) => void;
+}) {
+  if (node.matchStatus == null) return null;
+  const tooltipTitle = node.needsManualFix
+    ? (node.fixNote ?? 'Needs manual fix — click to clear')
+    : 'Mark as needing manual fix';
+  return (
+    <ActionIconButton
+      show={true}
+      title={tooltipTitle}
+      onClick={() => onManualFix(node.id, !node.needsManualFix)}
+      loading={false}
+      disabled={isMutating}
+      icon={<ManualFixIcon sx={{ fontSize: 16, color: node.needsManualFix ? 'error.main' : 'text.disabled' }} />}
+    />
+  );
+}
+
+/** Country-role status chip (auto/manual/matched). */
+function CountryStatusChip({ matchStatus, role }: { matchStatus: MatchTreeNode['matchStatus']; role: string }) {
+  if (role !== 'country') return null;
+  if (matchStatus === 'auto_matched' || matchStatus === 'children_matched') {
+    return <Chip label="matched" color="success" size="small" sx={{ height: 20, fontSize: '0.7rem' }} />;
+  }
+  if (matchStatus === 'manual_matched') {
+    return <Chip label="manual" color="info" size="small" sx={{ height: 20, fontSize: '0.7rem' }} />;
+  }
+  return null;
+}
+
+/** Container summary (resolved/total) with unresolved warning suffix. */
+function ContainerSummary({
+  role,
+  summary,
+  ancestorIsMatched,
+}: {
+  role: string;
+  summary: { resolved: number; total: number } | null | undefined;
+  ancestorIsMatched: boolean;
+}) {
+  if (role !== 'container' || !summary) return null;
+  const unresolved = summary.total - summary.resolved;
+  return (
+    <Typography variant="caption" color="text.secondary" sx={{ flexShrink: 0 }}>
+      {summary.resolved}/{summary.total} matched
+      {unresolved > 0 && !ancestorIsMatched && (
+        <Typography component="span" variant="caption" color="warning.main" sx={{ ml: 0.5 }}>
+          ({unresolved} unresolved)
+        </Typography>
+      )}
+    </Typography>
   );
 }
 
@@ -209,8 +381,6 @@ export function TreeNodeActions({
   dbSearchingRegionId,
   aiMatchingRegionId,
   dismissingRegionId,
-  simplifyingRegionId,
-  simplifyingChildrenRegionId,
   syncingRegionId,
   groupingRegionId,
   geocodeMatchingRegionId,
@@ -222,15 +392,6 @@ export function TreeNodeActions({
   onDBSearch,
   onAIMatch,
   onDismissChildren,
-  onSimplifyHierarchy,
-  onSimplifyChildren,
-  onSmartSimplify,
-  onAISuggestChildren,
-  aiSuggestingRegionId,
-  onCVMatch,
-  cvMatchingRegionId,
-  onMapshapeMatch,
-  mapshapeMatchingRegionId,
   onSync,
   onHandleAsGrouping,
   onGeocodeMatch,
@@ -238,19 +399,53 @@ export function TreeNodeActions({
   onPointMatch,
   onResetMatch,
   onManualFix,
+  onMergeChild,
+  mergingRegionId,
+  onSmartFlatten,
+  flatteningRegionId,
+  onDismissHierarchyWarnings,
+  onAddChild,
+  onRemoveRegion,
+  removingRegionId,
+  onCollapseToParent,
+  collapsingRegionId,
+  onAutoResolve,
+  autoResolvingRegionId,
+  onReviewSubtree,
+  reviewingRegionId,
+  onRename,
+  renamingRegionId,
+  onReparent,
+  reparentingRegionId,
+  onAISuggestChildren,
+  aiSuggestingRegionId,
+  onManualDivisionSearch,
+  onPruneToLeaves,
+  pruningRegionId,
+  onViewMap,
+  onCVMatch,
+  cvMatchingRegionId,
+  onMapshapeMatch,
+  mapshapeMatchingRegionId,
+  onClearMembers,
+  clearingMembersRegionId,
+  onSimplifyHierarchy,
+  simplifyingRegionId,
+  onSimplifyChildren,
+  simplifyingChildrenRegionId,
+  onSmartSimplify,
+  onCheckOverlap,
+  checkingOverlapRegionId,
+  isRoot,
 }: TreeNodeActionsProps) {
   // Show dismiss button when node has children with unsuccessful match statuses
   const hasUnmatchedChildren = hasChildren && node.children.some(
     c => c.matchStatus === 'needs_review' || c.matchStatus === 'no_candidates' || c.matchStatus === 'suggested',
   );
 
-  // Show "match parent" button when all matchable descendants failed to find candidates (deep check)
-  const allChildrenUnmatched = hasChildren && summary != null && summary.total > 0 && summary.resolved === 0;
-
   const searchButtonProps = {
     nodeId: node.id,
-    wikidataId: node.wikidataId ?? null,
-    geoAvailable: node.geoAvailable ?? null,
+    wikidataId: node.wikidataId,
     nodeGeocodeMsg,
     nodeGeocodeNextScope,
     nodeGeocodeRetryType,
@@ -261,127 +456,180 @@ export function TreeNodeActions({
     dbSearchingRegionId,
     aiMatchingRegionId,
     onGeocodeMatch,
-    onDBSearch,
-    onAIMatch,
     onGeoshapeMatch,
     onPointMatch,
+    onDBSearch,
+    onAIMatch,
   };
 
   return (
     <>
       {/* Container summary */}
-      {role === 'container' && summary && (
-        <Typography variant="caption" color="text.secondary" sx={{ flexShrink: 0 }}>
-          {summary.resolved}/{summary.total} matched
-          {summary.total - summary.resolved > 0 && !ancestorIsMatched && (
-            <Typography component="span" variant="caption" color="warning.main" sx={{ ml: 0.5 }}>
-              ({summary.total - summary.resolved} unresolved)
-            </Typography>
-          )}
-        </Typography>
-      )}
+      <ContainerSummary role={role} summary={summary} ancestorIsMatched={ancestorIsMatched} />
 
       {/* Status chips */}
-      {role === 'country' && node.matchStatus === 'auto_matched' && (
-        <Chip label="matched" color="success" size="small" sx={{ height: 20, fontSize: '0.7rem' }} />
-      )}
-      {role === 'country' && node.matchStatus === 'manual_matched' && (
-        <Chip label="manual" color="info" size="small" sx={{ height: 20, fontSize: '0.7rem' }} />
-      )}
-      {role === 'country' && node.matchStatus === 'children_matched' && (
-        <Chip label="matched" color="success" size="small" sx={{ height: 20, fontSize: '0.7rem' }} />
-      )}
+      <CountryStatusChip matchStatus={node.matchStatus} role={role} />
+
+      {/* View map — opens geoshape/division preview for any node with wikidataId */}
+      <ActionIconButton
+        show={!!onViewMap && !!node.wikidataId}
+        title="View map comparison"
+        onClick={() => onViewMap?.(node.id)}
+        loading={false}
+        disabled={false}
+        icon={<ViewMapIcon sx={{ fontSize: 16, color: 'info.main' }} />}
+      />
+
+      {/* CV color match — for parent nodes with children and a region map */}
+      <ActionIconButton
+        show={!!onCVMatch && hasChildren && !!node.regionMapUrl}
+        title="CV color match (gap divisions only)"
+        onClick={() => onCVMatch?.(node.id)}
+        loading={cvMatchingRegionId === node.id}
+        disabled={isMutating || cvMatchingRegionId === node.id}
+        icon={<CVMatchIcon sx={{ fontSize: 16, color: 'info.main' }} />}
+        loadingSize={16}
+      />
+
+      {/* Mapshape match — for parent nodes with children and a Wikivoyage source page */}
+      <ActionIconButton
+        show={!!onMapshapeMatch && hasChildren && !!node.sourceUrl}
+        title="Mapshape match (Kartographer region boundaries from Wikivoyage)"
+        onClick={() => onMapshapeMatch?.(node.id)}
+        loading={mapshapeMatchingRegionId === node.id}
+        disabled={isMutating || mapshapeMatchingRegionId === node.id}
+        icon={<MapshapeMatchIcon sx={{ fontSize: 16, color: 'info.main' }} />}
+        loadingSize={16}
+      />
 
       {/* Dismiss subregions button */}
-      {hasUnmatchedChildren && (
-        <Tooltip title="Dismiss subregions (make leaf)">
-          <span>
-            <IconButton
-              size="small"
-              onClick={() => onDismissChildren(node.id)}
-              disabled={isMutating || dismissingRegionId !== null}
-              sx={{ p: 0.25 }}
-            >
-              {dismissingRegionId === node.id
-                ? <CircularProgress size={14} />
-                : <DismissChildrenIcon sx={{ fontSize: 16 }} />
-              }
-            </IconButton>
-          </span>
-        </Tooltip>
+      <ActionIconButton
+        show={hasUnmatchedChildren}
+        title="Dismiss subregions (make leaf)"
+        onClick={() => onDismissChildren(node.id)}
+        loading={dismissingRegionId === node.id}
+        disabled={isMutating || dismissingRegionId !== null}
+        icon={<DismissChildrenIcon sx={{ fontSize: 16 }} />}
+      />
+
+      {/* Prune to leaves: keep direct children, remove grandchildren+ */}
+      <ActionIconButton
+        show={hasChildren && !!onPruneToLeaves}
+        title="Prune to leaves (keep children, remove grandchildren+)"
+        onClick={() => onPruneToLeaves?.(node.id)}
+        loading={pruningRegionId === node.id}
+        disabled={isMutating || pruningRegionId !== null}
+        icon={<PruneToLeavesIcon sx={{ fontSize: 16 }} />}
+      />
+
+      {/* Collapse to parent: clear children data, generate parent suggestions */}
+      <ActionIconButton
+        show={hasChildren && !!onCollapseToParent}
+        title="Clear children's matches, generate suggestions for this region"
+        onClick={() => onCollapseToParent?.(node.id)}
+        loading={collapsingRegionId === node.id}
+        disabled={isMutating || collapsingRegionId != null}
+        icon={<CollapseToParentIcon sx={{ fontSize: 16, color: 'info.main' }} />}
+      />
+
+      {/* Merge single child into parent */}
+      <ActionIconButton
+        show={role === 'container' && node.children.length === 1 && !!onMergeChild}
+        title="Merge single child into this node"
+        onClick={() => onMergeChild?.(node.id)}
+        loading={mergingRegionId === node.id}
+        disabled={isMutating || mergingRegionId != null}
+        icon={<MergeIcon sx={{ fontSize: 16, color: 'secondary.main' }} />}
+      />
+
+      {/* Smart flatten — absorb children's divisions */}
+      <ActionIconButton
+        show={
+          hasChildren &&
+          node.children.length > 1 &&
+          !!onSmartFlatten &&
+          (node.matchStatus == null ||
+            node.matchStatus === 'no_candidates' ||
+            node.matchStatus === 'children_matched')
+        }
+        title="Smart flatten: match children to GADM, absorb their divisions"
+        onClick={() => onSmartFlatten?.(node.id)}
+        loading={flatteningRegionId === node.id}
+        disabled={isMutating || flatteningRegionId != null}
+        icon={<SmartFlattenIcon sx={{ fontSize: 16, color: 'info.main' }} />}
+      />
+
+      {/* Auto-resolve children: batch-match all unmatched leaf descendants */}
+      <ActionIconButton
+        show={hasChildren && !!onAutoResolve && hasUnmatchedChildren}
+        title="Auto-resolve: batch-match all unmatched leaf descendants"
+        onClick={() => onAutoResolve?.(node.id)}
+        loading={autoResolvingRegionId === node.id}
+        disabled={isMutating || autoResolvingRegionId != null}
+        icon={<AutoResolveIcon sx={{ fontSize: 16, color: 'success.main' }} />}
+      />
+
+      {/* AI review subtree */}
+      <ActionIconButton
+        show={hasChildren && !!onReviewSubtree}
+        title="AI review of this branch"
+        onClick={() => onReviewSubtree?.(node.id)}
+        loading={reviewingRegionId === node.id}
+        disabled={isMutating || reviewingRegionId != null}
+        icon={<ReviewSubtreeIcon sx={{ fontSize: 16, color: 'info.main' }} />}
+      />
+
+      {/* Rename region */}
+      <ActionIconButton
+        show={!!onRename}
+        title="Rename region"
+        onClick={() => onRename?.(node.id, node.name)}
+        loading={renamingRegionId === node.id}
+        disabled={isMutating || renamingRegionId != null}
+        icon={<RenameIcon sx={{ fontSize: 16 }} />}
+      />
+
+      {/* Move region to new parent */}
+      <ActionIconButton
+        show={!isRoot && !!onReparent}
+        title="Move to different parent"
+        onClick={() => onReparent?.(node.id, null)}
+        loading={reparentingRegionId === node.id}
+        disabled={isMutating || reparentingRegionId != null}
+        icon={<ReparentIcon sx={{ fontSize: 16 }} />}
+      />
+
+      {/* Remove region from import tree */}
+      <ActionIconButton
+        show={!isRoot && !!onRemoveRegion}
+        title="Remove region from tree"
+        onClick={() => onRemoveRegion?.(node.id)}
+        loading={removingRegionId === node.id}
+        disabled={isMutating || removingRegionId != null}
+        icon={<RemoveRegionIcon sx={{ fontSize: 16, color: 'error.main' }} />}
+      />
+
+      {/* Container: all children resolved — show success chip */}
+      {role === 'container' && summary && summary.total > 0 && summary.resolved === summary.total && node.matchStatus !== 'children_matched' && (
+        <Chip label="matched" color="success" size="small" sx={{ height: 20, fontSize: '0.7rem' }} />
       )}
 
-      {/* Simplify hierarchy — merge child divisions into parents where all siblings assigned */}
-      {node.assignedDivisions.length >= 2 &&
-        (node.matchStatus === 'auto_matched' || node.matchStatus === 'manual_matched') &&
-        !!onSimplifyHierarchy && (
-        <Tooltip title="Simplify — merge child divisions into parents where all children are assigned">
-          <span>
-            <IconButton
-              size="small"
-              onClick={() => onSimplifyHierarchy(node.id)}
-              disabled={isMutating || simplifyingRegionId != null}
-              sx={{ p: 0.25 }}
-            >
-              {simplifyingRegionId === node.id
-                ? <CircularProgress size={14} />
-                : <SimplifyIcon sx={{ fontSize: 16, color: 'info.main' }} />
-              }
-            </IconButton>
-          </span>
-        </Tooltip>
-      )}
-
-      {/* Simplify children — apply simplification to each direct child independently */}
-      {hasChildren && !!onSimplifyChildren && (
-        <Tooltip title="Simplify children — merge child divisions into parents for each child region">
-          <span>
-            <IconButton
-              size="small"
-              onClick={() => onSimplifyChildren(node.id)}
-              disabled={isMutating || simplifyingChildrenRegionId != null}
-              sx={{ p: 0.25 }}
-            >
-              {simplifyingChildrenRegionId === node.id
-                ? <CircularProgress size={14} />
-                : <SimplifyChildrenIcon sx={{ fontSize: 16, color: 'info.main' }} />
-              }
-            </IconButton>
-          </span>
-        </Tooltip>
-      )}
-
-      {/* Smart Simplify — detect and fix cross-sibling division splits */}
-      {hasChildren && !!onSmartSimplify && (
-        <Tooltip title="Smart Simplify — detect divisions split across sibling regions">
-          <span>
-            <IconButton
-              size="small"
-              onClick={() => onSmartSimplify(node.id)}
-              disabled={isMutating}
-              sx={{ p: 0.25 }}
-            >
-              <SmartSimplifyIcon sx={{ fontSize: 16, color: 'secondary.main' }} />
-            </IconButton>
-          </span>
-        </Tooltip>
-      )}
-
-      {/* Container with all children unmatched — search buttons */}
-      {role === 'container' && allChildrenUnmatched && !ancestorIsMatched && (
-        <SearchActionButtons {...searchButtonProps} />
-      )}
-
-      {/* Container with no_candidates + unresolved descendants */}
-      {role === 'container' && node.matchStatus === 'no_candidates' && !ancestorIsMatched && !allChildrenUnmatched && summary && summary.resolved < summary.total && (
+      {/* Container with no_candidates + unresolved children — show search buttons */}
+      {role === 'container' && node.matchStatus === 'no_candidates' && !(summary && summary.total > 0 && summary.resolved === summary.total) && (
         <>
           <Chip label="no match" color="default" size="small" sx={{ height: 20, fontSize: '0.7rem' }} />
           <SearchActionButtons {...searchButtonProps} />
         </>
       )}
 
-      {/* Country: no_candidates */}
-      {role === 'country' && node.matchStatus === 'no_candidates' && !ancestorIsMatched && (
+      {/* Container with children_matched — show search buttons so user can match parent for coverage checking */}
+      {role === 'container' && node.matchStatus === 'children_matched' && (
+        <SearchActionButtons {...searchButtonProps} />
+      )}
+
+      {/* Country: no_candidates — always show search buttons (even under matched ancestors,
+          because the user may have explicitly dismissed subregions to search at this level) */}
+      {role === 'country' && node.matchStatus === 'no_candidates' && (
         <>
           <Chip label="no match" color="default" size="small" sx={{ height: 20, fontSize: '0.7rem' }} />
           <SearchActionButtons {...searchButtonProps} />
@@ -394,6 +642,11 @@ export function TreeNodeActions({
           <Chip label="review" color="warning" size="small" sx={{ height: 20, fontSize: '0.7rem' }} />
           <SearchActionButtons {...searchButtonProps} />
         </>
+      )}
+
+      {/* Country: already matched — show search buttons to add more divisions */}
+      {role === 'country' && (node.matchStatus === 'auto_matched' || node.matchStatus === 'manual_matched') && (
+        <SearchActionButtons {...searchButtonProps} />
       )}
 
       {/* Country: suggested */}
@@ -415,138 +668,140 @@ export function TreeNodeActions({
       )}
 
       {/* Drill into children — match them independently */}
-      {hasChildren && node.matchStatus != null && node.matchStatus !== 'children_matched' && (
-        <Tooltip title="Match children independently (drill down)">
-          <span>
-            <IconButton
-              size="small"
-              onClick={() => onHandleAsGrouping(node.id)}
-              disabled={isMutating || groupingRegionId !== null}
-              sx={{ p: 0.25 }}
-            >
-              {groupingRegionId === node.id
-                ? <CircularProgress size={14} />
-                : <GroupingIcon sx={{ fontSize: 16 }} />
-              }
-            </IconButton>
-          </span>
-        </Tooltip>
-      )}
+      <ActionIconButton
+        show={hasChildren && node.matchStatus != null && node.matchStatus !== 'children_matched'}
+        title="Match children independently (drill down)"
+        onClick={() => onHandleAsGrouping(node.id)}
+        loading={groupingRegionId === node.id}
+        disabled={isMutating || groupingRegionId !== null}
+        icon={<GroupingIcon sx={{ fontSize: 16 }} />}
+      />
+
+      {/* Smart simplify — detect misplaced divisions across children */}
+      <ActionIconButton
+        show={hasChildren && !!onSmartSimplify}
+        title="Smart simplify — detect misplaced divisions across children"
+        onClick={() => onSmartSimplify?.(node.id)}
+        loading={false}
+        disabled={isMutating}
+        icon={<SmartSimplifyIcon sx={{ fontSize: 16, color: 'info.main' }} />}
+      />
+
+      {/* Check division overlap among children */}
+      <ActionIconButton
+        show={hasChildren && !!onCheckOverlap}
+        title="Check for divisions shared between children (including via parent/child GADM relationships)"
+        onClick={() => onCheckOverlap?.(node.id)}
+        loading={checkingOverlapRegionId === node.id}
+        disabled={isMutating || checkingOverlapRegionId != null}
+        icon={<OverlapCheckIcon sx={{ fontSize: 16, color: 'warning.main' }} />}
+      />
 
       {/* Sync to other instances button */}
-      {role === 'country' && hasDuplicate && (node.matchStatus === 'auto_matched' || node.matchStatus === 'manual_matched' || node.matchStatus === 'children_matched') && (() => {
-        const isSynced = !!(node.sourceUrl && syncedUrls.has(node.sourceUrl));
-        return (
-          <Tooltip title={isSynced ? 'Already in sync' : 'Sync to other instances'}>
-            <span>
-              <IconButton
-                size="small"
-                onClick={() => onSync(node.id)}
-                disabled={isMutating || syncingRegionId !== null || isSynced}
-                sx={{ p: 0.25 }}
-              >
-                {syncingRegionId === node.id
-                  ? <CircularProgress size={14} />
-                  : <SyncIcon sx={{ fontSize: 16 }} />
-                }
-              </IconButton>
-            </span>
-          </Tooltip>
-        );
-      })()}
+      <SyncToInstancesButton
+        role={role}
+        hasDuplicate={hasDuplicate}
+        node={node}
+        syncedUrls={syncedUrls}
+        isMutating={isMutating}
+        syncingRegionId={syncingRegionId}
+        onSync={onSync}
+      />
+
+      {/* Simplify hierarchy — merge child divisions into parents */}
+      <ActionIconButton
+        show={
+          node.assignedDivisions.length >= 2 &&
+          (node.matchStatus === 'auto_matched' || node.matchStatus === 'manual_matched') &&
+          !!onSimplifyHierarchy
+        }
+        title="Simplify — merge child divisions into parents where all children are assigned"
+        onClick={() => onSimplifyHierarchy?.(node.id)}
+        loading={simplifyingRegionId === node.id}
+        disabled={isMutating || simplifyingRegionId != null}
+        icon={<SimplifyIcon sx={{ fontSize: 16, color: 'info.main' }} />}
+      />
+
+      {/* Simplify children — simplify each child region one by one */}
+      <ActionIconButton
+        show={hasChildren && !!onSimplifyChildren}
+        title="Simplify children — merge child divisions into parents for each child region"
+        onClick={() => onSimplifyChildren?.(node.id)}
+        loading={simplifyingChildrenRegionId === node.id}
+        disabled={isMutating || simplifyingChildrenRegionId != null}
+        icon={<SimplifyChildrenIcon sx={{ fontSize: 16, color: 'info.main' }} />}
+      />
+
+      {/* Clear all assigned divisions (keep suggestions) */}
+      <ActionIconButton
+        show={role === 'country' && node.assignedDivisions.length > 0 && !!onClearMembers}
+        title={`Clear all ${node.assignedDivisions.length} assigned division${node.assignedDivisions.length > 1 ? 's' : ''}`}
+        onClick={() => onClearMembers?.(node.id)}
+        loading={clearingMembersRegionId === node.id}
+        disabled={isMutating || clearingMembersRegionId != null}
+        icon={<ClearAssignedIcon sx={{ fontSize: 16, color: 'warning.main' }} />}
+      />
 
       {/* Reset match state */}
-      {node.matchStatus != null && (
-        <Tooltip title="Reset match (clear suggestions & rejections)">
-          <span>
-            <IconButton
-              size="small"
-              onClick={() => onResetMatch(node.id)}
-              disabled={isMutating}
-              sx={{ p: 0.25 }}
-            >
-              <ResetIcon sx={{ fontSize: 16, color: 'text.disabled' }} />
-            </IconButton>
-          </span>
-        </Tooltip>
-      )}
+      <ActionIconButton
+        show={node.matchStatus != null}
+        title="Reset match (clear suggestions & rejections)"
+        onClick={() => onResetMatch(node.id)}
+        loading={false}
+        disabled={isMutating}
+        icon={<ResetIcon sx={{ fontSize: 16, color: 'text.disabled' }} />}
+      />
+
+      {/* Add child region (available on all nodes) */}
+      <ActionIconButton
+        show={!!onAddChild}
+        title="Add child region"
+        onClick={() => onAddChild?.(node.id)}
+        loading={false}
+        disabled={isMutating}
+        icon={<AddChildIcon sx={{ fontSize: 16, color: 'info.main' }} />}
+      />
+
+      {/* AI review children (Wikivoyage + AI) */}
+      <ActionIconButton
+        show={!!node.sourceUrl && !!onAISuggestChildren}
+        title="AI review children"
+        onClick={() => onAISuggestChildren?.(node.id)}
+        loading={aiSuggestingRegionId === node.id}
+        disabled={isMutating || aiSuggestingRegionId != null}
+        icon={<SuggestChildrenIcon sx={{ fontSize: 16, color: 'secondary.main' }} />}
+      />
+
+      {/* Manual division search — assign a GADM division by name search */}
+      <ActionIconButton
+        show={!!onManualDivisionSearch && node.matchStatus != null}
+        title="Search and assign GADM division"
+        onClick={() => onManualDivisionSearch?.(node.id)}
+        loading={false}
+        disabled={isMutating}
+        icon={<DivisionSearchIcon sx={{ fontSize: 16 }} />}
+      />
+
+      {/* Dismiss hierarchy warnings (shown on nodes with unreviewed warnings) */}
+      <ActionIconButton
+        show={node.hierarchyWarnings.length > 0 && !node.hierarchyReviewed && !!onDismissHierarchyWarnings}
+        title="Dismiss hierarchy warnings"
+        onClick={() => onDismissHierarchyWarnings?.(node.id)}
+        loading={false}
+        disabled={isMutating}
+        icon={<DismissWarningsIcon sx={{ fontSize: 16, color: 'text.secondary' }} />}
+      />
 
       {/* Manual fix flag */}
-      {node.matchStatus != null && (
-        <Tooltip title={node.needsManualFix ? (node.fixNote ?? 'Needs manual fix — click to clear') : 'Mark as needing manual fix'}>
-          <span>
-            <IconButton
-              size="small"
-              onClick={() => onManualFix(node.id, !node.needsManualFix)}
-              disabled={isMutating}
-              sx={{ p: 0.25 }}
-            >
-              <ManualFixIcon sx={{ fontSize: 16, color: node.needsManualFix ? 'error.main' : 'text.disabled' }} />
-            </IconButton>
-          </span>
-        </Tooltip>
-      )}
+      <ManualFixButton
+        node={node}
+        isMutating={isMutating}
+        onManualFix={onManualFix}
+      />
       {node.needsManualFix && node.fixNote && (
         <Typography variant="caption" color="error" sx={{ fontSize: '0.65rem', fontStyle: 'italic' }}>
           {node.fixNote}
         </Typography>
-      )}
-
-      {/* CV color match — for parent nodes with children and a region map image */}
-      {onCVMatch && hasChildren && !!node.regionMapUrl && (
-        <Tooltip title="CV color match (gap divisions only)">
-          <span>
-            <IconButton
-              size="small"
-              onClick={() => onCVMatch(node.id)}
-              disabled={isMutating || cvMatchingRegionId === node.id}
-              sx={{ p: 0.25 }}
-            >
-              {cvMatchingRegionId === node.id
-                ? <CircularProgress size={14} />
-                : <CVMatchIcon sx={{ fontSize: 16, color: 'info.main' }} />
-              }
-            </IconButton>
-          </span>
-        </Tooltip>
-      )}
-
-      {/* Mapshape match — for parent nodes with children and a Wikivoyage source page */}
-      {onMapshapeMatch && hasChildren && !!node.sourceUrl && (
-        <Tooltip title="Mapshape match (Kartographer region boundaries from Wikivoyage)">
-          <span>
-            <IconButton
-              size="small"
-              onClick={() => onMapshapeMatch(node.id)}
-              disabled={isMutating || mapshapeMatchingRegionId === node.id}
-              sx={{ p: 0.25 }}
-            >
-              {mapshapeMatchingRegionId === node.id
-                ? <CircularProgress size={14} />
-                : <MapshapeMatchIcon sx={{ fontSize: 16, color: 'secondary.main' }} />
-              }
-            </IconButton>
-          </span>
-        </Tooltip>
-      )}
-
-      {/* AI review children (Wikivoyage + AI audit + enrichment) */}
-      {node.sourceUrl && onAISuggestChildren && (
-        <Tooltip title="AI review children">
-          <span>
-            <IconButton
-              size="small"
-              onClick={() => onAISuggestChildren(node.id)}
-              disabled={isMutating || aiSuggestingRegionId != null}
-              sx={{ p: 0.25 }}
-            >
-              {aiSuggestingRegionId === node.id
-                ? <CircularProgress size={14} />
-                : <ReviewChildrenIcon sx={{ fontSize: 16, color: 'secondary.main' }} />
-              }
-            </IconButton>
-          </span>
-        </Tooltip>
       )}
     </>
   );

--- a/frontend/src/components/admin/TreeNodeContent.tsx
+++ b/frontend/src/components/admin/TreeNodeContent.tsx
@@ -1,5 +1,9 @@
+import { useState, useCallback, useEffect } from 'react';
 import {
   Box,
+  Checkbox,
+  Chip,
+  CircularProgress,
   Typography,
   IconButton,
   Button,
@@ -33,27 +37,48 @@ function AssignedDivisionRow({ div, regionId, onReject, onPreview, isMutating }:
         </IconButton>
       </Tooltip>
       <Tooltip title="Reject">
+        <span>
         <IconButton size="small" color="error" onClick={() => onReject(regionId, div.divisionId)} disabled={isMutating} sx={{ p: 0.25 }}>
           <CloseIcon sx={{ fontSize: 16 }} />
         </IconButton>
+        </span>
       </Tooltip>
     </Box>
   );
 }
 
 /** Render a suggestion with accept + reject + preview buttons */
-function SuggestionRow({ suggestion, regionId, onAccept, onAcceptAndRejectRest, onReject, onPreview, onPreviewTransfer, isMutating }: {
+function SuggestionRow({ suggestion, regionId, onAccept, onAcceptAndRejectRest, onReject, onPreview, onAcceptTransfer, onPreviewTransfer, isMutating, checked, onToggle }: {
   suggestion: { divisionId: number; name: string; path: string; score: number; geoSimilarity?: number | null; conflict?: { type: 'direct' | 'split'; donorRegionId: number; donorRegionName: string; donorDivisionId: number; donorDivisionName: string } };
   regionId: number;
   onAccept: (regionId: number, divisionId: number) => void;
   onAcceptAndRejectRest: (regionId: number, divisionId: number) => void;
   onReject: (regionId: number, divisionId: number) => void;
   onPreview: (divisionId: number, name: string, path?: string) => void;
-  onPreviewTransfer?: (divisionId: number, name: string, path: string | undefined, conflict: { donorDivisionId: number; donorDivisionName: string; donorRegionId: number; type: 'direct' | 'split' }, regionId?: number, allDivisionIds?: number[]) => void;
+  onAcceptTransfer?: (regionId: number, divisionId: number, conflict: { type: 'direct' | 'split'; donorRegionId: number; donorDivisionId: number }) => void;
+  onPreviewTransfer?: (divisionId: number, name: string, path: string | undefined, conflict: { donorDivisionId: number; donorDivisionName: string; donorRegionId: number; type: 'direct' | 'split' }, regionId?: number, allDivisionIds?: number[], allSuggestions?: Array<{ divisionId: number; conflict?: { donorDivisionId: number; donorRegionId: number; type: 'direct' | 'split' } }>) => void;
   isMutating: boolean;
+  checked?: boolean;
+  onToggle?: (divisionId: number) => void;
 }) {
+  const geo = suggestion.geoSimilarity;
+  let geoColor: string | undefined;
+  if (geo != null) {
+    if (geo >= 0.7) geoColor = 'success.main';
+    else if (geo >= 0.5) geoColor = 'warning.main';
+    else geoColor = 'text.disabled';
+  }
+
   return (
     <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+      {onToggle && (
+        <Checkbox
+          size="small"
+          checked={checked ?? false}
+          onChange={() => onToggle(suggestion.divisionId)}
+          sx={{ p: 0, '& .MuiSvgIcon-root': { fontSize: 16 } }}
+        />
+      )}
       <Typography variant="caption" color="text.secondary" sx={{ wordBreak: 'break-word' }}>
         {suggestion.path || suggestion.name}
       </Typography>
@@ -75,6 +100,13 @@ function SuggestionRow({ suggestion, regionId, onAccept, onAcceptAndRejectRest, 
           {suggestion.conflict.type === 'split' ? ` (split ${suggestion.conflict.donorDivisionName})` : ''}
         </Typography>
       )}
+      {geo != null ? (
+        <Typography variant="caption" sx={{ color: geoColor, fontWeight: geo >= 0.5 ? 600 : 400, flexShrink: 0 }}>
+          {Math.round(geo * 100)}%
+        </Typography>
+      ) : (
+        <Typography variant="caption" color="text.disabled" sx={{ flexShrink: 0 }}>—</Typography>
+      )}
       <Tooltip title="Preview on map">
         <IconButton size="small" onClick={() => {
           if (suggestion.conflict && onPreviewTransfer) {
@@ -86,12 +118,10 @@ function SuggestionRow({ suggestion, regionId, onAccept, onAcceptAndRejectRest, 
           <MapIcon sx={{ fontSize: 16 }} />
         </IconButton>
       </Tooltip>
-      <Tooltip title={suggestion.conflict ? `Preview transfer from ${suggestion.conflict.donorRegionName}` : 'Accept'}>
+      <Tooltip title={suggestion.conflict ? `Accept and transfer from ${suggestion.conflict.donorRegionName}` : 'Accept'}>
         <IconButton size="small" color="success" onClick={() => {
-          // Conflict accepts must go through the Transfer Preview Dialog so the admin
-          // sees what they're moving before the destructive transfer is committed.
-          if (suggestion.conflict && onPreviewTransfer) {
-            onPreviewTransfer(suggestion.divisionId, suggestion.name, suggestion.path, suggestion.conflict);
+          if (suggestion.conflict && onAcceptTransfer) {
+            onAcceptTransfer(regionId, suggestion.divisionId, suggestion.conflict);
           } else {
             onAccept(regionId, suggestion.divisionId);
           }
@@ -152,6 +182,317 @@ function ShadowMemberRow({ shadow, onApprove, onReject, isMutating }: {
   );
 }
 
+type SelectedBatchAction = (regionId: number, divisionIds: number[]) => void;
+
+function coverageChipColor(pct: number): 'success' | 'warning' | 'error' {
+  if (pct >= 0.9) return 'success';
+  if (pct >= 0.5) return 'warning';
+  return 'error';
+}
+
+/** Coverage chips (loading skeleton + final value) for container nodes */
+function ChildrenCoverageChip({ hasChildren, coverageLoading, coveragePercent, coverageFetching, depth, onCoverageClick, nodeId }: {
+  hasChildren: boolean;
+  coverageLoading?: boolean;
+  coveragePercent?: number;
+  coverageFetching?: boolean;
+  depth: number;
+  onCoverageClick?: (regionId: number) => void;
+  nodeId: number;
+}) {
+  if (!hasChildren) return null;
+  if (coverageLoading) {
+    return (
+      <Box sx={{ pl: depth * 3 + 4.5, pb: 0.3 }}>
+        <Chip
+          size="small"
+          icon={<CircularProgress size={12} />}
+          label="Calculating coverage…"
+          variant="outlined"
+          sx={{ height: 20, '& .MuiChip-label': { px: 0.75, fontSize: '0.65rem' } }}
+        />
+      </Box>
+    );
+  }
+  if (coveragePercent == null) return null;
+  const chipColor = coverageChipColor(coveragePercent);
+  return (
+    <Box sx={{ pl: depth * 3 + 4.5, pb: 0.3 }}>
+      <Chip
+        size="small"
+        icon={coverageFetching ? <CircularProgress size={12} color="inherit" /> : undefined}
+        label={`Children cover ${(coveragePercent * 100).toFixed(2)}%`}
+        color={chipColor}
+        variant="outlined"
+        onClick={onCoverageClick && !coverageFetching ? () => onCoverageClick(nodeId) : undefined}
+        sx={{ height: 20, cursor: onCoverageClick && !coverageFetching ? 'pointer' : 'default', '& .MuiChip-label': { px: 0.75, fontSize: '0.65rem' } }}
+      />
+    </Box>
+  );
+}
+
+/** Geoshape coverage chip rendered below division list */
+function GeoshapeCoverageChip({ geoshapeCoveragePercent, coverageFetching, onCoverageClick, nodeId }: {
+  geoshapeCoveragePercent?: number;
+  coverageFetching?: boolean;
+  onCoverageClick?: (regionId: number) => void;
+  nodeId: number;
+}) {
+  if (geoshapeCoveragePercent == null) return null;
+  const geoChipColor = coverageChipColor(geoshapeCoveragePercent);
+  return (
+    <Chip
+      size="small"
+      variant="outlined"
+      label={`Geoshape ${(geoshapeCoveragePercent * 100).toFixed(1)}%`}
+      icon={coverageFetching ? <CircularProgress size={12} color="inherit" /> : undefined}
+      color={geoChipColor}
+      onClick={onCoverageClick && !coverageFetching ? () => onCoverageClick(nodeId) : undefined}
+      sx={{ height: 18, mt: 0.25, cursor: onCoverageClick && !coverageFetching ? 'pointer' : 'default', '& .MuiChip-label': { px: 0.75, fontSize: '0.65rem' } }}
+    />
+  );
+}
+
+/** Expandable list of assigned divisions with a toggle row */
+function AssignedDivisionsList({ node, divisionsExpanded, setDivisionsExpanded, onReject, handlePreviewAssigned, isMutating, keyPrefix = '' }: {
+  node: MatchTreeNode;
+  divisionsExpanded: boolean;
+  setDivisionsExpanded: (expanded: boolean) => void;
+  onReject: (regionId: number, divisionId: number) => void;
+  handlePreviewAssigned: (divisionId: number, name: string, path?: string) => void;
+  isMutating: boolean;
+  keyPrefix?: string;
+}) {
+  if (divisionsExpanded) {
+    return (
+      <>
+        {node.assignedDivisions.map((div) => (
+          <AssignedDivisionRow key={`${keyPrefix}${div.divisionId}`} div={div} regionId={node.id} onReject={onReject} onPreview={handlePreviewAssigned} isMutating={isMutating} />
+        ))}
+        <Typography
+          variant="caption"
+          color="primary"
+          onClick={() => setDivisionsExpanded(false)}
+          sx={{ cursor: 'pointer', '&:hover': { textDecoration: 'underline' } }}
+        >
+          Hide
+        </Typography>
+      </>
+    );
+  }
+  return (
+    <Typography
+      variant="caption"
+      color="primary"
+      onClick={() => setDivisionsExpanded(true)}
+      sx={{ cursor: 'pointer', '&:hover': { textDecoration: 'underline' } }}
+    >
+      {node.assignedDivisions.length} division{node.assignedDivisions.length !== 1 ? 's' : ''}…
+    </Typography>
+  );
+}
+
+/** Preview-or-accept action for a set of selected suggestions (shared logic) */
+function previewOrRunBatch(
+  node: MatchTreeNode,
+  selectedDivIds: Set<number>,
+  onPreviewTransfer: TreeNodeContentProps['onPreviewTransfer'],
+  fallback: (regionId: number, divisionIds: number[]) => void,
+) {
+  const selectedSuggestions = node.suggestions.filter(s => selectedDivIds.has(s.divisionId));
+  const firstConflict = selectedSuggestions.find(s => s.conflict)?.conflict;
+  if (firstConflict && onPreviewTransfer) {
+    const conflictSuggestions = selectedSuggestions.filter(s => s.conflict).map(s => ({ divisionId: s.divisionId, conflict: s.conflict! }));
+    onPreviewTransfer(selectedSuggestions[0].divisionId, selectedSuggestions[0].name, selectedSuggestions[0].path, firstConflict, node.id, [...selectedDivIds], conflictSuggestions);
+  } else {
+    fallback(node.id, [...selectedDivIds]);
+  }
+}
+
+/** Bulk-select toolbar (appears when 1+ suggestions selected) */
+function SelectedBatchToolbar({ node, selectedDivIds, onPreviewUnion, onAcceptSelected, onAcceptSelectedRejectRest, onRejectSelected, onPreviewTransfer, isMutating }: {
+  node: MatchTreeNode;
+  selectedDivIds: Set<number>;
+  onPreviewUnion?: (regionId: number, divisionIds: number[]) => void;
+  onAcceptSelected?: SelectedBatchAction;
+  onAcceptSelectedRejectRest?: SelectedBatchAction;
+  onRejectSelected?: SelectedBatchAction;
+  onPreviewTransfer?: TreeNodeContentProps['onPreviewTransfer'];
+  isMutating: boolean;
+}) {
+  const selectedSuggestions = node.suggestions.filter(s => selectedDivIds.has(s.divisionId));
+  const hasConflicts = selectedSuggestions.some(s => s.conflict);
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 0.25, pl: 0.25 }}>
+      <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.65rem' }}>
+        {selectedDivIds.size} selected
+      </Typography>
+      {onPreviewUnion && (
+        <Button size="small" variant="text" color="info"
+          onClick={() => onPreviewUnion(node.id, [...selectedDivIds])}
+          disabled={isMutating}
+          sx={{ fontSize: '0.65rem', py: 0, minHeight: 0, textTransform: 'none' }}>
+          Preview union
+        </Button>
+      )}
+      {onAcceptSelected && (
+        <Button size="small" variant="text" color="success"
+          onClick={() => previewOrRunBatch(node, selectedDivIds, onPreviewTransfer, onAcceptSelected)}
+          disabled={isMutating}
+          sx={{ fontSize: '0.65rem', py: 0, minHeight: 0, textTransform: 'none' }}>
+          {hasConflicts ? `Preview transfer (${selectedDivIds.size})` : `Accept ${selectedDivIds.size}`}
+        </Button>
+      )}
+      {onAcceptSelectedRejectRest && (
+        <Button size="small" variant="text" color="success"
+          onClick={() => previewOrRunBatch(node, selectedDivIds, onPreviewTransfer, onAcceptSelectedRejectRest)}
+          disabled={isMutating}
+          sx={{ fontSize: '0.65rem', py: 0, minHeight: 0, textTransform: 'none' }}>
+          {hasConflicts ? `Preview transfer (${selectedDivIds.size}) + reject rest` : `Accept ${selectedDivIds.size} + reject rest`}
+        </Button>
+      )}
+      {onRejectSelected && (
+        <Button size="small" variant="text" color="error"
+          onClick={() => onRejectSelected(node.id, [...selectedDivIds])}
+          disabled={isMutating}
+          sx={{ fontSize: '0.65rem', py: 0, minHeight: 0, textTransform: 'none' }}>
+          Reject {selectedDivIds.size}
+        </Button>
+      )}
+    </Box>
+  );
+}
+
+/** Bulk-accept/reject toolbar that appears above individual suggestion rows */
+function SuggestionsBulkActions({ node, selectedDivIds, setSelectedDivIds, onAcceptAll, onRejectRemaining, onPreviewTransfer, isMutating }: {
+  node: MatchTreeNode;
+  selectedDivIds: Set<number>;
+  setSelectedDivIds: React.Dispatch<React.SetStateAction<Set<number>>>;
+  onAcceptAll: (assignments: Array<{ regionId: number; divisionId: number }>) => void;
+  onRejectRemaining: (regionId: number) => void;
+  onPreviewTransfer?: TreeNodeContentProps['onPreviewTransfer'];
+  isMutating: boolean;
+}) {
+  return (
+    <>
+      {node.suggestions.length > 1 && (
+        <>
+          <Button
+            size="small"
+            variant="text"
+            color="info"
+            onClick={() => {
+              const allIds = node.suggestions.map(s => s.divisionId);
+              const allSelected = allIds.every(id => selectedDivIds.has(id));
+              setSelectedDivIds(allSelected ? new Set() : new Set(allIds));
+            }}
+            sx={{ fontSize: '0.65rem', py: 0, minHeight: 0, textTransform: 'none' }}
+          >
+            {node.suggestions.every(s => selectedDivIds.has(s.divisionId)) ? 'Deselect all' : 'Select all'}
+          </Button>
+          <Button
+            size="small"
+            variant="text"
+            color="success"
+            onClick={() => {
+              const firstConflict = node.suggestions.find(s => s.conflict)?.conflict;
+              if (firstConflict && onPreviewTransfer) {
+                const conflictSuggestions = node.suggestions.filter(s => s.conflict).map(s => ({ divisionId: s.divisionId, conflict: s.conflict! }));
+                onPreviewTransfer(node.suggestions[0].divisionId, node.suggestions[0].name, node.suggestions[0].path, firstConflict, node.id, node.suggestions.map(s => s.divisionId), conflictSuggestions);
+              } else {
+                onAcceptAll(node.suggestions.map(s => ({ regionId: node.id, divisionId: s.divisionId })));
+              }
+            }}
+            disabled={isMutating}
+            sx={{ fontSize: '0.65rem', py: 0, minHeight: 0, textTransform: 'none' }}
+          >
+            {node.suggestions.some(s => s.conflict) ? `Preview transfer (${node.suggestions.length})` : `Accept all ${node.suggestions.length}`}
+          </Button>
+        </>
+      )}
+      {node.suggestions.length > 0 && (
+        <Button
+          size="small"
+          variant="text"
+          color="error"
+          onClick={() => onRejectRemaining(node.id)}
+          disabled={isMutating}
+          sx={{ fontSize: '0.65rem', py: 0, minHeight: 0, textTransform: 'none' }}
+        >
+          Reject {node.assignedDivisions.length > 0 ? 'remaining ' : 'all '}{node.suggestions.length} suggestion{node.suggestions.length > 1 ? 's' : ''}
+        </Button>
+      )}
+    </>
+  );
+}
+
+/** List of add_member shadow insertions with approve/reject buttons */
+function ShadowMemberList({ nodeShadows, onApproveShadow, onRejectShadow, isMutating, depth }: {
+  nodeShadows: ShadowInsertion[];
+  onApproveShadow?: (insertion: ShadowInsertion) => void;
+  onRejectShadow?: (insertion: ShadowInsertion) => void;
+  isMutating: boolean;
+  depth: number;
+}) {
+  return (
+    <Box sx={{ pl: depth * 3 + 4.5, pb: 0.3 }}>
+      {nodeShadows.filter(s => s.action === 'add_member').map(shadow => (
+        <ShadowMemberRow key={`shadow-${shadow.gapDivisionId}`} shadow={shadow} onApprove={onApproveShadow} onReject={onRejectShadow} isMutating={isMutating} />
+      ))}
+    </Box>
+  );
+}
+
+/** create_region shadow rows rendered at the leaf level */
+function CreateRegionShadows({ nodeShadows, onApproveShadow, onRejectShadow, isMutating, depth }: {
+  nodeShadows: ShadowInsertion[];
+  onApproveShadow?: (insertion: ShadowInsertion) => void;
+  onRejectShadow?: (insertion: ShadowInsertion) => void;
+  isMutating: boolean;
+  depth: number;
+}) {
+  return (
+    <Box>
+      {nodeShadows.filter(s => s.action === 'create_region').map(shadow => (
+        <Box
+          key={`shadow-create-${shadow.gapDivisionId}`}
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 0.75,
+            pl: (depth + 1) * 3,
+            py: 0.3,
+            borderBottom: '1px solid',
+            borderColor: 'divider',
+            borderLeft: '2px dashed',
+            borderLeftColor: 'warning.main',
+            bgcolor: 'rgba(237, 108, 2, 0.06)',
+            minHeight: 32,
+          }}
+        >
+          <Box sx={{ width: 28, flexShrink: 0 }} />
+          <Typography variant="body2" sx={{ fontStyle: 'italic' }}>
+            + {shadow.gapDivisionName}
+          </Typography>
+          <Typography variant="caption" color="text.secondary">
+            (new region)
+          </Typography>
+          <Tooltip title="Approve — create region and add member">
+            <IconButton size="small" color="success" onClick={() => onApproveShadow?.(shadow)} disabled={isMutating} sx={{ p: 0.25 }}>
+              <CheckIcon sx={{ fontSize: 16 }} />
+            </IconButton>
+          </Tooltip>
+          <Tooltip title="Reject">
+            <IconButton size="small" color="error" onClick={() => onRejectShadow?.(shadow)} sx={{ p: 0.25 }}>
+              <CloseIcon sx={{ fontSize: 16 }} />
+            </IconButton>
+          </Tooltip>
+        </Box>
+      ))}
+    </Box>
+  );
+}
+
 interface TreeNodeContentProps {
   node: MatchTreeNode;
   depth: number;
@@ -165,10 +506,26 @@ interface TreeNodeContentProps {
   onAcceptAll: (assignments: Array<{ regionId: number; divisionId: number }>) => void;
   handlePreviewAssigned: (divisionId: number, name: string, path?: string) => void;
   handlePreviewSuggestion: (divisionId: number, name: string, path?: string) => void;
-  onPreviewTransfer?: (divisionId: number, name: string, path: string | undefined, conflict: { donorDivisionId: number; donorDivisionName: string; donorRegionId: number; type: 'direct' | 'split' }, regionId?: number, allDivisionIds?: number[]) => void;
+  onPreviewTransfer?: (divisionId: number, name: string, path: string | undefined, conflict: { donorDivisionId: number; donorDivisionName: string; donorRegionId: number; type: 'direct' | 'split' }, regionId?: number, allDivisionIds?: number[], allSuggestions?: Array<{ divisionId: number; conflict?: { donorDivisionId: number; donorRegionId: number; type: 'direct' | 'split' } }>) => void;
   onApproveShadow?: (insertion: ShadowInsertion) => void;
   onRejectShadow?: (insertion: ShadowInsertion) => void;
+  onPreviewUnion?: (regionId: number, divisionIds: number[]) => void;
+  onAcceptSelected?: (regionId: number, divisionIds: number[]) => void;
+  onAcceptSelectedRejectRest?: (regionId: number, divisionIds: number[]) => void;
+  onRejectSelected?: (regionId: number, divisionIds: number[]) => void;
   isMutating: boolean;
+  /** Children coverage percentage (0-1) for container nodes */
+  coveragePercent?: number;
+  /** Geoshape coverage percentage (0-1) — how well assigned divisions cover the source geoshape */
+  geoshapeCoveragePercent?: number;
+  /** Whether coverage data is still loading for the first time */
+  coverageLoading?: boolean;
+  /** Whether coverage data is being refetched for this node */
+  coverageFetching?: boolean;
+  /** Callback when coverage chip is clicked */
+  onCoverageClick?: (regionId: number) => void;
+  /** Notify virtualizer to re-measure row height after content resize */
+  onContentResize?: () => void;
 }
 
 export function TreeNodeContent({
@@ -187,34 +544,109 @@ export function TreeNodeContent({
   onPreviewTransfer,
   onApproveShadow,
   onRejectShadow,
+  onPreviewUnion,
+  onAcceptSelected,
+  onAcceptSelectedRejectRest,
+  onRejectSelected,
   isMutating,
+  coveragePercent,
+  geoshapeCoveragePercent,
+  coverageLoading,
+  coverageFetching,
+  onCoverageClick,
+  onContentResize,
 }: TreeNodeContentProps) {
+  const [selectedDivIds, setSelectedDivIds] = useState<Set<number>>(new Set());
+  const [divisionsExpanded, setDivisionsExpanded] = useState(false);
+  const showCheckboxes = node.suggestions.length > 1;
+
+  // Reset collapse state when node changes (virtualized list may reuse component)
+  useEffect(() => {
+    setDivisionsExpanded(false);
+  }, [node.id]);
+
+  // Notify virtualizer to re-measure row height when divisions expand/collapse
+  useEffect(() => {
+    onContentResize?.();
+  }, [divisionsExpanded, onContentResize]);
+
+  const toggleSelection = useCallback((divisionId: number) => {
+    setSelectedDivIds(prev => {
+      const next = new Set(prev);
+      if (next.has(divisionId)) next.delete(divisionId);
+      else next.add(divisionId);
+      return next;
+    });
+  }, []);
+
+  // Clear selection when suggestions change (accept/reject)
+  useEffect(() => {
+    setSelectedDivIds(new Set());
+  }, [node.suggestions.length]);
+
+  const isMatchedCountry = role === 'country' && (node.matchStatus === 'auto_matched' || node.matchStatus === 'manual_matched');
+  const isReviewSuggestedCountry = role === 'country' && (node.matchStatus === 'needs_review' || node.matchStatus === 'suggested');
+  const isChildrenMatched = role === 'country' || node.matchStatus === 'children_matched';
+  const showMatchedDivisions = isChildrenMatched
+    && (node.matchStatus === 'auto_matched' || node.matchStatus === 'manual_matched' || node.matchStatus === 'children_matched')
+    && node.assignedDivisions.length > 0;
+  const showReviewDivisions = isReviewSuggestedCountry && (node.assignedDivisions.length > 0 || node.suggestions.length > 0);
+  const hasAddMemberShadows = !!nodeShadows?.some(s => s.action === 'add_member');
+  const showUnmatchedAddMemberShadows = node.matchStatus !== 'auto_matched'
+    && node.matchStatus !== 'manual_matched'
+    && !(node.matchStatus === 'needs_review' || node.matchStatus === 'suggested')
+    && hasAddMemberShadows;
+  const showCreateRegionShadows = !hasChildren && !!nodeShadows?.some(s => s.action === 'create_region');
+
   return (
     <>
-      {/* Division list for matched countries */}
-      {role === 'country' && (node.matchStatus === 'auto_matched' || node.matchStatus === 'manual_matched') && node.assignedDivisions.length > 0 && (
+      <ChildrenCoverageChip
+        hasChildren={hasChildren}
+        coverageLoading={coverageLoading}
+        coveragePercent={coveragePercent}
+        coverageFetching={coverageFetching}
+        depth={depth}
+        onCoverageClick={onCoverageClick}
+        nodeId={node.id}
+      />
+
+      {/* Division list for matched countries and drilled-down parents */}
+      {showMatchedDivisions && (
         <Box sx={{ pl: depth * 3 + 4.5, pb: 0.3 }}>
-          {node.assignedDivisions.map((div) => (
-            <AssignedDivisionRow key={div.divisionId} div={div} regionId={node.id} onReject={onReject} onPreview={handlePreviewAssigned} isMutating={isMutating} />
-          ))}
+          <AssignedDivisionsList
+            node={node}
+            divisionsExpanded={divisionsExpanded}
+            setDivisionsExpanded={setDivisionsExpanded}
+            onReject={onReject}
+            handlePreviewAssigned={handlePreviewAssigned}
+            isMutating={isMutating}
+          />
+          <GeoshapeCoverageChip
+            geoshapeCoveragePercent={geoshapeCoveragePercent}
+            coverageFetching={coverageFetching}
+            onCoverageClick={onCoverageClick}
+            nodeId={node.id}
+          />
         </Box>
       )}
 
       {/* Shadow insertions for add_member on matched regions */}
-      {role === 'country' && (node.matchStatus === 'auto_matched' || node.matchStatus === 'manual_matched') && nodeShadows?.some(s => s.action === 'add_member') && (
-        <Box sx={{ pl: depth * 3 + 4.5, pb: 0.3 }}>
-          {nodeShadows.filter(s => s.action === 'add_member').map(shadow => (
-            <ShadowMemberRow key={`shadow-${shadow.gapDivisionId}`} shadow={shadow} onApprove={onApproveShadow} onReject={onRejectShadow} isMutating={isMutating} />
-          ))}
-        </Box>
+      {isMatchedCountry && hasAddMemberShadows && nodeShadows && (
+        <ShadowMemberList nodeShadows={nodeShadows} onApproveShadow={onApproveShadow} onRejectShadow={onRejectShadow} isMutating={isMutating} depth={depth} />
       )}
 
       {/* Suggestions and assigned divisions for review/suggested countries */}
-      {role === 'country' && (node.matchStatus === 'needs_review' || node.matchStatus === 'suggested') && (node.assignedDivisions.length > 0 || node.suggestions.length > 0) && (
+      {showReviewDivisions && (
         <Box sx={{ pl: depth * 3 + 4.5, pb: 0.3 }}>
-          {node.assignedDivisions.map((div) => (
-            <AssignedDivisionRow key={`a-${div.divisionId}`} div={div} regionId={node.id} onReject={onReject} onPreview={handlePreviewAssigned} isMutating={isMutating} />
-          ))}
+          <AssignedDivisionsList
+            node={node}
+            divisionsExpanded={divisionsExpanded}
+            setDivisionsExpanded={setDivisionsExpanded}
+            onReject={onReject}
+            handlePreviewAssigned={handlePreviewAssigned}
+            isMutating={isMutating}
+            keyPrefix="a-"
+          />
           {node.suggestions.map((suggestion) => (
             <SuggestionRow
               key={`s-${suggestion.divisionId}`}
@@ -226,103 +658,47 @@ export function TreeNodeContent({
               onPreview={handlePreviewSuggestion}
               onPreviewTransfer={onPreviewTransfer}
               isMutating={isMutating}
+              checked={selectedDivIds.has(suggestion.divisionId)}
+              onToggle={showCheckboxes ? toggleSelection : undefined}
             />
           ))}
-          {node.suggestions.length > 1 && (
-            <Button
-              size="small"
-              variant="text"
-              color="success"
-              onClick={() => {
-                const conflictSuggestion = node.suggestions.find(s => s.conflict);
-                if (conflictSuggestion?.conflict && onPreviewTransfer) {
-                  onPreviewTransfer(conflictSuggestion.divisionId, conflictSuggestion.name, conflictSuggestion.path, conflictSuggestion.conflict, node.id, node.suggestions.map(s => s.divisionId));
-                } else {
-                  onAcceptAll(node.suggestions.map(s => ({ regionId: node.id, divisionId: s.divisionId })));
-                }
-              }}
-              disabled={isMutating}
-              sx={{ fontSize: '0.65rem', py: 0, minHeight: 0, textTransform: 'none' }}
-            >
-              {node.suggestions.some(s => s.conflict) ? `Preview transfer (${node.suggestions.length})` : `Accept all ${node.suggestions.length}`}
-            </Button>
-          )}
-          {node.suggestions.length > 0 && (
-            <Button
-              size="small"
-              variant="text"
-              color="error"
-              onClick={() => onRejectRemaining(node.id)}
-              disabled={isMutating}
-              sx={{ fontSize: '0.65rem', py: 0, minHeight: 0, textTransform: 'none' }}
-            >
-              Reject {node.assignedDivisions.length > 0 ? 'remaining ' : 'all '}{node.suggestions.length} suggestion{node.suggestions.length > 1 ? 's' : ''}
-            </Button>
+          <SuggestionsBulkActions
+            node={node}
+            selectedDivIds={selectedDivIds}
+            setSelectedDivIds={setSelectedDivIds}
+            onAcceptAll={onAcceptAll}
+            onRejectRemaining={onRejectRemaining}
+            onPreviewTransfer={onPreviewTransfer}
+            isMutating={isMutating}
+          />
+          {selectedDivIds.size > 0 && (
+            <SelectedBatchToolbar
+              node={node}
+              selectedDivIds={selectedDivIds}
+              onPreviewUnion={onPreviewUnion}
+              onAcceptSelected={onAcceptSelected}
+              onAcceptSelectedRejectRest={onAcceptSelectedRejectRest}
+              onRejectSelected={onRejectSelected}
+              onPreviewTransfer={onPreviewTransfer}
+              isMutating={isMutating}
+            />
           )}
         </Box>
       )}
 
       {/* Shadow insertions for add_member on unmatched/container regions */}
-      {node.matchStatus !== 'auto_matched' && node.matchStatus !== 'manual_matched'
-        && !(node.matchStatus === 'needs_review' || node.matchStatus === 'suggested')
-        && nodeShadows?.some(s => s.action === 'add_member') && (
-        <Box sx={{ pl: depth * 3 + 4.5, pb: 0.3 }}>
-          {nodeShadows.filter(s => s.action === 'add_member').map(shadow => (
-            <ShadowMemberRow key={`shadow-${shadow.gapDivisionId}`} shadow={shadow} onApprove={onApproveShadow} onReject={onRejectShadow} isMutating={isMutating} />
-          ))}
-        </Box>
+      {showUnmatchedAddMemberShadows && nodeShadows && (
+        <ShadowMemberList nodeShadows={nodeShadows} onApproveShadow={onApproveShadow} onRejectShadow={onRejectShadow} isMutating={isMutating} depth={depth} />
       )}
 
       {/* Shadow insertions for add_member on needs_review/suggested regions */}
-      {role === 'country' && (node.matchStatus === 'needs_review' || node.matchStatus === 'suggested')
-        && nodeShadows?.some(s => s.action === 'add_member') && (
-        <Box sx={{ pl: depth * 3 + 4.5, pb: 0.3 }}>
-          {nodeShadows.filter(s => s.action === 'add_member').map(shadow => (
-            <ShadowMemberRow key={`shadow-${shadow.gapDivisionId}`} shadow={shadow} onApprove={onApproveShadow} onReject={onRejectShadow} isMutating={isMutating} />
-          ))}
-        </Box>
+      {isReviewSuggestedCountry && hasAddMemberShadows && nodeShadows && (
+        <ShadowMemberList nodeShadows={nodeShadows} onApproveShadow={onApproveShadow} onRejectShadow={onRejectShadow} isMutating={isMutating} depth={depth} />
       )}
 
       {/* Shadow insertions for create_region on leaf nodes */}
-      {!hasChildren && nodeShadows?.some(s => s.action === 'create_region') && (
-        <Box>
-          {nodeShadows.filter(s => s.action === 'create_region').map(shadow => (
-            <Box
-              key={`shadow-create-${shadow.gapDivisionId}`}
-              sx={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: 0.75,
-                pl: (depth + 1) * 3,
-                py: 0.3,
-                borderBottom: '1px solid',
-                borderColor: 'divider',
-                borderLeft: '2px dashed',
-                borderLeftColor: 'warning.main',
-                bgcolor: 'rgba(237, 108, 2, 0.06)',
-                minHeight: 32,
-              }}
-            >
-              <Box sx={{ width: 28, flexShrink: 0 }} />
-              <Typography variant="body2" sx={{ fontStyle: 'italic' }}>
-                + {shadow.gapDivisionName}
-              </Typography>
-              <Typography variant="caption" color="text.secondary">
-                (new region)
-              </Typography>
-              <Tooltip title="Approve — create region and add member">
-                <IconButton size="small" color="success" onClick={() => onApproveShadow?.(shadow)} disabled={isMutating} sx={{ p: 0.25 }}>
-                  <CheckIcon sx={{ fontSize: 16 }} />
-                </IconButton>
-              </Tooltip>
-              <Tooltip title="Reject">
-                <IconButton size="small" color="error" onClick={() => onRejectShadow?.(shadow)} sx={{ p: 0.25 }}>
-                  <CloseIcon sx={{ fontSize: 16 }} />
-                </IconButton>
-              </Tooltip>
-            </Box>
-          ))}
-        </Box>
+      {showCreateRegionShadows && nodeShadows && (
+        <CreateRegionShadows nodeShadows={nodeShadows} onApproveShadow={onApproveShadow} onRejectShadow={onRejectShadow} isMutating={isMutating} depth={depth} />
       )}
     </>
   );

--- a/frontend/src/components/admin/TreeNodeRow.tsx
+++ b/frontend/src/components/admin/TreeNodeRow.tsx
@@ -1,18 +1,18 @@
-import { useCallback, useMemo } from 'react';
+import { memo, useCallback, useMemo, type ReactElement } from 'react';
 import {
   Box,
+  Chip,
   Typography,
   IconButton,
-  Collapse,
   Link,
 } from '@mui/material';
 import {
   ExpandMore as ExpandIcon,
   ChevronRight as CollapseRightIcon,
-  Check as CheckIcon,
-  Close as CloseIcon,
   OpenInNew as OpenInNewIcon,
   Image as ImageIcon,
+  WarningAmber as WarningAmberIcon,
+  PublicOff as PublicOffIcon,
 } from '@mui/icons-material';
 import type { MatchTreeNode } from '../../api/admin/worldViewImport';
 import { Tooltip, type ShadowInsertion } from './treeNodeShared';
@@ -32,47 +32,269 @@ export interface TreeNodeRowProps {
   onDBSearch: (regionId: number) => void;
   onAIMatch: (regionId: number) => void;
   onDismissChildren: (regionId: number) => void;
-  onSimplifyHierarchy: (regionId: number) => void;
-  onSimplifyChildren: (regionId: number) => void;
-  onSmartSimplify: (regionId: number) => void;
-  onAISuggestChildren?: (regionId: number) => void;
-  onCVMatch?: (regionId: number) => void;
-  cvMatchingRegionId?: number | null;
-  onMapshapeMatch?: (regionId: number) => void;
-  mapshapeMatchingRegionId?: number | null;
   onSync: (regionId: number) => void;
   onHandleAsGrouping: (regionId: number) => void;
   onGeocodeMatch: (regionId: number) => void;
   onGeoshapeMatch: (regionId: number, scopeAncestorId?: number) => void;
   onPointMatch: (regionId: number, scopeAncestorId?: number) => void;
-  onPreviewTransfer?: (divisionId: number, name: string, path: string | undefined, conflict: { donorDivisionId: number; donorDivisionName: string; donorRegionId: number; type: 'direct' | 'split' }, wikidataId: string, regionName: string, regionId?: number, allDivisionIds?: number[]) => void;
   onResetMatch: (regionId: number) => void;
   onRejectRemaining: (regionId: number) => void;
   onAcceptAll: (assignments: Array<{ regionId: number; divisionId: number }>) => void;
-  onPreview: (divisionId: number, name: string, path?: string, regionMapUrl?: string, wikidataId?: string, regionId?: number, isAssigned?: boolean, markerPoints?: Array<{ name: string; lat: number; lon: number }>) => void;
+  onPreviewUnion?: (regionId: number, divisionIds: number[], context: { wikidataId?: string; regionMapUrl?: string; regionMapLabel?: string; regionName: string }) => void;
+  onPreviewTransfer?: (divisionId: number, name: string, path: string | undefined, conflict: { donorDivisionId: number; donorDivisionName: string; donorRegionId: number; type: 'direct' | 'split' }, wikidataId: string, regionName: string, regionId?: number, allDivisionIds?: number[], allSuggestions?: Array<{ divisionId: number; conflict?: { donorDivisionId: number; donorRegionId: number; type: 'direct' | 'split' } }>) => void;
+  onAcceptSelected?: (regionId: number, divisionIds: number[]) => void;
+  onAcceptSelectedRejectRest?: (regionId: number, divisionIds: number[]) => void;
+  onRejectSelected?: (regionId: number, divisionIds: number[]) => void;
+  onPreview: (divisionId: number, name: string, path?: string, regionMapUrl?: string, wikidataId?: string, regionId?: number, isAssigned?: boolean, regionMapLabel?: string, regionName?: string, markerPoints?: Array<{ name: string; lat: number; lon: number }>) => void;
   onOpenMapPicker: (node: MatchTreeNode, pendingPreview?: { divisionId: number; name: string; path?: string; isAssigned: boolean }) => void;
   onManualFix: (regionId: number, needsManualFix: boolean, fixNote?: string) => void;
   isMutating: boolean;
   dbSearchingRegionId: number | null;
   aiMatchingRegionId: number | null;
   dismissingRegionId: number | null;
-  simplifyingRegionId: number | null;
-  simplifyingChildrenRegionId: number | null;
-  aiSuggestingRegionId?: number | null;
   syncingRegionId: number | null;
   groupingRegionId: number | null;
   geocodeMatchingRegionId: number | null;
   geoshapeMatchingRegionId: number | null;
   pointMatchingRegionId: number | null;
+  /** Nearest ancestor's region map URL — fallback for preview when node has no own image/geoshape */
+  parentRegionMapUrl?: string;
+  parentRegionMapName?: string;
   geocodeProgress: { regionId: number; message: string; nextScope?: { ancestorId: number; ancestorName: string }; retryType?: 'geoshape' | 'point' } | null;
   duplicateUrls: Set<string>;
   syncedUrls: Set<string>;
   shadowsByRegionId: Map<number, ShadowInsertion[]>;
   onApproveShadow?: (insertion: ShadowInsertion) => void;
   onRejectShadow?: (insertion: ShadowInsertion) => void;
-  skipAnimationRef: React.RefObject<boolean>;
   /** True when any ancestor is matched (has assigned GADM divisions covering this node's territory) */
   ancestorIsMatched: boolean;
+  /** Region ID currently highlighted by single-child navigation */
+  highlightedRegionId?: number | null;
+  onMergeChild?: (regionId: number) => void;
+  mergingRegionId?: number | null;
+  onSmartFlatten?: (regionId: number) => void;
+  flatteningRegionId?: number | null;
+  onDismissHierarchyWarnings?: (regionId: number) => void;
+  onAddChild?: (parentRegionId: number) => void;
+  onRemoveRegion?: (regionId: number) => void;
+  removingRegionId?: number | null;
+  onCollapseToParent?: (regionId: number) => void;
+  collapsingRegionId?: number | null;
+  onAutoResolve?: (regionId: number) => void;
+  autoResolvingRegionId?: number | null;
+  onReviewSubtree?: (regionId: number) => void;
+  reviewingRegionId?: number | null;
+  onRename?: (regionId: number, currentName: string) => void;
+  renamingRegionId?: number | null;
+  onReparent?: (regionId: number, currentParentId: number | null) => void;
+  reparentingRegionId?: number | null;
+  onAISuggestChildren?: (regionId: number) => void;
+  aiSuggestingRegionId?: number | null;
+  onManualDivisionSearch?: (regionId: number) => void;
+  onPruneToLeaves?: (regionId: number) => void;
+  pruningRegionId?: number | null;
+  onViewMap?: (regionId: number, context: { wikidataId?: string; regionMapUrl?: string; regionMapLabel?: string; regionName: string; divisionIds: number[] }) => void;
+  onCVMatch?: (regionId: number) => void;
+  cvMatchingRegionId?: number | null;
+  onMapshapeMatch?: (regionId: number) => void;
+  mapshapeMatchingRegionId?: number | null;
+  onClearMembers?: (regionId: number) => void;
+  clearingMembersRegionId?: number | null;
+  onSimplifyHierarchy?: (regionId: number) => void;
+  simplifyingRegionId?: number | null;
+  onSimplifyChildren?: (regionId: number) => void;
+  simplifyingChildrenRegionId?: number | null;
+  onSmartSimplify?: (regionId: number) => void;
+  onCheckOverlap?: (regionId: number) => void;
+  checkingOverlapRegionId?: number | null;
+  /** Coverage % data for all regions */
+  coverageData?: Record<string, number>;
+  /** Whether coverage data is still loading for the first time */
+  coverageLoading?: boolean;
+  /** Set of region IDs whose coverage is being recalculated */
+  coverageDirtyIds?: ReadonlySet<number>;
+  /** Callback when coverage chip is clicked */
+  onCoverageClick?: (regionId: number) => void;
+  /** Notify virtualizer to re-measure row height after content resize */
+  onContentResize?: () => void;
+}
+
+/** Compute the fallback map label when the node has no own region map. */
+function computeFallbackMapLabel(
+  ownRegionMapUrl: string | null | undefined,
+  parentRegionMapUrl: string | undefined,
+  parentRegionMapName: string | undefined,
+): string | undefined {
+  if (ownRegionMapUrl || !parentRegionMapUrl) return undefined;
+  return parentRegionMapName ? `Parent region map (${parentRegionMapName})` : 'Parent region map';
+}
+
+/** Hook: build the preview-callbacks that depend on node + map-picker interception */
+function usePreviewCallbacks(
+  node: MatchTreeNode,
+  shouldInterceptPreview: boolean,
+  effectiveMapUrl: string | undefined,
+  fallbackMapLabel: string | undefined,
+  onPreview: TreeNodeRowProps['onPreview'],
+  onOpenMapPicker: TreeNodeRowProps['onOpenMapPicker'],
+  onPreviewTransfer: TreeNodeRowProps['onPreviewTransfer'],
+  onPreviewUnion: TreeNodeRowProps['onPreviewUnion'],
+  onViewMap: TreeNodeRowProps['onViewMap'],
+) {
+  const handlePreviewAssigned = useCallback(
+    (divisionId: number, name: string, path?: string) => {
+      if (shouldInterceptPreview) {
+        onOpenMapPicker(node, { divisionId, name, path, isAssigned: true });
+        return;
+      }
+      onPreview(divisionId, name, path, effectiveMapUrl, node.wikidataId ?? undefined, node.id, true, fallbackMapLabel, node.name, node.markerPoints ?? undefined);
+    },
+    [onPreview, node, shouldInterceptPreview, onOpenMapPicker, effectiveMapUrl, fallbackMapLabel],
+  );
+  const handlePreviewSuggestion = useCallback(
+    (divisionId: number, name: string, path?: string) => {
+      if (shouldInterceptPreview) {
+        onOpenMapPicker(node, { divisionId, name, path, isAssigned: false });
+        return;
+      }
+      onPreview(divisionId, name, path, effectiveMapUrl, node.wikidataId ?? undefined, node.id, false, fallbackMapLabel, node.name, node.markerPoints ?? undefined);
+    },
+    [onPreview, node, shouldInterceptPreview, onOpenMapPicker, effectiveMapUrl, fallbackMapLabel],
+  );
+  const handlePreviewUnion = useCallback(
+    (regionId: number, divisionIds: number[]) => {
+      onPreviewUnion?.(regionId, divisionIds, {
+        wikidataId: node.wikidataId ?? undefined,
+        regionMapUrl: effectiveMapUrl,
+        regionMapLabel: fallbackMapLabel,
+        regionName: node.name,
+      });
+    },
+    [onPreviewUnion, node.wikidataId, node.name, effectiveMapUrl, fallbackMapLabel],
+  );
+  const handlePreviewTransferSuggestion = useCallback(
+    (divisionId: number, name: string, path: string | undefined, conflict: { donorDivisionId: number; donorDivisionName: string; donorRegionId: number; type: 'direct' | 'split' }, regionId?: number, allDivisionIds?: number[], allSuggestions?: Array<{ divisionId: number; conflict?: { donorDivisionId: number; donorRegionId: number; type: 'direct' | 'split' } }>) => {
+      if (onPreviewTransfer && node.wikidataId) {
+        onPreviewTransfer(divisionId, name, path, conflict, node.wikidataId, node.name, regionId, allDivisionIds, allSuggestions);
+      }
+    },
+    [onPreviewTransfer, node.wikidataId, node.name],
+  );
+  const handleViewMap = useCallback(
+    () => {
+      onViewMap?.(node.id, {
+        wikidataId: node.wikidataId ?? undefined,
+        regionMapUrl: effectiveMapUrl,
+        regionMapLabel: fallbackMapLabel,
+        regionName: node.name,
+        divisionIds: node.assignedDivisions.map(d => d.divisionId),
+      });
+    },
+    [onViewMap, node.id, node.wikidataId, node.name, node.assignedDivisions, effectiveMapUrl, fallbackMapLabel],
+  );
+  return {
+    handlePreviewAssigned,
+    handlePreviewSuggestion,
+    handlePreviewUnion,
+    handlePreviewTransferSuggestion,
+    handleViewMap,
+  };
+}
+
+/** Render the map-image picker button for a country-role node if applicable. */
+function MapImagePickerButton({
+  node,
+  role,
+  onOpenMapPicker,
+}: {
+  node: MatchTreeNode;
+  role: 'container' | 'country' | 'subdivision';
+  onOpenMapPicker: TreeNodeRowProps['onOpenMapPicker'];
+}): ReactElement | null {
+  if (role !== 'country') return null;
+  if (node.mapImageCandidates.length <= 1) return null;
+  if (node.regionMapUrl) return null;
+  if (node.matchStatus !== 'needs_review' && node.matchStatus !== 'suggested') return null;
+  return (
+    <Tooltip title={`${node.mapImageCandidates.length} image candidates${node.mapImageReviewed ? ' (reviewed)' : ''}`}>
+      <IconButton size="small" onClick={() => onOpenMapPicker(node)} sx={{ p: 0.25 }}>
+        <ImageIcon sx={{ fontSize: 16, color: node.mapImageReviewed ? 'success.main' : 'warning.main' }} />
+      </IconButton>
+    </Tooltip>
+  );
+}
+
+/** Render the expand/collapse caret for a row. */
+function ExpandToggle({
+  hasChildren,
+  isExpanded,
+  onClick,
+}: {
+  hasChildren: boolean;
+  isExpanded: boolean;
+  onClick: () => void;
+}): ReactElement {
+  return (
+    <Box sx={{ width: 28, flexShrink: 0 }}>
+      {hasChildren ? (
+        <IconButton size="small" onClick={onClick} sx={{ p: 0.25 }}>
+          {isExpanded ? <ExpandIcon fontSize="small" /> : <CollapseRightIcon fontSize="small" />}
+        </IconButton>
+      ) : null}
+    </Box>
+  );
+}
+
+/** Render the hierarchy-warning indicator when there are unreviewed warnings. */
+function HierarchyWarningIcon({ node }: { node: MatchTreeNode }): ReactElement | null {
+  if (node.hierarchyWarnings.length === 0 || node.hierarchyReviewed) return null;
+  return (
+    <Tooltip title={node.hierarchyWarnings.join('\n')}>
+      <WarningAmberIcon sx={{ fontSize: 16, color: 'warning.main', flexShrink: 0 }} />
+    </Tooltip>
+  );
+}
+
+/** External source link glyph. */
+function SourcePageLink({ url }: { url: string | null | undefined }): ReactElement | null {
+  if (!url) return null;
+  return (
+    <Link
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      sx={{ display: 'flex', alignItems: 'center', flexShrink: 0 }}
+    >
+      <OpenInNewIcon sx={{ fontSize: 13 }} />
+    </Link>
+  );
+}
+
+/** Render the geo-similarity chip (or "no geoshape" icon) for a node, or null. */
+function GeoSimilarityBadge({ node }: { node: MatchTreeNode }): ReactElement | null {
+  if (node.assignedDivisions.length > 0) return null;
+  const topSuggestion = node.suggestions[0];
+  const geo = topSuggestion?.geoSimilarity;
+  if (geo != null && geo >= 0.5) {
+    const isStrong = geo >= 0.7;
+    return (
+      <Chip
+        size="small"
+        variant="outlined"
+        label={`${isStrong ? 'Strong geo' : 'Geo'} ${Math.round(geo * 100)}%`}
+        color={isStrong ? 'success' : 'warning'}
+        sx={{ height: 18, '& .MuiChip-label': { px: 0.75, fontSize: '0.65rem' } }}
+      />
+    );
+  }
+  if (node.geoAvailable === false) {
+    return (
+      <Tooltip title="No geoshape available for comparison">
+        <PublicOffIcon sx={{ fontSize: 14, color: 'text.disabled', flexShrink: 0 }} />
+      </Tooltip>
+    );
+  }
+  return null;
 }
 
 /** Determine the role of a node for display purposes */
@@ -93,13 +315,109 @@ function getNodeRole(node: MatchTreeNode): 'container' | 'country' | 'subdivisio
   return 'container';
 }
 
-export function TreeNodeRow({ node, depth, expanded, onToggle, onAccept, onAcceptTransfer, onAcceptAndRejectRest, onReject, onDBSearch, onAIMatch, onDismissChildren, onSimplifyHierarchy, onSimplifyChildren, onSmartSimplify, onAISuggestChildren, onCVMatch, cvMatchingRegionId, onMapshapeMatch, mapshapeMatchingRegionId, onSync, onHandleAsGrouping, onGeocodeMatch, onGeoshapeMatch, onPointMatch, onResetMatch, onRejectRemaining, onAcceptAll, onPreview, onPreviewTransfer, onOpenMapPicker, onManualFix, isMutating, dbSearchingRegionId, aiMatchingRegionId, dismissingRegionId, simplifyingRegionId, simplifyingChildrenRegionId, aiSuggestingRegionId, syncingRegionId, groupingRegionId, geocodeMatchingRegionId, geoshapeMatchingRegionId, pointMatchingRegionId, geocodeProgress, duplicateUrls, syncedUrls, shadowsByRegionId, onApproveShadow, onRejectShadow, skipAnimationRef, ancestorIsMatched }: TreeNodeRowProps) {
+/** Every per-node "currently-busy-with-this-ID" prop. Comparator scans these as a list. */
+const LOADING_KEYS: ReadonlyArray<keyof TreeNodeRowProps> = [
+  'dbSearchingRegionId',
+  'aiMatchingRegionId',
+  'dismissingRegionId',
+  'syncingRegionId',
+  'groupingRegionId',
+  'geocodeMatchingRegionId',
+  'geoshapeMatchingRegionId',
+  'pointMatchingRegionId',
+  'mergingRegionId',
+  'flatteningRegionId',
+  'removingRegionId',
+  'collapsingRegionId',
+  'autoResolvingRegionId',
+  'reviewingRegionId',
+  'renamingRegionId',
+  'reparentingRegionId',
+  'aiSuggestingRegionId',
+  'cvMatchingRegionId',
+  'mapshapeMatchingRegionId',
+  'clearingMembersRegionId',
+  'simplifyingRegionId',
+  'simplifyingChildrenRegionId',
+  'checkingOverlapRegionId',
+];
+
+function scalarPropsEqual(prev: TreeNodeRowProps, next: TreeNodeRowProps): boolean {
+  return (
+    prev.node === next.node &&
+    prev.depth === next.depth &&
+    prev.ancestorIsMatched === next.ancestorIsMatched &&
+    prev.isMutating === next.isMutating &&
+    prev.parentRegionMapUrl === next.parentRegionMapUrl &&
+    prev.parentRegionMapName === next.parentRegionMapName &&
+    prev.coverageLoading === next.coverageLoading
+  );
+}
+
+function loadingStatesEqual(prev: TreeNodeRowProps, next: TreeNodeRowProps, id: number): boolean {
+  for (const key of LOADING_KEYS) {
+    // eslint-disable-next-line security/detect-object-injection -- key iterated from LOADING_KEYS (module-level const string[]); prev/next are typed TreeNodeRowProps
+    if ((prev[key] === id) !== (next[key] === id)) return false;
+  }
+  return true;
+}
+
+function geocodeStatusEqual(prev: TreeNodeRowProps, next: TreeNodeRowProps, id: number): boolean {
+  const prevGeo = prev.geocodeProgress?.regionId === id ? prev.geocodeProgress : null;
+  const nextGeo = next.geocodeProgress?.regionId === id ? next.geocodeProgress : null;
+  return (
+    prevGeo?.message === nextGeo?.message &&
+    prevGeo?.nextScope?.ancestorId === nextGeo?.nextScope?.ancestorId
+  );
+}
+
+function urlStatusEqual(prev: TreeNodeRowProps, next: TreeNodeRowProps): boolean {
+  const url = prev.node.sourceUrl;
+  if (!url) return true;
+  return (
+    prev.duplicateUrls.has(url) === next.duplicateUrls.has(url) &&
+    prev.syncedUrls.has(url) === next.syncedUrls.has(url)
+  );
+}
+
+/** Custom comparator for React.memo — only re-render when rendering-relevant props change.
+ * Skips callback comparisons (they're semantically stable) and compares collection props
+ * (Sets, Maps) only for THIS node's values, not by reference identity. */
+function arePropsEqual(prev: TreeNodeRowProps, next: TreeNodeRowProps): boolean {
+  if (!scalarPropsEqual(prev, next)) return false;
+
+  // Only this node's expanded state matters
+  if (prev.expanded.has(prev.node.id) !== next.expanded.has(next.node.id)) return false;
+
+  // Only whether THIS node is highlighted matters
+  if (
+    (prev.highlightedRegionId === prev.node.id) !==
+    (next.highlightedRegionId === next.node.id)
+  ) {
+    return false;
+  }
+
+  const id = prev.node.id;
+  if (!loadingStatesEqual(prev, next, id)) return false;
+
+  // Coverage data for this node
+  if (prev.coverageData?.[String(id)] !== next.coverageData?.[String(id)]) return false;
+  if (prev.coverageDirtyIds?.has(id) !== next.coverageDirtyIds?.has(id)) return false;
+
+  if (!geocodeStatusEqual(prev, next, id)) return false;
+  if (!urlStatusEqual(prev, next)) return false;
+
+  // Shadow insertions for this node
+  if (prev.shadowsByRegionId.get(id) !== next.shadowsByRegionId.get(id)) return false;
+
+  return true;
+}
+
+export const TreeNodeRow = memo(function TreeNodeRow({ node, depth, expanded, onToggle, onAccept, onAcceptTransfer: _onAcceptTransfer, onAcceptAndRejectRest, onReject, onDBSearch, onAIMatch, onDismissChildren, onSync, onHandleAsGrouping, onGeocodeMatch, onGeoshapeMatch, onPointMatch, onResetMatch, onRejectRemaining, onAcceptAll, onPreviewUnion, onPreviewTransfer, onAcceptSelected, onAcceptSelectedRejectRest, onRejectSelected, onPreview, onOpenMapPicker, onManualFix, isMutating, dbSearchingRegionId, aiMatchingRegionId, dismissingRegionId, syncingRegionId, groupingRegionId, geocodeMatchingRegionId, geoshapeMatchingRegionId, pointMatchingRegionId, parentRegionMapUrl, parentRegionMapName, geocodeProgress, duplicateUrls, syncedUrls, shadowsByRegionId, onApproveShadow, onRejectShadow, ancestorIsMatched, highlightedRegionId, onMergeChild, mergingRegionId, onSmartFlatten, flatteningRegionId, onDismissHierarchyWarnings, onAddChild, onRemoveRegion, removingRegionId, onCollapseToParent, collapsingRegionId, onAutoResolve, autoResolvingRegionId, onReviewSubtree, reviewingRegionId, onRename, renamingRegionId, onReparent, reparentingRegionId, onAISuggestChildren, aiSuggestingRegionId, onManualDivisionSearch, onPruneToLeaves, pruningRegionId, onViewMap, onCVMatch, cvMatchingRegionId, onMapshapeMatch, mapshapeMatchingRegionId, onClearMembers, clearingMembersRegionId, onSimplifyHierarchy, simplifyingRegionId, onSimplifyChildren, simplifyingChildrenRegionId, onSmartSimplify, onCheckOverlap, checkingOverlapRegionId, coverageData, coverageLoading, coverageDirtyIds, onCoverageClick, onContentResize }: TreeNodeRowProps) {
   const isExpanded = expanded.has(node.id);
   const hasChildren = node.children.length > 0;
   const role = getNodeRole(node);
   const hasDuplicate = !!(node.sourceUrl && duplicateUrls.has(node.sourceUrl));
-  // This node is matched — its territory is covered by assigned GADM divisions
-  const nodeIsMatched = ancestorIsMatched || node.matchStatus === 'auto_matched' || node.matchStatus === 'manual_matched' || node.memberCount > 0;
 
   // Geocode progress for this specific node
   const nodeGeocode = geocodeProgress?.regionId === node.id ? geocodeProgress : null;
@@ -107,46 +425,36 @@ export function TreeNodeRow({ node, depth, expanded, onToggle, onAccept, onAccep
   // Intercept preview: if unreviewed candidates and no map URL, open picker first
   const shouldInterceptPreview = node.mapImageCandidates.length > 1 && !node.mapImageReviewed && !node.regionMapUrl;
 
-  // Wrap onPreview to inject this node's regionMapUrl, wikidataId, regionId, markerPoints, and isAssigned
-  const handlePreviewAssigned = useCallback(
-    (divisionId: number, name: string, path?: string) => {
-      if (shouldInterceptPreview) {
-        onOpenMapPicker(node, { divisionId, name, path, isAssigned: true });
-        return;
-      }
-      onPreview(divisionId, name, path, node.regionMapUrl ?? undefined, node.wikidataId ?? undefined, node.id, true, node.markerPoints ?? undefined);
-    },
-    [onPreview, node, shouldInterceptPreview, onOpenMapPicker],
-  );
-  const handlePreviewSuggestion = useCallback(
-    (divisionId: number, name: string, path?: string) => {
-      if (shouldInterceptPreview) {
-        onOpenMapPicker(node, { divisionId, name, path, isAssigned: false });
-        return;
-      }
-      onPreview(divisionId, name, path, node.regionMapUrl ?? undefined, node.wikidataId ?? undefined, node.id, false, node.markerPoints ?? undefined);
-    },
-    [onPreview, node, shouldInterceptPreview, onOpenMapPicker],
-  );
-  const handlePreviewTransferSuggestion = useCallback(
-    (divisionId: number, name: string, path: string | undefined, conflict: { donorDivisionId: number; donorDivisionName: string; donorRegionId: number; type: 'direct' | 'split' }, regionId?: number, allDivisionIds?: number[]) => {
-      if (onPreviewTransfer && node.wikidataId) {
-        onPreviewTransfer(divisionId, name, path, conflict, node.wikidataId, node.name, regionId, allDivisionIds);
-      } else if (!node.wikidataId) {
-        // Transfer preview needs the target's Wikidata geoshape for the dashed-blue outline.
-        // Fall back to a regular division preview so the click is not a silent no-op.
-        console.warn(`[TreeNodeRow] Cannot show transfer preview for region "${node.name}" — no wikidataId; falling back to division preview.`);
-        onPreview(divisionId, name, path, node.regionMapUrl ?? undefined, undefined, node.id, false, node.markerPoints ?? undefined);
-      }
-    },
-    [onPreviewTransfer, onPreview, node.wikidataId, node.name, node.regionMapUrl, node.id, node.markerPoints],
+  // Wrap onPreview to inject this node's regionMapUrl, wikidataId, regionId, and isAssigned.
+  // When node has no own map image, fall back to parent's regionMapUrl for side-by-side reference.
+  const effectiveMapUrl = node.regionMapUrl ?? parentRegionMapUrl ?? undefined;
+  const fallbackMapLabel = computeFallbackMapLabel(node.regionMapUrl, parentRegionMapUrl, parentRegionMapName);
+  const {
+    handlePreviewAssigned,
+    handlePreviewSuggestion,
+    handlePreviewUnion,
+    handlePreviewTransferSuggestion,
+    handleViewMap,
+  } = usePreviewCallbacks(
+    node,
+    shouldInterceptPreview,
+    effectiveMapUrl,
+    fallbackMapLabel,
+    onPreview,
+    onOpenMapPicker,
+    onPreviewTransfer,
+    onPreviewUnion,
+    onViewMap,
   );
 
-  // For nodes with children, count resolved direct children
+  // For nodes with children, count resolved direct children.
+  // Only this node's own match counts as coverage — ancestor matches are NOT propagated
+  // to avoid showing "X/X matched" when children haven't been individually matched.
   const summary = useMemo(() => {
     if (!hasChildren) return null;
-    return countDirectChildrenResolved(node.children, nodeIsMatched);
-  }, [hasChildren, node.children, nodeIsMatched]);
+    const nodeHasOwnMembers = node.matchStatus === 'auto_matched' || node.matchStatus === 'manual_matched' || node.memberCount > 0;
+    return countDirectChildrenResolved(node.children, nodeHasOwnMembers);
+  }, [hasChildren, node.children, node.matchStatus, node.memberCount]);
 
   const nodeShadows = shadowsByRegionId.get(node.id);
 
@@ -164,16 +472,13 @@ export function TreeNodeRow({ node, depth, expanded, onToggle, onAccept, onAccep
           borderColor: 'divider',
           minHeight: role === 'container' ? 36 : 32,
           flexWrap: 'wrap',
+          ...(node.id === highlightedRegionId && {
+            bgcolor: 'rgba(25, 118, 210, 0.08)',
+          }),
         }}
       >
         {/* Expand/collapse toggle */}
-        <Box sx={{ width: 28, flexShrink: 0 }}>
-          {hasChildren ? (
-            <IconButton size="small" onClick={() => onToggle(node.id)} sx={{ p: 0.25 }}>
-              {isExpanded ? <ExpandIcon fontSize="small" /> : <CollapseRightIcon fontSize="small" />}
-            </IconButton>
-          ) : null}
-        </Box>
+        <ExpandToggle hasChildren={hasChildren} isExpanded={isExpanded} onClick={() => onToggle(node.id)} />
 
         {/* Region name */}
         <Typography
@@ -187,30 +492,17 @@ export function TreeNodeRow({ node, depth, expanded, onToggle, onAccept, onAccep
           {node.name}
         </Typography>
 
+        {/* Hierarchy warning indicator */}
+        <HierarchyWarningIcon node={node} />
+
+        {/* Geo similarity badge (top suggestion) — only when no divisions assigned yet */}
+        <GeoSimilarityBadge node={node} />
+
         {/* Source page link */}
-        {node.sourceUrl && (
-          <Link
-            href={node.sourceUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            sx={{ display: 'flex', alignItems: 'center', flexShrink: 0 }}
-          >
-            <OpenInNewIcon sx={{ fontSize: 13 }} />
-          </Link>
-        )}
+        <SourcePageLink url={node.sourceUrl} />
 
         {/* Map image picker button */}
-        {role === 'country' && node.mapImageCandidates.length > 1 && !node.regionMapUrl && (node.matchStatus === 'needs_review' || node.matchStatus === 'suggested') && (
-          <Tooltip title={`${node.mapImageCandidates.length} image candidates${node.mapImageReviewed ? ' (reviewed)' : ''}`}>
-            <IconButton
-              size="small"
-              onClick={() => onOpenMapPicker(node)}
-              sx={{ p: 0.25 }}
-            >
-              <ImageIcon sx={{ fontSize: 16, color: node.mapImageReviewed ? 'success.main' : 'warning.main' }} />
-            </IconButton>
-          </Tooltip>
-        )}
+        <MapImagePickerButton node={node} role={role} onOpenMapPicker={onOpenMapPicker} />
 
         {/* Actions: status chips, search buttons, sync, reset, manual fix */}
         <TreeNodeActions
@@ -236,17 +528,6 @@ export function TreeNodeRow({ node, depth, expanded, onToggle, onAccept, onAccep
           onDBSearch={onDBSearch}
           onAIMatch={onAIMatch}
           onDismissChildren={onDismissChildren}
-          onSimplifyHierarchy={onSimplifyHierarchy}
-          onSimplifyChildren={onSimplifyChildren}
-          simplifyingRegionId={simplifyingRegionId}
-          simplifyingChildrenRegionId={simplifyingChildrenRegionId}
-          onSmartSimplify={onSmartSimplify}
-          onAISuggestChildren={onAISuggestChildren}
-          aiSuggestingRegionId={aiSuggestingRegionId}
-          onCVMatch={onCVMatch}
-          cvMatchingRegionId={cvMatchingRegionId}
-          onMapshapeMatch={onMapshapeMatch}
-          mapshapeMatchingRegionId={mapshapeMatchingRegionId}
           onSync={onSync}
           onHandleAsGrouping={onHandleAsGrouping}
           onGeocodeMatch={onGeocodeMatch}
@@ -254,10 +535,48 @@ export function TreeNodeRow({ node, depth, expanded, onToggle, onAccept, onAccep
           onPointMatch={onPointMatch}
           onResetMatch={onResetMatch}
           onManualFix={onManualFix}
+          onMergeChild={onMergeChild}
+          mergingRegionId={mergingRegionId}
+          onSmartFlatten={onSmartFlatten}
+          flatteningRegionId={flatteningRegionId}
+          onDismissHierarchyWarnings={onDismissHierarchyWarnings}
+          onAddChild={onAddChild}
+          onRemoveRegion={onRemoveRegion}
+          removingRegionId={removingRegionId}
+          onCollapseToParent={onCollapseToParent}
+          collapsingRegionId={collapsingRegionId}
+          onAutoResolve={onAutoResolve}
+          autoResolvingRegionId={autoResolvingRegionId}
+          onReviewSubtree={onReviewSubtree}
+          reviewingRegionId={reviewingRegionId}
+          onRename={onRename}
+          renamingRegionId={renamingRegionId}
+          onReparent={onReparent}
+          reparentingRegionId={reparentingRegionId}
+          onAISuggestChildren={onAISuggestChildren}
+          aiSuggestingRegionId={aiSuggestingRegionId}
+          onManualDivisionSearch={onManualDivisionSearch}
+          onPruneToLeaves={onPruneToLeaves}
+          pruningRegionId={pruningRegionId}
+          onViewMap={onViewMap ? handleViewMap : undefined}
+          onCVMatch={onCVMatch}
+          cvMatchingRegionId={cvMatchingRegionId}
+          onMapshapeMatch={onMapshapeMatch}
+          mapshapeMatchingRegionId={mapshapeMatchingRegionId}
+          onClearMembers={onClearMembers}
+          clearingMembersRegionId={clearingMembersRegionId}
+          onSimplifyHierarchy={onSimplifyHierarchy}
+          simplifyingRegionId={simplifyingRegionId}
+          onSimplifyChildren={onSimplifyChildren}
+          simplifyingChildrenRegionId={simplifyingChildrenRegionId}
+          onSmartSimplify={onSmartSimplify}
+          onCheckOverlap={onCheckOverlap}
+          checkingOverlapRegionId={checkingOverlapRegionId}
+          isRoot={depth === 0}
         />
       </Box>
 
-      {/* Content: division lists, suggestions, shadow insertions */}
+      {/* Content: division lists, suggestions, shadow insertions (add_member only) */}
       <TreeNodeContent
         node={node}
         depth={depth}
@@ -274,107 +593,17 @@ export function TreeNodeRow({ node, depth, expanded, onToggle, onAccept, onAccep
         onPreviewTransfer={handlePreviewTransferSuggestion}
         onApproveShadow={onApproveShadow}
         onRejectShadow={onRejectShadow}
+        onPreviewUnion={onPreviewUnion ? handlePreviewUnion : undefined}
+        onAcceptSelected={onAcceptSelected}
+        onAcceptSelectedRejectRest={onAcceptSelectedRejectRest}
+        onRejectSelected={onRejectSelected}
         isMutating={isMutating}
+        coveragePercent={hasChildren ? coverageData?.[String(node.id)] : undefined}
+        coverageLoading={hasChildren ? coverageLoading : false}
+        coverageFetching={(coverageDirtyIds?.has(node.id) ?? false)}
+        onCoverageClick={onCoverageClick}
+        onContentResize={onContentResize}
       />
-
-      {/* Children */}
-      {hasChildren && (
-        <Collapse in={isExpanded} timeout={skipAnimationRef.current ? 0 : 'auto'} unmountOnExit>
-          {node.children.map(child => (
-            <TreeNodeRow
-              key={child.id}
-              node={child}
-              depth={depth + 1}
-              expanded={expanded}
-              onToggle={onToggle}
-              onAccept={onAccept}
-              onAcceptTransfer={onAcceptTransfer}
-              onAcceptAndRejectRest={onAcceptAndRejectRest}
-              onReject={onReject}
-              onDBSearch={onDBSearch}
-              onAIMatch={onAIMatch}
-              onDismissChildren={onDismissChildren}
-              onSimplifyHierarchy={onSimplifyHierarchy}
-              onSimplifyChildren={onSimplifyChildren}
-              onSmartSimplify={onSmartSimplify}
-              onAISuggestChildren={onAISuggestChildren}
-              onCVMatch={onCVMatch}
-              cvMatchingRegionId={cvMatchingRegionId}
-              onMapshapeMatch={onMapshapeMatch}
-              mapshapeMatchingRegionId={mapshapeMatchingRegionId}
-              onSync={onSync}
-              onHandleAsGrouping={onHandleAsGrouping}
-              onGeocodeMatch={onGeocodeMatch}
-              onGeoshapeMatch={onGeoshapeMatch}
-              onPointMatch={onPointMatch}
-              onResetMatch={onResetMatch}
-              onRejectRemaining={onRejectRemaining}
-              onAcceptAll={onAcceptAll}
-              onPreview={onPreview}
-              onPreviewTransfer={onPreviewTransfer}
-              onOpenMapPicker={onOpenMapPicker}
-              onManualFix={onManualFix}
-              isMutating={isMutating}
-              dbSearchingRegionId={dbSearchingRegionId}
-              aiMatchingRegionId={aiMatchingRegionId}
-              dismissingRegionId={dismissingRegionId}
-              simplifyingRegionId={simplifyingRegionId}
-              simplifyingChildrenRegionId={simplifyingChildrenRegionId}
-              aiSuggestingRegionId={aiSuggestingRegionId}
-              syncingRegionId={syncingRegionId}
-              groupingRegionId={groupingRegionId}
-              geocodeMatchingRegionId={geocodeMatchingRegionId}
-              geoshapeMatchingRegionId={geoshapeMatchingRegionId}
-              pointMatchingRegionId={pointMatchingRegionId}
-              geocodeProgress={geocodeProgress}
-              duplicateUrls={duplicateUrls}
-              syncedUrls={syncedUrls}
-              shadowsByRegionId={shadowsByRegionId}
-              onApproveShadow={onApproveShadow}
-              onRejectShadow={onRejectShadow}
-              skipAnimationRef={skipAnimationRef}
-              ancestorIsMatched={nodeIsMatched}
-            />
-          ))}
-          {/* Shadow insertions for create_region — show as synthetic child nodes */}
-          {nodeShadows?.filter(s => s.action === 'create_region').map(shadow => (
-            <Box
-              key={`shadow-create-${shadow.gapDivisionId}`}
-              sx={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: 0.75,
-                pl: (depth + 1) * 3,
-                py: 0.3,
-                borderBottom: '1px solid',
-                borderColor: 'divider',
-                borderLeft: '2px dashed',
-                borderLeftColor: 'warning.main',
-                bgcolor: 'rgba(237, 108, 2, 0.06)',
-                minHeight: 32,
-              }}
-            >
-              <Box sx={{ width: 28, flexShrink: 0 }} />
-              <Typography variant="body2" sx={{ fontStyle: 'italic' }}>
-                + {shadow.gapDivisionName}
-              </Typography>
-              <Typography variant="caption" color="text.secondary">
-                (new region)
-              </Typography>
-              <Tooltip title="Approve — create region and add member">
-                <IconButton size="small" color="success" onClick={() => onApproveShadow?.(shadow)} disabled={isMutating} sx={{ p: 0.25 }}>
-                  <CheckIcon sx={{ fontSize: 16 }} />
-                </IconButton>
-              </Tooltip>
-              <Tooltip title="Reject">
-                <IconButton size="small" color="error" onClick={() => onRejectShadow?.(shadow)} sx={{ p: 0.25 }}>
-                  <CloseIcon sx={{ fontSize: 16 }} />
-                </IconButton>
-              </Tooltip>
-            </Box>
-          ))}
-        </Collapse>
-      )}
     </Box>
   );
-}
+}, arePropsEqual);

--- a/frontend/src/components/admin/WorldViewImportReview.tsx
+++ b/frontend/src/components/admin/WorldViewImportReview.tsx
@@ -5,7 +5,7 @@
  * for imported regions. Uses the hierarchical tree view.
  */
 
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
 import {
   Alert,
   Box,
@@ -14,6 +14,7 @@ import {
   Card,
   CardContent,
   Chip,
+  LinearProgress,
   Stack,
   Tooltip,
   Dialog,
@@ -22,6 +23,11 @@ import {
   DialogActions,
 } from '@mui/material';
 import { fetchDivisionGeometry } from '../../api/divisions';
+import {
+  startWorldViewGeometryComputation,
+  fetchWorldViewComputationStatus,
+  cancelWorldViewGeometryComputation,
+} from '../../api/geometry';
 import { DivisionPreviewDialog } from '../WorldViewEditor/components/dialogs/DivisionPreviewDialog';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
@@ -32,10 +38,14 @@ import {
   startRematch,
   getRematchStatus,
   acceptMatch,
+  acceptBatchMatches,
   rejectSuggestion,
   rejectRemaining,
-  acceptWithTransfer as acceptWithTransferApi,
+  getUnionGeometry,
   getTransferPreview,
+  acceptWithTransfer,
+  splitDivisionsDeeper,
+  visionMatchDivisions,
 } from '../../api/admin/worldViewImport';
 import type { CoverageResult } from '../../api/admin/worldViewImport';
 
@@ -50,28 +60,223 @@ interface WorldViewImportReviewProps {
   onFinalize?: () => void;
 }
 
+// Geometry computation progress Alert — extracted to reduce parent cognitive complexity
+interface GeomStatus {
+  percent: number;
+  computed: number;
+  total: number;
+  errors: number;
+  currentRegion?: string;
+  status?: string;
+}
+
+type PreviewDivisionState = {
+  divisionId?: number;
+  regionId?: number;
+  isAssigned?: boolean;
+  divisionIds?: number[];
+} | null;
+
+type PreviewMutationWithMutate = { mutate: (args: { regionId: number; divisionId: number }) => void };
+type PreviewBatchMutationWithMutate = { mutate: (args: { regionId: number; divisionIds: number[] }) => void };
+type PreviewTransferMutationWithMutate = {
+  mutate: (args: { regionId: number; groups: Array<{ divisionIds: number[]; donorRegionId: number; donorDivisionId: number; transferType: 'direct' | 'split' }> }) => void;
+};
+
+// Computes onAccept / onAcceptAndRejectRest / onReject handlers for the
+// DivisionPreviewDialog based on current preview state — factored out so the
+// parent component stays under the cognitive-complexity cap.
+function computePreviewDialogHandlers(params: {
+  previewDivision: PreviewDivisionState;
+  pendingTransfer: { regionId: number; groups: Array<{ divisionIds: number[]; donorRegionId: number; donorDivisionId: number; transferType: 'direct' | 'split' }> } | null;
+  previewAcceptMutation: PreviewMutationWithMutate;
+  previewAcceptSelectedMutation: PreviewBatchMutationWithMutate;
+  previewTransferMutation: PreviewTransferMutationWithMutate;
+  previewAcceptAndRejectRestMutation: PreviewMutationWithMutate;
+  previewAcceptSelectedRejectRestMutation: PreviewBatchMutationWithMutate;
+  previewRejectMutation: PreviewMutationWithMutate;
+  previewRejectSelectedMutation: PreviewBatchMutationWithMutate;
+}): { onAccept?: () => void; onAcceptAndRejectRest?: () => void; onReject?: () => void } {
+  const {
+    previewDivision, pendingTransfer,
+    previewAcceptMutation, previewAcceptSelectedMutation, previewTransferMutation,
+    previewAcceptAndRejectRestMutation, previewAcceptSelectedRejectRestMutation,
+    previewRejectMutation, previewRejectSelectedMutation,
+  } = params;
+
+  const hasSelectedDivisions = !!(previewDivision?.divisionIds && previewDivision.regionId != null);
+  const hasSingleDivision = previewDivision?.regionId != null && previewDivision?.divisionId != null;
+  const singleDivisionNotYetAssigned = hasSingleDivision && !previewDivision!.isAssigned;
+
+  const buildAccept = (): (() => void) | undefined => {
+    if (pendingTransfer) return () => previewTransferMutation.mutate(pendingTransfer);
+    if (hasSelectedDivisions) {
+      return () => previewAcceptSelectedMutation.mutate({
+        regionId: previewDivision!.regionId!,
+        divisionIds: previewDivision!.divisionIds!,
+      });
+    }
+    if (singleDivisionNotYetAssigned) {
+      return () => previewAcceptMutation.mutate({
+        regionId: previewDivision!.regionId!,
+        divisionId: previewDivision!.divisionId!,
+      });
+    }
+    return undefined;
+  };
+
+  const buildAcceptAndRejectRest = (): (() => void) | undefined => {
+    if (hasSelectedDivisions) {
+      return () => previewAcceptSelectedRejectRestMutation.mutate({
+        regionId: previewDivision!.regionId!,
+        divisionIds: previewDivision!.divisionIds!,
+      });
+    }
+    if (singleDivisionNotYetAssigned) {
+      return () => previewAcceptAndRejectRestMutation.mutate({
+        regionId: previewDivision!.regionId!,
+        divisionId: previewDivision!.divisionId!,
+      });
+    }
+    return undefined;
+  };
+
+  const buildReject = (): (() => void) | undefined => {
+    if (hasSelectedDivisions) {
+      return () => previewRejectSelectedMutation.mutate({
+        regionId: previewDivision!.regionId!,
+        divisionIds: previewDivision!.divisionIds!,
+      });
+    }
+    if (hasSingleDivision) {
+      return () => previewRejectMutation.mutate({
+        regionId: previewDivision!.regionId!,
+        divisionId: previewDivision!.divisionId!,
+      });
+    }
+    return undefined;
+  };
+
+  return {
+    onAccept: buildAccept(),
+    onAcceptAndRejectRest: buildAcceptAndRejectRest(),
+    onReject: buildReject(),
+  };
+}
+
+// Hook that bundles all preview accept/reject mutations. Factored out to keep
+// WorldViewImportReview's cognitive complexity under the Sonar cap.
+function usePreviewMutations(worldViewId: number, onDone: () => void) {
+  const onSuccess = () => { onDone(); };
+  const previewAcceptMutation = useMutation({
+    mutationFn: ({ regionId, divisionId }: { regionId: number; divisionId: number }) =>
+      acceptMatch(worldViewId, regionId, divisionId),
+    onSuccess,
+  });
+  const previewRejectMutation = useMutation({
+    mutationFn: ({ regionId, divisionId }: { regionId: number; divisionId: number }) =>
+      rejectSuggestion(worldViewId, regionId, divisionId),
+    onSuccess,
+  });
+  const previewTransferMutation = useMutation({
+    mutationFn: async (params: { regionId: number; groups: Array<{ divisionIds: number[]; donorRegionId: number; donorDivisionId: number; transferType: 'direct' | 'split' }> }) => {
+      for (const g of params.groups) {
+        await acceptWithTransfer(worldViewId, params.regionId, g.divisionIds, g.donorRegionId, g.donorDivisionId, g.transferType);
+      }
+    },
+    onSuccess,
+  });
+  const previewAcceptAndRejectRestMutation = useMutation({
+    mutationFn: async ({ regionId, divisionId }: { regionId: number; divisionId: number }) => {
+      await acceptMatch(worldViewId, regionId, divisionId);
+      await rejectRemaining(worldViewId, regionId);
+    },
+    onSuccess,
+  });
+  const previewAcceptSelectedMutation = useMutation({
+    mutationFn: ({ regionId, divisionIds }: { regionId: number; divisionIds: number[] }) =>
+      acceptBatchMatches(worldViewId, divisionIds.map(d => ({ regionId, divisionId: d }))),
+    onSuccess,
+  });
+  const previewAcceptSelectedRejectRestMutation = useMutation({
+    mutationFn: async ({ regionId, divisionIds }: { regionId: number; divisionIds: number[] }) => {
+      await acceptBatchMatches(worldViewId, divisionIds.map(d => ({ regionId, divisionId: d })));
+      await rejectRemaining(worldViewId, regionId);
+    },
+    onSuccess,
+  });
+  const previewRejectSelectedMutation = useMutation({
+    mutationFn: ({ regionId, divisionIds }: { regionId: number; divisionIds: number[] }) =>
+      Promise.all(divisionIds.map(d => rejectSuggestion(worldViewId, regionId, d))).then(() => {}),
+    onSuccess,
+  });
+  return {
+    previewAcceptMutation,
+    previewRejectMutation,
+    previewTransferMutation,
+    previewAcceptAndRejectRestMutation,
+    previewAcceptSelectedMutation,
+    previewAcceptSelectedRejectRestMutation,
+    previewRejectSelectedMutation,
+  };
+}
+
+function GeomComputationAlert({
+  geomStatus, geomComputing, onCancel,
+}: {
+  geomStatus: GeomStatus;
+  geomComputing: boolean;
+  onCancel: () => void;
+}) {
+  let severity: 'info' | 'warning' | 'success';
+  if (geomComputing) severity = 'info';
+  else if (geomStatus.errors > 0) severity = 'warning';
+  else severity = 'success';
+
+  const currentRegionSuffix = geomStatus.currentRegion ? ` — ${geomStatus.currentRegion}` : '';
+  const errorsSuffix = geomStatus.errors > 0 ? `, ${geomStatus.errors} errors` : '';
+  const statusLabel = geomStatus.status ?? 'Complete';
+  const progressText = geomComputing
+    ? `Computing geometries... ${geomStatus.computed}/${geomStatus.total}${currentRegionSuffix}`
+    : `${statusLabel} — ${geomStatus.computed} computed${errorsSuffix}`;
+
+  return (
+    <Alert
+      severity={severity}
+      sx={{ mb: 2 }}
+      action={geomComputing ? (
+        <Button color="inherit" size="small" onClick={onCancel}>Cancel</Button>
+      ) : undefined}
+    >
+      <Box sx={{ width: '100%' }}>
+        <Typography variant="body2">{progressText}</Typography>
+        {geomComputing && (
+          <LinearProgress variant="determinate" value={geomStatus.percent} sx={{ mt: 0.5 }} />
+        )}
+      </Box>
+    </Alert>
+  );
+}
+
 export function WorldViewImportReview({ worldViewId, onFinalize }: WorldViewImportReviewProps) {
   const queryClient = useQueryClient();
   const [rematchDialogOpen, setRematchDialogOpen] = useState(false);
   const [previewDivision, setPreviewDivision] = useState<{
     name: string; path?: string; regionMapUrl?: string; wikidataId?: string;
-    divisionId?: number; regionId?: number; isAssigned?: boolean;
+    divisionId?: number; regionId?: number; isAssigned?: boolean; regionMapLabel?: string; regionName?: string;
+    divisionIds?: number[];
     markerPoints?: Array<{ name: string; lat: number; lon: number }>;
   } | null>(null);
   const [previewGeometry, setPreviewGeometry] = useState<GeoJSON.Geometry | GeoJSON.FeatureCollection | null>(null);
   const [previewLoading, setPreviewLoading] = useState(false);
-
-  // Pending transfer info — kept while transfer preview dialog is open
+  // Pending transfer groups: one entry per donor, executed sequentially on confirm
   const [pendingTransfer, setPendingTransfer] = useState<{
     regionId: number;
-    divisionIds: number[];
-    donorRegionId: number;
-    donorDivisionId: number;
-    transferType: 'direct' | 'split';
+    groups: Array<{ divisionIds: number[]; donorRegionId: number; donorDivisionId: number; transferType: 'direct' | 'split' }>;
   } | null>(null);
 
-  const handlePreviewDivision = useCallback(async (divisionId: number, name: string, path?: string, regionMapUrl?: string, wikidataId?: string, regionId?: number, isAssigned?: boolean, markerPoints?: Array<{ name: string; lat: number; lon: number }>) => {
-    setPreviewDivision({ name, path, regionMapUrl, wikidataId, divisionId, regionId, isAssigned, markerPoints });
+  const handlePreviewDivision = useCallback(async (divisionId: number, name: string, path?: string, regionMapUrl?: string, wikidataId?: string, regionId?: number, isAssigned?: boolean, regionMapLabel?: string, regionName?: string, markerPoints?: Array<{ name: string; lat: number; lon: number }>) => {
+    setPreviewDivision({ name, path, regionMapUrl, wikidataId, divisionId, regionId, isAssigned, regionMapLabel, regionName, markerPoints });
     setPreviewGeometry(null);
     setPreviewLoading(true);
     try {
@@ -87,6 +292,133 @@ export function WorldViewImportReview({ worldViewId, onFinalize }: WorldViewImpo
     setPreviewGeometry(null);
     setPendingTransfer(null);
   }, []);
+
+  const handlePreviewUnion = useCallback(async (regionId: number, divisionIds: number[], context: { wikidataId?: string; regionMapUrl?: string; regionMapLabel?: string; regionName: string }) => {
+    setPreviewDivision({
+      name: `${divisionIds.length} divisions (union)`,
+      regionId,
+      isAssigned: false,
+      divisionIds,
+      wikidataId: context.wikidataId,
+      regionMapUrl: context.regionMapUrl,
+      regionMapLabel: context.regionMapLabel,
+      regionName: context.regionName,
+    });
+    setPreviewGeometry(null);
+    setPreviewLoading(true);
+    try {
+      const result = await getUnionGeometry(worldViewId, divisionIds, regionId);
+      setPreviewGeometry(result.geometry);
+    } finally {
+      setPreviewLoading(false);
+    }
+  }, [worldViewId]);
+
+  const handlePreviewTransfer = useCallback(async (
+    divisionId: number, name: string, path: string | undefined,
+    conflict: { donorDivisionId: number; donorDivisionName: string; donorRegionId: number; type: 'direct' | 'split' },
+    wikidataId: string, regionName: string,
+    regionId?: number, allDivisionIds?: number[],
+    allSuggestions?: Array<{ divisionId: number; conflict?: { donorDivisionId: number; donorRegionId: number; type: 'direct' | 'split' } }>,
+  ) => {
+    const movingIds = allDivisionIds ?? [divisionId];
+    const label = movingIds.length > 1 ? `Transfer: ${movingIds.length} divisions` : `Transfer: ${name}`;
+    setPreviewDivision({ name: label, path, regionMapUrl: undefined, wikidataId, regionId: undefined, regionName });
+    setPreviewGeometry(null);
+    setPreviewLoading(true);
+
+    // Group by donor for multi-donor support
+    const suggestions = allSuggestions ?? [{ divisionId, conflict }];
+    const groupsByDonor = new Map<number, { divisionIds: number[]; donorRegionId: number; donorDivisionId: number; transferType: 'direct' | 'split' }>();
+    for (const s of suggestions) {
+      const c = s.conflict ?? conflict;
+      const key = c.donorDivisionId;
+      const existing = groupsByDonor.get(key);
+      if (existing) {
+        existing.divisionIds.push(s.divisionId);
+      } else {
+        groupsByDonor.set(key, { divisionIds: [s.divisionId], donorRegionId: c.donorRegionId, donorDivisionId: c.donorDivisionId, transferType: c.type });
+      }
+    }
+    const groups = [...groupsByDonor.values()];
+    setPendingTransfer(regionId != null ? { regionId, groups } : null);
+
+    try {
+      // Fetch preview for each donor group and merge
+      const fcs = await Promise.all(groups.map(g => getTransferPreview(worldViewId, g.donorDivisionId, g.divisionIds, wikidataId)));
+      const merged: GeoJSON.FeatureCollection = { type: 'FeatureCollection', features: fcs.flatMap(fc => fc.features) };
+      // Deduplicate target_outline (same geoshape repeated per group)
+      const seen = new Set<string>();
+      merged.features = merged.features.filter(f => {
+        if (f.properties?.role !== 'target_outline') return true;
+        const key = f.properties.role;
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      });
+      setPreviewGeometry(merged);
+    } catch {
+      setPreviewGeometry(null);
+    } finally {
+      setPreviewLoading(false);
+    }
+  }, [worldViewId]);
+
+  const handleViewMap = useCallback(async (regionId: number, context: { wikidataId?: string; regionMapUrl?: string; regionMapLabel?: string; regionName: string; divisionIds: number[] }) => {
+    const hasDivisions = context.divisionIds.length > 0;
+    const divSuffix = context.divisionIds.length > 1 ? 's' : '';
+    const previewName = hasDivisions
+      ? `${context.regionName} — ${context.divisionIds.length} division${divSuffix}`
+      : context.regionName;
+    setPreviewDivision({
+      name: previewName,
+      wikidataId: context.wikidataId,
+      regionMapUrl: context.regionMapUrl,
+      regionMapLabel: context.regionMapLabel,
+      regionName: context.regionName,
+      regionId,
+    });
+    setPreviewGeometry(null);
+    if (hasDivisions) {
+      setPreviewLoading(true);
+      try {
+        const result = await getUnionGeometry(worldViewId, context.divisionIds);
+        setPreviewGeometry(result.geometry);
+      } finally {
+        setPreviewLoading(false);
+      }
+    }
+  }, [worldViewId]);
+
+  const handleSplitDeeper = useCallback(async (source: 'geoshape' | 'points' | 'image' | null) => {
+    const computeIds = (): number[] | null => {
+      if (previewDivision?.divisionIds?.length) return previewDivision.divisionIds;
+      if (previewDivision?.divisionId) return [previewDivision.divisionId];
+      return null;
+    };
+    const ids = computeIds();
+    if (!ids || !previewDivision?.wikidataId || !previewDivision.regionId) return;
+    setPreviewLoading(true);
+    try {
+      const result = await splitDivisionsDeeper(worldViewId, ids, previewDivision.wikidataId, previewDivision.regionId, source ?? undefined);
+      const newIds = result.divisions.map(d => d.divisionId);
+      setPreviewDivision(prev => prev ? {
+        ...prev,
+        name: `${newIds.length} divisions (refined)`,
+        divisionIds: newIds,
+        markerPoints: result.points ?? prev.markerPoints,
+      } : prev);
+      setPreviewGeometry(result.geometry);
+    } finally {
+      setPreviewLoading(false);
+    }
+  }, [worldViewId, previewDivision?.divisionIds, previewDivision?.divisionId, previewDivision?.wikidataId, previewDivision?.regionId]);
+
+  const handleVisionMatch = useCallback(async (): Promise<{ ids: number[]; rejectedIds?: number[]; unclearIds?: number[]; reasoning?: string; debugImages?: { regionMap: string; divisionsMap: string } }> => {
+    if (!previewDivision?.divisionIds?.length || !previewDivision.regionId || !previewDivision.regionMapUrl) return { ids: [] };
+    const result = await visionMatchDivisions(worldViewId, previewDivision.divisionIds, previewDivision.regionId, previewDivision.regionMapUrl);
+    return { ids: result.suggestedIds, rejectedIds: result.rejectedIds, unclearIds: result.unclearIds, reasoning: result.reasoning, debugImages: result.debugImages };
+  }, [worldViewId, previewDivision?.divisionIds, previewDivision?.regionId, previewDivision?.regionMapUrl]);
 
   const [shadowInsertions, setShadowInsertions] = useState<ShadowInsertion[]>([]);
 
@@ -138,87 +470,20 @@ export function WorldViewImportReview({ worldViewId, onFinalize }: WorldViewImpo
     setCoverageStale(true);
   }, [queryClient, worldViewId]);
 
-  // Preview accept/reject
-  const previewAcceptMutation = useMutation({
-    mutationFn: ({ regionId, divisionId }: { regionId: number; divisionId: number }) =>
-      acceptMatch(worldViewId, regionId, divisionId),
-    onSuccess: () => {
-      invalidateAll();
-      handleClosePreview();
-    },
-  });
-
-  const previewRejectMutation = useMutation({
-    mutationFn: ({ regionId, divisionId }: { regionId: number; divisionId: number }) =>
-      rejectSuggestion(worldViewId, regionId, divisionId),
-    onSuccess: () => {
-      invalidateAll();
-      handleClosePreview();
-    },
-  });
-
-  const previewAcceptAndRejectRestMutation = useMutation({
-    mutationFn: async ({ regionId, divisionId }: { regionId: number; divisionId: number }) => {
-      await acceptMatch(worldViewId, regionId, divisionId);
-      await rejectRemaining(worldViewId, regionId);
-    },
-    onSuccess: () => {
-      invalidateAll();
-      handleClosePreview();
-    },
-  });
-
-  // Transfer preview — fetches 3-layer GeoJSON and opens dialog
-  const previewTransferMutation = useMutation({
-    mutationFn: ({ donorDivisionId, movingDivisionIds, wikidataId }: { donorDivisionId: number; movingDivisionIds: number[]; wikidataId: string }) =>
-      getTransferPreview(worldViewId, donorDivisionId, movingDivisionIds, wikidataId),
-    onSuccess: (featureCollection) => {
-      setPreviewGeometry(featureCollection);
-      setPreviewLoading(false);
-    },
-    onError: (err) => {
-      console.error('[WorldViewImportReview] Transfer preview failed:', err);
-      setPreviewLoading(false);
-      setPendingTransfer(null);
-      handleClosePreview();
-    },
-  });
-
-  // Accept transfer from the preview dialog
-  const acceptTransferFromPreviewMutation = useMutation({
-    mutationFn: ({ regionId, divisionIds, donorRegionId, donorDivisionId, transferType }: {
-      regionId: number; divisionIds: number[]; donorRegionId: number; donorDivisionId: number; transferType: 'direct' | 'split';
-    }) => acceptWithTransferApi(worldViewId, regionId, divisionIds, donorRegionId, donorDivisionId, transferType),
-    onSuccess: () => {
-      invalidateAll();
-      setPendingTransfer(null);
-      handleClosePreview();
-    },
-  });
-
-  const handlePreviewTransfer = useCallback((
-    divisionId: number,
-    name: string,
-    _path: string | undefined,
-    conflict: { donorDivisionId: number; donorDivisionName: string; donorRegionId: number; type: 'direct' | 'split' },
-    wikidataId: string,
-    regionName: string,
-    regionId?: number,
-    allDivisionIds?: number[],
-  ) => {
-    const movingIds = allDivisionIds ?? [divisionId];
-    setPreviewDivision({ name: regionName, path: name });
-    setPreviewGeometry(null);
-    setPreviewLoading(true);
-    setPendingTransfer(regionId != null ? {
-      regionId,
-      divisionIds: movingIds,
-      donorRegionId: conflict.donorRegionId,
-      donorDivisionId: conflict.donorDivisionId,
-      transferType: conflict.type,
-    } : null);
-    previewTransferMutation.mutate({ donorDivisionId: conflict.donorDivisionId, movingDivisionIds: movingIds, wikidataId });
-  }, [previewTransferMutation]);
+  // Preview accept/reject — all mutations bundled in a helper hook
+  const onPreviewMutationSuccess = useCallback(() => {
+    invalidateAll();
+    handleClosePreview();
+  }, [invalidateAll, handleClosePreview]);
+  const {
+    previewAcceptMutation,
+    previewRejectMutation,
+    previewTransferMutation,
+    previewAcceptAndRejectRestMutation,
+    previewAcceptSelectedMutation,
+    previewAcceptSelectedRejectRestMutation,
+    previewRejectSelectedMutation,
+  } = usePreviewMutations(worldViewId, onPreviewMutationSuccess);
 
   const finalizeMutation = useMutation({
     mutationFn: () => finalizeReview(worldViewId),
@@ -243,13 +508,80 @@ export function WorldViewImportReview({ worldViewId, onFinalize }: WorldViewImpo
       const st = query.state.data;
       if (st?.status === 'matching') return 1000;
       if (st?.status === 'complete') {
-        invalidateAll();
+        // Invalidate tree + stats + children coverage but NOT rematch status
+        // itself — otherwise the invalidation triggers a refetch, which sees
+        // 'complete' again, calls invalidateAll again → infinite loop that
+        // freezes the page.
+        queryClient.invalidateQueries({ queryKey: ['admin', 'wvImport', 'matchTree', worldViewId] });
+        queryClient.invalidateQueries({ queryKey: ['admin', 'wvImport', 'matchStats', worldViewId] });
+        queryClient.invalidateQueries({ queryKey: ['admin', 'wvImport', 'childrenCoverage', worldViewId] });
+        setCoverageStale(true);
       }
       return false;
     },
   });
 
   const rematchRunning = rematchStatus?.status === 'matching';
+
+  // ── Geometry computation (polling-based) ──────────────────────────────────
+  const [geomComputing, setGeomComputing] = useState(false);
+  const [geomStatus, setGeomStatus] = useState<{
+    percent: number; computed: number; total: number; errors: number;
+    currentRegion?: string; status?: string;
+  } | null>(null);
+  const geomPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const stopGeomPolling = useCallback(() => {
+    if (geomPollRef.current) { clearInterval(geomPollRef.current); geomPollRef.current = null; }
+  }, []);
+
+  // Cleanup on unmount
+  useEffect(() => stopGeomPolling, [stopGeomPolling]);
+
+  const startGeomPolling = useCallback(() => {
+    stopGeomPolling();
+    setGeomComputing(true);
+    geomPollRef.current = setInterval(async () => {
+      try {
+        const s = await fetchWorldViewComputationStatus(worldViewId);
+        setGeomStatus({
+          percent: s.percent ?? 0,
+          computed: s.progress ?? 0,
+          total: s.total ?? 0,
+          errors: s.errors ?? 0,
+          currentRegion: s.currentRegion,
+          status: s.status,
+        });
+        if (!s.running) {
+          stopGeomPolling();
+          setGeomComputing(false);
+        }
+      } catch {
+        stopGeomPolling();
+        setGeomComputing(false);
+      }
+    }, 1500);
+  }, [worldViewId, stopGeomPolling]);
+
+  const handleComputeGeometries = useCallback(async () => {
+    try {
+      const result = await startWorldViewGeometryComputation(worldViewId, false, true);
+      if (result.started) {
+        setGeomStatus({ percent: 0, computed: 0, total: result.total ?? 0, errors: 0, status: 'Starting...' });
+        startGeomPolling();
+      } else {
+        setGeomStatus({ percent: 100, computed: result.alreadyComputed ?? 0, total: result.total ?? 0, errors: 0, status: result.message });
+      }
+    } catch (err) {
+      console.error('Failed to start geometry computation:', err);
+    }
+  }, [worldViewId, startGeomPolling]);
+
+  const handleCancelGeomComputation = useCallback(async () => {
+    try {
+      await cancelWorldViewGeometryComputation(worldViewId);
+    } catch { /* poll will detect stopped state */ }
+  }, [worldViewId]);
 
   const matchingDone = stats
     && parseInt(stats.needs_review_blocking) === 0
@@ -331,6 +663,44 @@ export function WorldViewImportReview({ worldViewId, onFinalize }: WorldViewImpo
 
   const coverageChecking = coverageProgress.running;
 
+  // Label for the coverage button: shows "Checking...", "Coverage OK", "Coverage (N gaps)", or "Check Coverage"
+  let coverageButtonLabel: string;
+  if (coverageChecking) {
+    coverageButtonLabel = 'Checking...';
+  } else if (coverageData && !coverageStale) {
+    coverageButtonLabel = coverageData.gaps.length === 0
+      ? 'Coverage OK'
+      : `Coverage (${coverageData.gaps.length} gaps)`;
+  } else {
+    coverageButtonLabel = 'Check Coverage';
+  }
+
+  // Compute handlers for the DivisionPreviewDialog actions based on preview state.
+  // Extracted to a memo to avoid deeply nested ternaries and reduce component complexity.
+  const previewDialogHandlers = useMemo(() => {
+    return computePreviewDialogHandlers({
+      previewDivision,
+      pendingTransfer,
+      previewAcceptMutation,
+      previewAcceptSelectedMutation,
+      previewTransferMutation,
+      previewAcceptAndRejectRestMutation,
+      previewAcceptSelectedRejectRestMutation,
+      previewRejectMutation,
+      previewRejectSelectedMutation,
+    });
+  }, [
+    previewDivision,
+    pendingTransfer,
+    previewAcceptMutation,
+    previewAcceptSelectedMutation,
+    previewTransferMutation,
+    previewAcceptAndRejectRestMutation,
+    previewAcceptSelectedRejectRestMutation,
+    previewRejectMutation,
+    previewRejectSelectedMutation,
+  ]);
+
   return (
     <Box>
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 1 }}>
@@ -345,16 +715,17 @@ export function WorldViewImportReview({ worldViewId, onFinalize }: WorldViewImpo
               onClick={handleCheckCoverage}
               disabled={!matchingDone || coverageChecking}
             >
-              {coverageChecking
-                ? 'Checking...'
-                : coverageData && !coverageStale
-                  ? coverageData.gaps.length === 0
-                    ? 'Coverage OK'
-                    : `Coverage (${coverageData.gaps.length} gaps)`
-                  : 'Check Coverage'}
+              {coverageButtonLabel}
             </Button>
           </span>
         </Tooltip>
+        <Button
+          variant="outlined"
+          onClick={handleComputeGeometries}
+          disabled={geomComputing || rematchRunning}
+        >
+          {geomComputing ? 'Computing...' : 'Compute Geometries'}
+        </Button>
         <Tooltip title={closeReviewTooltip}>
           <span>
             <Button
@@ -398,6 +769,23 @@ export function WorldViewImportReview({ worldViewId, onFinalize }: WorldViewImpo
         </Card>
       )}
 
+      {/* Geometry computation progress */}
+      {geomStatus && (
+        <GeomComputationAlert
+          geomStatus={geomStatus}
+          geomComputing={geomComputing}
+          onCancel={handleCancelGeomComputation}
+        />
+      )}
+
+      {/* Hierarchy warnings banner */}
+      {stats && parseInt(stats.hierarchy_warnings_count) > 0 && (
+        <Alert severity="warning" sx={{ mb: 2 }}>
+          {stats.hierarchy_warnings_count} region{parseInt(stats.hierarchy_warnings_count) !== 1 ? 's have' : ' has'} parsing ambiguities — some sub-regions may have been dropped during extraction.
+          Use the <strong>Hierarchy Warnings</strong> button in the tree toolbar to review.
+        </Alert>
+      )}
+
       {/* Re-match progress */}
       {rematchRunning && rematchStatus && (
         <Alert severity="info" sx={{ mb: 2 }}>
@@ -413,7 +801,9 @@ export function WorldViewImportReview({ worldViewId, onFinalize }: WorldViewImpo
       <WorldViewImportTree
         worldViewId={worldViewId}
         onPreview={handlePreviewDivision}
+        onPreviewUnion={handlePreviewUnion}
         onPreviewTransfer={handlePreviewTransfer}
+        onViewMap={handleViewMap}
         shadowInsertions={shadowInsertions}
         onApproveShadow={(insertion) => approveShadowMutation.mutate(insertion)}
         onRejectShadow={handleRejectShadow}
@@ -425,23 +815,18 @@ export function WorldViewImportReview({ worldViewId, onFinalize }: WorldViewImpo
         loading={previewLoading}
         onClose={handleClosePreview}
         regionMapUrl={previewDivision?.regionMapUrl}
+        regionMapLabel={previewDivision?.regionMapLabel}
+        regionName={previewDivision?.regionName}
         wikidataId={previewDivision?.wikidataId}
         markerPoints={previewDivision?.markerPoints}
-        acceptLabel={pendingTransfer ? 'Accept Transfer' : undefined}
-        onAccept={
-          pendingTransfer
-            ? () => acceptTransferFromPreviewMutation.mutate(pendingTransfer)
-            : previewDivision?.regionId != null && previewDivision?.divisionId != null && !previewDivision.isAssigned
-              ? () => previewAcceptMutation.mutate({ regionId: previewDivision.regionId!, divisionId: previewDivision.divisionId! })
-              : undefined
-        }
-        onAcceptAndRejectRest={!pendingTransfer && previewDivision?.regionId != null && previewDivision?.divisionId != null && !previewDivision.isAssigned
-          ? () => previewAcceptAndRejectRestMutation.mutate({ regionId: previewDivision.regionId!, divisionId: previewDivision.divisionId! })
-          : undefined}
-        onReject={!pendingTransfer && previewDivision?.regionId != null && previewDivision?.divisionId != null
-          ? () => previewRejectMutation.mutate({ regionId: previewDivision.regionId!, divisionId: previewDivision.divisionId! })
-          : undefined}
-        actionPending={previewAcceptMutation.isPending || previewRejectMutation.isPending || previewAcceptAndRejectRestMutation.isPending || previewTransferMutation.isPending || acceptTransferFromPreviewMutation.isPending}
+        worldViewId={worldViewId}
+        regionId={previewDivision?.regionId}
+        onAccept={previewDialogHandlers.onAccept}
+        onAcceptAndRejectRest={previewDialogHandlers.onAcceptAndRejectRest}
+        onReject={previewDialogHandlers.onReject}
+        onSplitDeeper={(previewDivision?.divisionIds?.length || previewDivision?.divisionId) && previewDivision?.wikidataId ? handleSplitDeeper : undefined}
+        onVisionMatch={previewDivision?.divisionIds?.length && previewDivision.regionId && previewDivision.regionMapUrl ? handleVisionMatch : undefined}
+        actionPending={previewTransferMutation.isPending || previewAcceptMutation.isPending || previewRejectMutation.isPending || previewAcceptAndRejectRestMutation.isPending || previewAcceptSelectedMutation.isPending || previewAcceptSelectedRejectRestMutation.isPending || previewRejectSelectedMutation.isPending || previewLoading}
       />
 
       {/* Re-match confirmation dialog */}

--- a/frontend/src/components/admin/WorldViewImportTree.tsx
+++ b/frontend/src/components/admin/WorldViewImportTree.tsx
@@ -1,10 +1,9 @@
 /**
  * WorldView Import Tree View
  *
- * Clean hierarchical tree showing match results at the country level.
- * Containers (continents, sub-regions) show summary counts.
- * Countries show their match status and GADM assignment.
- * Children of drilled-down regions appear as regular country nodes.
+ * Virtualized hierarchical tree showing match results at the country level.
+ * Uses @tanstack/react-virtual to render only visible rows (~40 at a time),
+ * keeping the DOM lightweight even when hundreds of nodes are expanded.
  */
 
 import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
@@ -13,14 +12,7 @@ import {
   Typography,
   Button,
   CircularProgress,
-  Checkbox,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
-  TextField,
   Snackbar,
-  Link as MuiLink,
 } from '@mui/material';
 
 import {
@@ -28,488 +20,168 @@ import {
   UnfoldLess as CollapseAllIcon,
   ErrorOutline as UnresolvedIcon,
   Layers as GapsIcon,
-  Link as LinkIcon,
-  ArrowForward as ArrowForwardIcon,
+  CallMerge as SingleChildIcon,
+  WarningAmber as WarningIcon,
+  Psychology as ReviewIcon,
+  PieChartOutline as CoverageIcon,
 } from '@mui/icons-material';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import {
   getMatchTree,
-  acceptMatch,
-  acceptBatchMatches,
-  rejectSuggestion,
-  dbSearchOneRegion,
-  aiMatchOneRegion,
-  aiReviewChildren,
+  getChildrenCoverage,
   addChildRegion,
   removeRegionFromImport,
   renameRegion,
-  dismissChildren,
-  simplifyHierarchy,
-  simplifyChildren,
-  undoLastOperation,
-  syncInstances,
-  handleAsGrouping,
-  geocodeMatchRegion,
-  geoshapeMatchRegion,
-  pointMatchRegion,
-  resetMatchRegion,
-  rejectRemaining,
-  acceptAndRejectRest as acceptAndRejectRestApi,
-  selectMapImage,
-  markManualFix,
-  acceptWithTransfer as acceptWithTransferApi,
   type MatchTreeNode,
-  type AIReviewChildrenResult,
-  type ReviewChildAction,
 } from '../../api/admin/worldViewImport';
 import { MapImagePickerDialog } from './MapImagePickerDialog';
-import { SmartSimplifyDialog } from './SmartSimplifyDialog';
-import { useCvMatchPipeline } from './useCvMatchPipeline';
-import { CvMatchDialog } from './CvMatchDialog';
+import { SmartFlattenPreviewDialog } from './SmartFlattenPreviewDialog';
 import { type ShadowInsertion } from './treeNodeShared';
 import { TreeNodeRow } from './TreeNodeRow';
-import { collectAncestorsOfUnresolved, collectAncestorsOfIds } from './importTreeUtils';
+import { useTreeMutations, type MapPickerState } from './useTreeMutations';
+import {
+  ManualFixDialog, RemoveRegionDialog, CoverageCompareDialog,
+  RenameRegionDialog, ReparentRegionDialog, AddChildDialog,
+  AISuggestChildrenDialog, DivisionSearchDialog, GapAnalysisDialog,
+} from './ImportTreeDialogs';
+import { ShadowCreateRow, NavControls } from './GapAnalysis';
+import { useCvMatchPipeline } from './useCvMatchPipeline';
+import { useNavigationState } from './useNavigationState';
+import { useImportTreeDialogs } from './useImportTreeDialogs';
+import { CvMatchDialog } from './CvMatchDialog';
+import { AIReviewDrawer } from './AIReviewDrawer';
+import { SmartSimplifyDialog } from './SmartSimplifyDialog';
+import { OverlapResolutionDialog } from './OverlapResolutionDialog';
+import type { DivisionOverlapResult } from '../../api/admin/worldViewImport';
 
-/** Extracted to avoid re-rendering the entire tree on every keystroke */
-function ManualFixDialog({ state, onClose, onSubmit, isPending }: {
-  state: { regionId: number; regionName: string } | null;
-  onClose: () => void;
-  onSubmit: (regionId: number, fixNote: string | undefined) => void;
-  isPending: boolean;
-}) {
-  const [fixNote, setFixNote] = useState('');
-
-  // Reset note when dialog opens with a new region
-  const prevRegionId = state?.regionId;
-  const [lastRegionId, setLastRegionId] = useState<number | undefined>();
-  if (prevRegionId !== lastRegionId) {
-    setLastRegionId(prevRegionId);
-    if (prevRegionId != null) setFixNote('');
+/** Find a child region's ID by name under a specific parent */
+function findChildIdByName(nodes: MatchTreeNode[], parentId: number, childName: string): number | undefined {
+  for (const node of nodes) {
+    if (node.id === parentId) {
+      return node.children.find(c => c.name === childName)?.id;
+    }
+    const found = findChildIdByName(node.children, parentId, childName);
+    if (found) return found;
   }
-
-  return (
-    <Dialog open={!!state} onClose={onClose} maxWidth="sm" fullWidth>
-      <DialogTitle>Mark as Needing Manual Fix</DialogTitle>
-      <DialogContent>
-        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-          {state?.regionName}
-        </Typography>
-        <TextField
-          autoFocus
-          fullWidth
-          multiline
-          minRows={2}
-          maxRows={4}
-          label="What needs to be fixed?"
-          placeholder="e.g., Borders don't match GADM, need to split into sub-regions..."
-          value={fixNote}
-          onChange={(e) => setFixNote(e.target.value)}
-          slotProps={{ htmlInput: { maxLength: 500 } }}
-        />
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={onClose}>Cancel</Button>
-        <Button
-          variant="contained"
-          color="warning"
-          onClick={() => {
-            if (state) {
-              onSubmit(state.regionId, fixNote || undefined);
-              onClose();
-            }
-          }}
-          disabled={isPending}
-        >
-          Mark for Fix
-        </Button>
-      </DialogActions>
-    </Dialog>
-  );
+  return undefined;
 }
 
 interface WorldViewImportTreeProps {
   worldViewId: number;
-  onPreview: (divisionId: number, name: string, path?: string, regionMapUrl?: string, wikidataId?: string, regionId?: number, isAssigned?: boolean, markerPoints?: Array<{ name: string; lat: number; lon: number }>) => void;
-  onPreviewTransfer?: (divisionId: number, name: string, path: string | undefined, conflict: { donorDivisionId: number; donorDivisionName: string; donorRegionId: number; type: 'direct' | 'split' }, wikidataId: string, regionName: string, regionId?: number, allDivisionIds?: number[]) => void;
+  onPreview: (divisionId: number, name: string, path?: string, regionMapUrl?: string, wikidataId?: string, regionId?: number, isAssigned?: boolean, regionMapLabel?: string, regionName?: string) => void;
+  onPreviewUnion?: (regionId: number, divisionIds: number[], context: { wikidataId?: string; regionMapUrl?: string; regionMapLabel?: string; regionName: string }) => void;
+  onPreviewTransfer?: (divisionId: number, name: string, path: string | undefined, conflict: { donorDivisionId: number; donorDivisionName: string; donorRegionId: number; type: 'direct' | 'split' }, wikidataId: string, regionName: string, regionId?: number, allDivisionIds?: number[], allSuggestions?: Array<{ divisionId: number; conflict?: { donorDivisionId: number; donorRegionId: number; type: 'direct' | 'split' } }>) => void;
+  onViewMap?: (regionId: number, context: { wikidataId?: string; regionMapUrl?: string; regionMapLabel?: string; regionName: string; divisionIds: number[] }) => void;
   shadowInsertions?: ShadowInsertion[];
   onApproveShadow?: (insertion: ShadowInsertion) => void;
   onRejectShadow?: (insertion: ShadowInsertion) => void;
+  /** Called when division assignments change, so parent can mark coverage as stale */
+  onMatchChange?: () => void;
 }
 
-export function WorldViewImportTree({ worldViewId, onPreview, onPreviewTransfer, shadowInsertions, onApproveShadow, onRejectShadow }: WorldViewImportTreeProps) {
-  const queryClient = useQueryClient();
-  const [expanded, setExpanded] = useState<Set<number>>(new Set());
-  const skipAnimationRef = useRef(false);
-  const [geocodeProgress, setGeocodeProgress] = useState<{ regionId: number; message: string; nextScope?: { ancestorId: number; ancestorName: string }; retryType?: 'geoshape' | 'point' } | null>(null);
-  const [fixDialogState, setFixDialogState] = useState<{ regionId: number; regionName: string } | null>(null);
-  const [mapPickerState, setMapPickerState] = useState<{
+export function WorldViewImportTree({ worldViewId, onPreview, onPreviewUnion, onPreviewTransfer, onViewMap, shadowInsertions, onApproveShadow, onRejectShadow, onMatchChange }: WorldViewImportTreeProps) {
+  const [mapPickerState, setMapPickerState] = useState<MapPickerState | null>(null);
+  const [removeDialogState, setRemoveDialogState] = useState<{
     regionId: number;
     regionName: string;
-    candidates: string[];
-    currentSelection: string | null;
-    wikidataId: string | null;
-    pendingPreview?: {
-      divisionId: number;
-      name: string;
-      path?: string;
-      isAssigned: boolean;
-    };
+    hasChildren: boolean;
+    hasDivisions: boolean;
   } | null>(null);
-
-  const [undoSnackbar, setUndoSnackbar] = useState<{
-    open: boolean;
-    message: string;
-    worldViewId: number;
-  } | null>(null);
-
-  const [smartSimplifyDialog, setSmartSimplifyDialog] = useState<{
-    regionId: number;
-    regionName: string;
-    regionMapUrl: string | null;
-  } | null>(null);
-
-  const [aiReviewDialog, setAIReviewDialog] = useState<{
-    regionId: number;
-    regionName: string;
-    result: AIReviewChildrenResult;
-    selected: Set<string>;
-  } | null>(null);
-  const [aiSuggestingRegionId, setAISuggestingRegionId] = useState<number | null>(null);
-
-  /** Find a child region ID by name under a specific parent node */
-  function findChildIdByName(nodes: MatchTreeNode[], parentId: number, childName: string): number | undefined {
-    for (const node of nodes) {
-      if (node.id === parentId) {
-        return node.children.find(c => c.name === childName)?.id;
-      }
-      const found = findChildIdByName(node.children, parentId, childName);
-      if (found !== undefined) return found;
-    }
-    return undefined;
-  }
 
   const { data: tree, isLoading } = useQuery({
     queryKey: ['admin', 'wvImport', 'matchTree', worldViewId],
     queryFn: () => getMatchTree(worldViewId),
   });
 
-  const invalidateTree = () => {
-    queryClient.invalidateQueries({ queryKey: ['admin', 'wvImport', 'matchTree', worldViewId] });
-    queryClient.invalidateQueries({ queryKey: ['admin', 'wvImport', 'matchStats', worldViewId] });
-  };
+  // Children coverage query (separate from tree to avoid slowing every tree load).
+  // staleTime=Infinity: we manage updates manually via setQueryData in refreshCoverage,
+  // so prevent TanStack Query from auto-refetching (which would recompute ALL containers).
+  const { data: coverageData, isRefetching: coverageRefetching, isLoading: coverageLoading } = useQuery({
+    queryKey: ['admin', 'wvImport', 'childrenCoverage', worldViewId],
+    queryFn: () => getChildrenCoverage(worldViewId),
+    staleTime: Infinity,
+  });
+
+  // Track which region was last mutated so we only show spinner on affected ancestors
+  const [lastMutatedRegionId, setLastMutatedRegionId] = useState<number | null>(null);
+  const [simplifySnackbar, setSimplifySnackbar] = useState<string | null>(null);
+  const [overlapDialog, setOverlapDialog] = useState<{
+    regionId: number;
+    regionName: string;
+    regionMapUrl: string | null;
+    data: DivisionOverlapResult;
+  } | null>(null);
+
+  // Clear the dirty marker once coverage refetch completes
+  useEffect(() => {
+    if (!coverageRefetching && lastMutatedRegionId != null) {
+      setLastMutatedRegionId(null);
+    }
+  }, [coverageRefetching, lastMutatedRegionId]);
+
+
+  // Compute the set of ancestor IDs for the last mutated region
+  const coverageDirtyIds = useMemo<ReadonlySet<number>>(() => {
+    if (!coverageRefetching || lastMutatedRegionId == null || !tree) return new Set();
+    // Build parent map from tree
+    const parentOf = new Map<number, number | null>();
+    const walkTree = (nodes: MatchTreeNode[], parentId: number | null) => {
+      for (const n of nodes) {
+        parentOf.set(n.id, parentId);
+        walkTree(n.children, n.id);
+      }
+    };
+    walkTree(tree, null);
+    // Walk up from mutated region collecting ancestors
+    const dirtyIds = new Set<number>();
+    let current: number | null = lastMutatedRegionId;
+    while (current != null) {
+      dirtyIds.add(current);
+      current = parentOf.get(current) ?? null;
+    }
+    return dirtyIds;
+  }, [coverageRefetching, lastMutatedRegionId, tree]);
+
+  // Ref for mapPickerState — needed by selectMapMutation to read pending preview
+  const mapPickerStateRef = useRef(mapPickerState);
+  mapPickerStateRef.current = mapPickerState;
+
+  const mutations = useTreeMutations(worldViewId, {
+    onPreview,
+    mapPickerStateRef,
+    setMapPickerState,
+    setRemoveDialogState,
+    onMatchChange,
+  });
 
   const {
-    cvMatchDialog,
-    setCVMatchDialog,
-    cvMatchingRegionId,
-    mapshapeMatchingRegionId,
-    handleCVMatch,
-    handleMapshapeMatch,
-    cancelCvMatch,
-  } = useCvMatchPipeline(worldViewId, tree, (regionId) => {
-    // Invalidate tree when CV match completes so match status refreshes
-    queryClient.invalidateQueries({ queryKey: ['admin', 'wvImport', 'matchTree', worldViewId] });
-    queryClient.invalidateQueries({ queryKey: ['admin', 'wvImport', 'matchStats', worldViewId] });
-    // Expand the node so newly assigned divisions are visible
-    setExpanded(prev => new Set([...prev, regionId]));
+    acceptMutation, rejectMutation, rejectRemainingMutation, acceptAndRejectRestMutation,
+    acceptAllMutation, acceptSelectedMutation, acceptSelectedRejectRestMutation, rejectSelectedMutation, onAcceptTransfer,
+    dbSearchOneMutation, aiMatchOneMutation, geocodeMatchMutation, geoshapeMatchMutation, pointMatchMutation,
+    resetMatchMutation, clearMembersMutation, dismissMutation, pruneMutation, syncMutation, groupingMutation, mergeMutation,
+    smartFlattenMutation, removeMutation, collapseToParentMutation, autoResolveMutation, simplifyHierarchyMutation, simplifyChildrenMutation, overlapCheckMutation, undoMutation,
+    selectMapMutation, manualFixMutation, addChildMutation,
+    dismissWarningsMutation, renameMutation, reparentMutation,
+    renamingRegionId, reparentingRegionId,
+    geocodeProgress, undoSnackbar, setUndoSnackbar,
+    isMutating, invalidateTree,
+  } = mutations;
+
+  // ── Extracted hooks ────────────────────────────────────────────────────────
+
+  const dialogs = useImportTreeDialogs(worldViewId, tree, {
+    renameMutation,
+    reparentMutation,
+    setRemoveDialogState,
+    setUndoSnackbar,
+    invalidateTree,
   });
 
-  const acceptMutation = useMutation({
-    mutationFn: ({ regionId, divisionId }: { regionId: number; divisionId: number }) =>
-      acceptMatch(worldViewId, regionId, divisionId),
-    onSuccess: invalidateTree,
-  });
+  const cvPipeline = useCvMatchPipeline(worldViewId, tree, dialogs.handleSmartSimplify);
 
-  const rejectMutation = useMutation({
-    mutationFn: ({ regionId, divisionId }: { regionId: number; divisionId: number }) =>
-      rejectSuggestion(worldViewId, regionId, divisionId),
-    onSuccess: invalidateTree,
-  });
+  const nav = useNavigationState(tree, shadowInsertions, coverageData);
 
-  const dbSearchOneMutation = useMutation({
-    mutationFn: (regionId: number) => dbSearchOneRegion(worldViewId, regionId),
-    onSuccess: invalidateTree,
-  });
-
-  const aiMatchOneMutation = useMutation({
-    mutationFn: (regionId: number) => aiMatchOneRegion(worldViewId, regionId),
-    onSuccess: invalidateTree,
-  });
-
-  const dismissMutation = useMutation({
-    mutationFn: (regionId: number) => dismissChildren(worldViewId, regionId),
-    onSuccess: (data) => {
-      invalidateTree();
-      if (data.undoAvailable) {
-        setUndoSnackbar({
-          open: true,
-          message: `Dismissed ${data.dismissed} descendant(s)`,
-          worldViewId,
-        });
-      }
-    },
-  });
-
-  const simplifyHierarchyMutation = useMutation({
-    mutationFn: (regionId: number) => simplifyHierarchy(worldViewId, regionId),
-    onSuccess: invalidateTree,
-  });
-
-  const simplifyChildrenMutation = useMutation({
-    mutationFn: (parentRegionId: number) => simplifyChildren(worldViewId, parentRegionId),
-    onSuccess: invalidateTree,
-  });
-
-  const syncMutation = useMutation({
-    mutationFn: (regionId: number) => syncInstances(worldViewId, regionId),
-    onSuccess: invalidateTree,
-  });
-
-  const groupingMutation = useMutation({
-    mutationFn: (regionId: number) => handleAsGrouping(worldViewId, regionId),
-    onSuccess: (data) => {
-      invalidateTree();
-      if (data.undoAvailable) {
-        setUndoSnackbar({
-          open: true,
-          message: `Matched ${data.matched}/${data.total} children`,
-          worldViewId,
-        });
-      }
-    },
-  });
-
-  const undoMutation = useMutation({
-    mutationFn: () => undoLastOperation(worldViewId),
-    onSuccess: () => {
-      setUndoSnackbar(null);
-      invalidateTree();
-    },
-  });
-
-  const geocodeMatchMutation = useMutation({
-    mutationFn: (regionId: number) => geocodeMatchRegion(worldViewId, regionId),
-    onMutate: (regionId) => {
-      setGeocodeProgress({ regionId, message: 'Geocoding via Nominatim...' });
-    },
-    onSuccess: (data, regionId) => {
-      if (data.geocodedName) {
-        const radiusMsg = data.searchRadiusKm
-          ? ` within ${data.searchRadiusKm}km`
-          : ' (exact)';
-        setGeocodeProgress({
-          regionId,
-          message: data.found > 0
-            ? `Found ${data.found} division(s)${radiusMsg}`
-            : `No divisions found — ${data.geocodedName}`,
-        });
-      } else {
-        setGeocodeProgress({ regionId, message: 'Not found in Nominatim' });
-      }
-      invalidateTree();
-      setTimeout(() => setGeocodeProgress(null), 4000);
-    },
-    onError: () => {
-      setGeocodeProgress(null);
-    },
-  });
-
-  const geoshapeMatchMutation = useMutation({
-    mutationFn: ({ regionId, scopeAncestorId }: { regionId: number; scopeAncestorId?: number }) =>
-      geoshapeMatchRegion(worldViewId, regionId, scopeAncestorId),
-    onMutate: ({ regionId }) => {
-      setGeocodeProgress({ regionId, message: 'Matching by geoshape...' });
-    },
-    onSuccess: (data, { regionId }) => {
-      const coverageMsg = data.totalCoverage != null
-        ? ` (${Math.round(data.totalCoverage * 100)}% coverage)`
-        : '';
-      if (data.found > 0) {
-        setGeocodeProgress({
-          regionId,
-          message: `Covering set: ${data.found} division(s)${coverageMsg}`,
-        });
-        setTimeout(() => setGeocodeProgress(null), 4000);
-      } else if (data.nextScope) {
-        setGeocodeProgress({
-          regionId,
-          message: `No matches in ${data.scopeAncestorName ?? 'current'} scope`,
-          nextScope: data.nextScope,
-          retryType: 'geoshape',
-        });
-        // Do NOT auto-dismiss — user needs to decide
-      } else {
-        setGeocodeProgress({
-          regionId,
-          message: 'No geoshape matches found',
-        });
-        setTimeout(() => setGeocodeProgress(null), 4000);
-      }
-      invalidateTree();
-    },
-    onError: () => {
-      setGeocodeProgress(null);
-    },
-  });
-
-  const acceptTransferMutation = useMutation({
-    mutationFn: ({ regionId, divisionIds, donorRegionId, donorDivisionId, transferType }: {
-      regionId: number; divisionIds: number[]; donorRegionId: number; donorDivisionId: number; transferType: 'direct' | 'split';
-    }) => acceptWithTransferApi(worldViewId, regionId, divisionIds, donorRegionId, donorDivisionId, transferType),
-    onSuccess: (_data, { regionId }) => {
-      invalidateTree();
-      if (regionId) setGeocodeProgress(null);
-    },
-  });
-
-  const onAcceptTransfer = (regionId: number, divisionId: number, conflict: { type: 'direct' | 'split'; donorRegionId: number; donorDivisionId: number }) =>
-    acceptTransferMutation.mutate({
-      regionId,
-      divisionIds: [divisionId],
-      donorRegionId: conflict.donorRegionId,
-      donorDivisionId: conflict.donorDivisionId,
-      transferType: conflict.type,
-    });
-
-  const pointMatchMutation = useMutation({
-    mutationFn: ({ regionId, scopeAncestorId }: { regionId: number; scopeAncestorId?: number }) =>
-      pointMatchRegion(worldViewId, regionId, scopeAncestorId),
-    onMutate: ({ regionId }) => {
-      setGeocodeProgress({ regionId, message: 'Matching by markers...' });
-    },
-    onSuccess: (data, { regionId }) => {
-      if (data.found > 0) {
-        setGeocodeProgress({
-          regionId,
-          message: `Found ${data.found} division(s) from markers`,
-        });
-        setTimeout(() => setGeocodeProgress(null), 4000);
-      } else if (data.nextScope) {
-        setGeocodeProgress({
-          regionId,
-          message: `No marker matches in ${data.scopeAncestorName ?? 'current'} scope`,
-          nextScope: data.nextScope,
-          retryType: 'point',
-        });
-      } else {
-        setGeocodeProgress({
-          regionId,
-          message: 'No divisions found from markers',
-        });
-        setTimeout(() => setGeocodeProgress(null), 4000);
-      }
-      invalidateTree();
-    },
-    onError: () => {
-      setGeocodeProgress(null);
-    },
-  });
-
-  const resetMatchMutation = useMutation({
-    mutationFn: (regionId: number) => resetMatchRegion(worldViewId, regionId),
-    onSuccess: invalidateTree,
-  });
-
-  const rejectRemainingMutation = useMutation({
-    mutationFn: (regionId: number) => rejectRemaining(worldViewId, regionId),
-    onSuccess: invalidateTree,
-  });
-
-  const acceptAndRejectRestMutation = useMutation({
-    mutationFn: ({ regionId, divisionId }: { regionId: number; divisionId: number }) =>
-      acceptAndRejectRestApi(worldViewId, regionId, divisionId),
-    onSuccess: invalidateTree,
-  });
-
-  const acceptAllMutation = useMutation({
-    mutationFn: (assignments: Array<{ regionId: number; divisionId: number }>) =>
-      acceptBatchMatches(worldViewId, assignments),
-    onSuccess: invalidateTree,
-  });
-
-  const selectMapMutation = useMutation({
-    mutationFn: ({ regionId, imageUrl }: { regionId: number; imageUrl: string | null }) =>
-      selectMapImage(worldViewId, regionId, imageUrl),
-    onSuccess: (_data, variables) => {
-      const pending = mapPickerState?.pendingPreview;
-      const wikidataId = mapPickerState?.wikidataId;
-      const pickerRegionId = mapPickerState?.regionId;
-      setMapPickerState(null);
-      invalidateTree();
-      // If preview was intercepted, proceed to the regular preview now
-      if (pending) {
-        onPreview(
-          pending.divisionId,
-          pending.name,
-          pending.path,
-          variables.imageUrl ?? undefined,
-          wikidataId ?? undefined,
-          pickerRegionId,
-          pending.isAssigned,
-        );
-      }
-    },
-  });
-
-  const manualFixMutation = useMutation({
-    mutationFn: ({ regionId, needsManualFix, fixNote }: { regionId: number; needsManualFix: boolean; fixNote?: string }) =>
-      markManualFix(worldViewId, regionId, needsManualFix, fixNote),
-    onSuccess: invalidateTree,
-  });
-
-  const handleSmartSimplify = useCallback((regionId: number) => {
-    if (!tree) return;
-    const findNode = (nodes: MatchTreeNode[]): MatchTreeNode | null => {
-      for (const n of nodes) {
-        if (n.id === regionId) return n;
-        const found = findNode(n.children);
-        if (found) return found;
-      }
-      return null;
-    };
-    const node = findNode(tree);
-    if (!node) return;
-    setSmartSimplifyDialog({
-      regionId,
-      regionName: node.name,
-      regionMapUrl: node.regionMapUrl,
-    });
-  }, [tree]);
-
-  const handleAIReviewChildren = useCallback(async (regionId: number) => {
-    if (!tree) return;
-    const findNode = (nodes: MatchTreeNode[]): MatchTreeNode | null => {
-      for (const n of nodes) {
-        if (n.id === regionId) return n;
-        const found = findNode(n.children);
-        if (found) return found;
-      }
-      return null;
-    };
-    const node = findNode(tree);
-    if (!node) return;
-
-    setAISuggestingRegionId(regionId);
-    try {
-      const result = await aiReviewChildren(worldViewId, regionId);
-      // Pre-select add and rename actions (not remove — destructive)
-      const selected = new Set(
-        result.actions
-          .filter((a: ReviewChildAction) => a.type !== 'remove')
-          .map((a: ReviewChildAction) => `${a.type}:${a.name}`),
-      );
-      setAIReviewDialog({ regionId, regionName: node.name, result, selected });
-    } catch (err) {
-      console.error('AI review children failed:', err);
-      setUndoSnackbar({
-        open: true,
-        message: `AI review children failed: ${err instanceof Error ? err.message : 'Unknown error'}`,
-        worldViewId,
-      });
-    } finally {
-      setAISuggestingRegionId(null);
-    }
-  }, [tree, worldViewId]);
+  // ── Callbacks ──────────────────────────────────────────────────────────────
 
   const handleOpenMapPicker = useCallback((node: MatchTreeNode, pendingPreview?: { divisionId: number; name: string; path?: string; isAssigned: boolean }) => {
     setMapPickerState({
@@ -521,6 +193,258 @@ export function WorldViewImportTree({ worldViewId, onPreview, onPreviewTransfer,
       pendingPreview,
     });
   }, []);
+
+  const handleSimplifyHierarchy = useCallback((regionId: number) => {
+    simplifyHierarchyMutation.mutate(regionId, {
+      onSuccess: (data) => {
+        if (data.replacements.length === 0) {
+          setSimplifySnackbar('Nothing to simplify');
+        } else {
+          const summary = data.replacements
+            .map(r => `${r.parentName} (${r.replacedCount} → 1)`)
+            .join(', ');
+          setSimplifySnackbar(`Simplified: ${summary}`);
+        }
+      },
+    });
+  }, [simplifyHierarchyMutation]);
+
+  const handleSimplifyChildren = useCallback((regionId: number) => {
+    simplifyChildrenMutation.mutate(regionId, {
+      onSuccess: (data) => {
+        if (data.totalSimplified === 0) {
+          setSimplifySnackbar('No children could be simplified');
+        } else {
+          const summary = data.results.map(r => `${r.regionName} (${r.totalReduced} reduced)`).join(', ');
+          setSimplifySnackbar(`Simplified ${data.totalSimplified} children: ${summary}`);
+        }
+      },
+    });
+  }, [simplifyChildrenMutation]);
+
+  const handleCheckOverlap = useCallback((regionId: number) => {
+    // Find node in tree for name/mapUrl
+    function findNode(nodes: MatchTreeNode[], id: number): MatchTreeNode | null {
+      for (const n of nodes) {
+        if (n.id === id) return n;
+        const found = findNode(n.children, id);
+        if (found) return found;
+      }
+      return null;
+    }
+    const node = tree ? findNode(tree, regionId) : null;
+    overlapCheckMutation.mutate(regionId, {
+      onSuccess: (data) => {
+        if (data.overlaps.length === 0) {
+          setSimplifySnackbar('No division overlaps found among children');
+        } else {
+          setOverlapDialog({
+            regionId,
+            regionName: node?.name ?? `Region ${regionId}`,
+            regionMapUrl: node?.regionMapUrl ?? null,
+            data,
+          });
+        }
+      },
+    });
+  }, [overlapCheckMutation, tree]);
+
+  // Build a pending promise for a single AI-suggested action
+  const buildSuggestChildrenActionPromise = useCallback((
+    parentId: number,
+    action: { type: 'add' | 'remove' | 'rename' | 'enrich'; name: string; newName?: string; sourceUrl?: string | null; sourceExternalId?: string | null },
+  ): Promise<unknown> | undefined => {
+    if (action.type === 'add') {
+      return addChildRegion(
+        worldViewId, parentId, action.name,
+        action.sourceUrl ?? undefined, action.sourceExternalId ?? undefined,
+      );
+    }
+    if (action.type === 'remove') {
+      const childId = tree ? findChildIdByName(tree, parentId, action.name) : undefined;
+      if (!childId) return undefined;
+      // Reparent both children AND assigned GADM divisions up to the parent;
+      // otherwise CASCADE would silently delete `region_members` rows the admin
+      // had already accepted.
+      return removeRegionFromImport(worldViewId, childId, true, true);
+    }
+    // rename or enrich
+    const childId = tree ? findChildIdByName(tree, parentId, action.name) : undefined;
+    if (!childId) return undefined;
+    return renameRegion(
+      worldViewId, childId, action.newName ?? action.name,
+      action.sourceUrl ?? undefined, action.sourceExternalId ?? undefined,
+    );
+  }, [worldViewId, tree]);
+
+  // Handler bundle for TreeNodeRow, extracted to reduce complexity of the render
+  // virtualization map callback below. Each handler is a narrow wrapper around a
+  // mutation so the JSX doesn't inline dozens of arrow functions.
+  const handleAccept = useCallback((regionId: number, divisionId: number) => {
+    setLastMutatedRegionId(regionId);
+    acceptMutation.mutate({ regionId, divisionId });
+  }, [acceptMutation]);
+
+  const handleAcceptAndRejectRest = useCallback((regionId: number, divisionId: number) => {
+    setLastMutatedRegionId(regionId);
+    acceptAndRejectRestMutation.mutate({ regionId, divisionId });
+  }, [acceptAndRejectRestMutation]);
+
+  const handleReject = useCallback((regionId: number, divisionId: number) => {
+    rejectMutation.mutate({ regionId, divisionId });
+  }, [rejectMutation]);
+
+  const handleDBSearch = useCallback((regionId: number) => dbSearchOneMutation.mutate(regionId), [dbSearchOneMutation]);
+  const handleAIMatch = useCallback((regionId: number) => aiMatchOneMutation.mutate(regionId), [aiMatchOneMutation]);
+  const handleDismissChildren = useCallback((regionId: number) => dismissMutation.mutate(regionId), [dismissMutation]);
+  const handleSync = useCallback((regionId: number) => syncMutation.mutate(regionId), [syncMutation]);
+  const handleHandleAsGrouping = useCallback((regionId: number) => {
+    setLastMutatedRegionId(regionId);
+    groupingMutation.mutate(regionId);
+  }, [groupingMutation]);
+  const handleGeocodeMatch = useCallback((regionId: number) => geocodeMatchMutation.mutate(regionId), [geocodeMatchMutation]);
+  const handleGeoshapeMatch = useCallback((regionId: number, scopeAncestorId?: number) =>
+    geoshapeMatchMutation.mutate({ regionId, scopeAncestorId }), [geoshapeMatchMutation]);
+  const handlePointMatch = useCallback((regionId: number, scopeAncestorId?: number) =>
+    pointMatchMutation.mutate({ regionId, scopeAncestorId }), [pointMatchMutation]);
+  const handleResetMatch = useCallback((regionId: number) => resetMatchMutation.mutate(regionId), [resetMatchMutation]);
+  const handleRejectRemaining = useCallback((regionId: number) => rejectRemainingMutation.mutate(regionId), [rejectRemainingMutation]);
+
+  const handleAcceptAll = useCallback((assignments: Array<{ regionId: number; divisionId: number }>) => {
+    if (assignments[0]) setLastMutatedRegionId(assignments[0].regionId);
+    acceptAllMutation.mutate(assignments);
+  }, [acceptAllMutation]);
+
+  const handleAcceptSelected = useCallback((regionId: number, divisionIds: number[]) => {
+    setLastMutatedRegionId(regionId);
+    acceptSelectedMutation.mutate({ regionId, divisionIds });
+  }, [acceptSelectedMutation]);
+
+  const handleAcceptSelectedRejectRest = useCallback((regionId: number, divisionIds: number[]) => {
+    setLastMutatedRegionId(regionId);
+    acceptSelectedRejectRestMutation.mutate({ regionId, divisionIds });
+  }, [acceptSelectedRejectRestMutation]);
+
+  const handleRejectSelected = useCallback((regionId: number, divisionIds: number[]) => {
+    rejectSelectedMutation.mutate({ regionId, divisionIds });
+  }, [rejectSelectedMutation]);
+
+  const handleMergeChild = useCallback((regionId: number) => mergeMutation.mutate(regionId), [mergeMutation]);
+  const handleDismissHierarchyWarnings = useCallback((regionId: number) => dismissWarningsMutation.mutate(regionId), [dismissWarningsMutation]);
+  const handleCollapseToParent = useCallback((regionId: number) => collapseToParentMutation.mutate(regionId), [collapseToParentMutation]);
+  const handleAutoResolve = useCallback((regionId: number) => autoResolveMutation.mutate(regionId), [autoResolveMutation]);
+  const handleReviewSubtree = useCallback((regionId: number) => dialogs.handleReview(regionId), [dialogs]);
+
+  const handleRename = useCallback((regionId: number, currentName: string) => {
+    dialogs.setRenameDialog({ regionId, currentName, newName: currentName });
+  }, [dialogs]);
+
+  const handleReparent = useCallback((regionId: number) => {
+    const region = dialogs.flatRegionList.find(r => r.id === regionId);
+    dialogs.setReparentDialog({ regionId, regionName: region?.name ?? '', selectedParentId: null });
+  }, [dialogs]);
+
+  const handlePruneToLeaves = useCallback((regionId: number) => pruneMutation.mutate(regionId), [pruneMutation]);
+  const handleClearMembers = useCallback((regionId: number) => clearMembersMutation.mutate(regionId), [clearMembersMutation]);
+
+  // Compute pending region IDs for each mutation via a single memo, so the
+  // JSX below doesn't need to inline dozens of ternaries (and the enclosing
+  // component function stays under the cognitive-complexity cap).
+  const pendingIds = useMemo(() => {
+    const simple = <V,>(m: { isPending: boolean; variables?: V }): V | null =>
+      (m.isPending ? (m.variables ?? null) : null);
+    const nested = <V,>(m: { isPending: boolean; variables?: { regionId?: V } }): V | null =>
+      (m.isPending ? (m.variables?.regionId ?? null) : null);
+    return {
+      mergingRegionId: simple(mergeMutation),
+      flatteningRegionId: dialogs.flattenPreviewLoading ?? simple(smartFlattenMutation),
+      removingRegionId: nested(removeMutation),
+      collapsingRegionId: simple(collapseToParentMutation),
+      autoResolvingRegionId: simple(autoResolveMutation),
+      reviewingRegionId: dialogs.reviewLoading?.key.startsWith('region-')
+        ? Number(dialogs.reviewLoading.key.replace('region-', ''))
+        : null,
+      pruningRegionId: simple(pruneMutation),
+      clearingMembersRegionId: simple(clearMembersMutation),
+      simplifyingRegionId: simple(simplifyHierarchyMutation),
+      simplifyingChildrenRegionId: simple(simplifyChildrenMutation),
+      checkingOverlapRegionId: simple(overlapCheckMutation),
+      dbSearchingRegionId: simple(dbSearchOneMutation),
+      aiMatchingRegionId: simple(aiMatchOneMutation),
+      dismissingRegionId: simple(dismissMutation),
+      syncingRegionId: simple(syncMutation),
+      groupingRegionId: simple(groupingMutation),
+      geocodeMatchingRegionId: simple(geocodeMatchMutation),
+      geoshapeMatchingRegionId: nested(geoshapeMatchMutation),
+      pointMatchingRegionId: nested(pointMatchMutation),
+    };
+  }, [
+    mergeMutation, smartFlattenMutation, removeMutation, collapseToParentMutation,
+    autoResolveMutation, pruneMutation, clearMembersMutation, simplifyHierarchyMutation,
+    simplifyChildrenMutation, overlapCheckMutation, dbSearchOneMutation, aiMatchOneMutation,
+    dismissMutation, syncMutation, groupingMutation, geocodeMatchMutation,
+    geoshapeMatchMutation, pointMatchMutation, dialogs.flattenPreviewLoading, dialogs.reviewLoading,
+  ]);
+
+  const handleContentResize = useCallback(() => {
+    // Re-measure visible items after DOM update (don't use virtualizer.measure()
+    // which clears ALL cached sizes and causes layout thrash)
+    const measureVisibleElement = (el: HTMLElement) => {
+      nav.virtualizer.measureElement(el);
+    };
+    const performMeasurements = () => {
+      nav.parentRef.current?.querySelectorAll<HTMLElement>('[data-index]').forEach(measureVisibleElement);
+    };
+    requestAnimationFrame(performMeasurements);
+  }, [nav]);
+
+  const findNodeName = useCallback((regionId: number): string => {
+    if (!tree) return '';
+    const walk = (nodes: MatchTreeNode[]): string => {
+      for (const n of nodes) {
+        if (n.id === regionId) return n.name;
+        const found = walk(n.children);
+        if (found) return found;
+      }
+      return '';
+    };
+    return walk(tree);
+  }, [tree]);
+
+  const handleManualFix = useCallback((regionId: number, needsManualFix: boolean) => {
+    if (needsManualFix) {
+      dialogs.setFixDialogState({ regionId, regionName: findNodeName(regionId) });
+    } else {
+      manualFixMutation.mutate({ regionId, needsManualFix: false });
+    }
+  }, [dialogs, findNodeName, manualFixMutation]);
+
+  const handleSuggestChildrenSubmit = useCallback(async () => {
+    if (!dialogs.suggestChildrenResult) return;
+    const { regionId: parentId, result, selected } = dialogs.suggestChildrenResult;
+    dialogs.setSuggestChildrenResult(null);
+
+    const promises: Promise<unknown>[] = [];
+    for (const key of selected) {
+      const colonIdx = key.indexOf(':');
+      const type = key.slice(0, colonIdx);
+      const name = key.slice(colonIdx + 1);
+      const action = result.actions.find(a => a.type === type && a.name === name);
+      if (!action) continue;
+      const promise = buildSuggestChildrenActionPromise(parentId, action);
+      if (promise) promises.push(promise);
+    }
+
+    const results = await Promise.allSettled(promises);
+    const failures = results.filter(r => r.status === 'rejected');
+    if (failures.length > 0) {
+      for (const f of failures) {
+        console.error('[AI Review Children] action failed:', (f as PromiseRejectedResult).reason);
+      }
+      alert(`AI Review Children: ${failures.length} of ${results.length} action(s) failed. See browser console for details. The tree will refresh to reflect the partial result.`);
+    }
+    invalidateTree(parentId);
+  }, [dialogs, buildSuggestChildrenActionPromise, invalidateTree]);
 
   // Compute which sourceUrls appear on multiple nodes (duplicates)
   // and which are already synced (same matchStatus and same division set)
@@ -556,106 +480,59 @@ export function WorldViewImportTree({ worldViewId, onPreview, onPreviewTransfer,
     return { duplicateUrls: dups, syncedUrls: synced };
   }, [tree]);
 
-  const toggleExpand = useCallback((id: number) => {
-    setExpanded(prev => {
-      const next = new Set(prev);
-      if (next.has(id)) {
-        next.delete(id);
-      } else {
-        next.add(id);
-      }
-      return next;
-    });
-  }, []);
-
-  const allBranchIds = useMemo(() => {
-    if (!tree) return new Set<number>();
-    const ids = new Set<number>();
-    function walk(nodes: MatchTreeNode[]) {
+  // Build maps from node ID -> direct parent's regionMapUrl and name (for fallback in preview)
+  const { parentRegionMapUrlById, parentRegionMapNameById } = useMemo(() => {
+    const urlMap = new Map<number, string>();
+    const nameMap = new Map<number, string>();
+    if (!tree) return { parentRegionMapUrlById: urlMap, parentRegionMapNameById: nameMap };
+    function walk(nodes: MatchTreeNode[], parentMapUrl: string | null, parentMapName: string | null) {
       for (const node of nodes) {
-        if (node.children.length > 0) {
-          ids.add(node.id);
-          walk(node.children);
-        }
+        if (parentMapUrl) urlMap.set(node.id, parentMapUrl);
+        if (parentMapName) nameMap.set(node.id, parentMapName);
+        // Only pass THIS node's own map to children — don't propagate inherited ancestor maps
+        walk(node.children, node.regionMapUrl ?? null, node.regionMapUrl ? node.name : null);
       }
     }
-    walk(tree);
-    return ids;
+    walk(tree, null, null);
+    return { parentRegionMapUrlById: urlMap, parentRegionMapNameById: nameMap };
   }, [tree]);
 
-  const expandAll = useCallback(() => {
-    skipAnimationRef.current = true;
-    setExpanded(new Set(allBranchIds));
-    requestAnimationFrame(() => { skipAnimationRef.current = false; });
-  }, [allBranchIds]);
-
-  const collapseAll = useCallback(() => {
-    skipAnimationRef.current = true;
-    setExpanded(new Set());
-    requestAnimationFrame(() => { skipAnimationRef.current = false; });
-  }, []);
-
-  const expandToUnresolved = useCallback(() => {
-    if (!tree) return;
-    skipAnimationRef.current = true;
-    setExpanded(collectAncestorsOfUnresolved(tree));
-    requestAnimationFrame(() => { skipAnimationRef.current = false; });
-  }, [tree]);
-
-  const expandToShadows = useCallback(() => {
-    if (!tree || !shadowInsertions?.length) return;
-    skipAnimationRef.current = true;
-    const targetIds = new Set(shadowInsertions.map(s => s.targetRegionId));
-    const ancestorIds = collectAncestorsOfIds(tree, targetIds);
-    setExpanded(new Set([...ancestorIds, ...targetIds]));
-    // Scroll to first target
-    requestAnimationFrame(() => {
-      skipAnimationRef.current = false;
-      setTimeout(() => {
-        const firstId = shadowInsertions[0].targetRegionId;
-        document.querySelector(`[data-region-id="${firstId}"]`)
-          ?.scrollIntoView({ behavior: 'smooth', block: 'center' });
-      }, 100);
-    });
-  }, [tree, shadowInsertions]);
-
-  // Compute per-region shadow map
-  const shadowsByRegionId = useMemo(() => {
-    const map = new Map<number, ShadowInsertion[]>();
-    for (const s of shadowInsertions ?? []) {
-      const arr = map.get(s.targetRegionId) ?? [];
-      arr.push(s);
-      map.set(s.targetRegionId, arr);
+  // Render nav-category toolbar: either NavControls (when active) or a count button.
+  // Extracted to keep the component body's cognitive complexity under the cap.
+  const renderNavCategoryButton = (params: {
+    category: 'unresolved' | 'warnings' | 'single-child' | 'incomplete-coverage';
+    ids: ReadonlyArray<number>;
+    label: string;
+    icon: React.ReactNode;
+    buttonText: string;
+    buttonColor?: 'warning' | 'info' | 'secondary' | 'error' | 'inherit';
+    buttonSx?: { color: string };
+  }) => {
+    if (params.ids.length === 0) return null;
+    if (nav.activeNav?.category === params.category) {
+      return (
+        <NavControls
+          label={params.label}
+          idx={nav.activeNav.idx}
+          total={params.ids.length}
+          onPrev={() => nav.navigateTo(params.category, nav.activeNav!.idx - 1)}
+          onNext={() => nav.navigateTo(params.category, nav.activeNav!.idx + 1)}
+          onClose={() => nav.setActiveNav(null)}
+        />
+      );
     }
-    return map;
-  }, [shadowInsertions]);
-
-  // Auto-expand tree ancestors when shadow insertions appear
-  const prevShadowCount = useRef(0);
-  useEffect(() => {
-    if (!tree || !shadowInsertions?.length) {
-      prevShadowCount.current = 0;
-      return;
-    }
-    if (prevShadowCount.current === shadowInsertions.length) return;
-    prevShadowCount.current = shadowInsertions.length;
-
-    const targetIds = new Set(shadowInsertions.map(s => s.targetRegionId));
-    const ancestorIds = collectAncestorsOfIds(tree, targetIds);
-    // Also expand the target nodes themselves (for create_region, shadows appear as children)
-    setExpanded(prev => new Set([...prev, ...ancestorIds, ...targetIds]));
-
-    // Scroll to first target
-    requestAnimationFrame(() => {
-      setTimeout(() => {
-        const firstId = shadowInsertions[0].targetRegionId;
-        document.querySelector(`[data-region-id="${firstId}"]`)
-          ?.scrollIntoView({ behavior: 'smooth', block: 'center' });
-      }, 100);
-    });
-  }, [tree, shadowInsertions]);
-
-  const isMutating = acceptMutation.isPending || rejectMutation.isPending || acceptAndRejectRestMutation.isPending || dismissMutation.isPending || simplifyHierarchyMutation.isPending || simplifyChildrenMutation.isPending || syncMutation.isPending || groupingMutation.isPending || geocodeMatchMutation.isPending || geoshapeMatchMutation.isPending || pointMatchMutation.isPending || resetMatchMutation.isPending || rejectRemainingMutation.isPending || acceptAllMutation.isPending || acceptTransferMutation.isPending || selectMapMutation.isPending || manualFixMutation.isPending;
+    return (
+      <Button
+        size="small"
+        startIcon={params.icon}
+        onClick={() => nav.navigateTo(params.category, 0)}
+        color={params.buttonColor}
+        sx={params.buttonSx}
+      >
+        {params.buttonText}
+      </Button>
+    );
+  };
 
   if (isLoading) {
     return (
@@ -670,94 +547,186 @@ export function WorldViewImportTree({ worldViewId, onPreview, onPreviewTransfer,
   }
 
   return (
-    <Box>
-      <Box sx={{ display: 'flex', gap: 1, mb: 2 }}>
-        <Button size="small" startIcon={<ExpandAllIcon />} onClick={expandAll}>
+    <Box sx={{ display: 'flex', flexDirection: 'column', height: 'calc(100vh - 250px)' }}>
+      <Box sx={{ display: 'flex', gap: 1, mb: 2, flexShrink: 0, flexWrap: 'wrap', alignItems: 'center' }}>
+        <Button size="small" startIcon={<ExpandAllIcon />} onClick={nav.expandAll}>
           Expand All
         </Button>
-        <Button size="small" startIcon={<CollapseAllIcon />} onClick={collapseAll}>
+        <Button size="small" startIcon={<CollapseAllIcon />} onClick={nav.collapseAll}>
           Collapse All
         </Button>
-        <Button size="small" startIcon={<UnresolvedIcon />} onClick={expandToUnresolved} color="warning">
-          Show Unresolved
-        </Button>
+        {renderNavCategoryButton({
+          category: 'unresolved',
+          ids: nav.unresolvedIds,
+          label: 'unresolved',
+          icon: <UnresolvedIcon />,
+          buttonText: `${nav.unresolvedIds.length} Unresolved`,
+          buttonColor: 'warning',
+        })}
         {shadowInsertions && shadowInsertions.length > 0 && (
-          <Button size="small" startIcon={<GapsIcon />} onClick={expandToShadows} color="info">
+          <Button size="small" startIcon={<GapsIcon />} onClick={nav.expandToShadows} color="info">
             Show {shadowInsertions.length} Gap{shadowInsertions.length !== 1 ? 's' : ''} to Review
           </Button>
         )}
+        {renderNavCategoryButton({
+          category: 'warnings',
+          ids: nav.warningIds,
+          label: 'warnings',
+          icon: <WarningIcon />,
+          buttonText: `${nav.warningIds.length} Hierarchy Warning${nav.warningIds.length !== 1 ? 's' : ''}`,
+          buttonSx: { color: 'warning.main' },
+        })}
+        {renderNavCategoryButton({
+          category: 'single-child',
+          ids: nav.singleChildIds,
+          label: 'single-child',
+          icon: <SingleChildIcon />,
+          buttonText: `${nav.singleChildIds.length} Single-Child`,
+          buttonColor: 'secondary',
+        })}
+        {renderNavCategoryButton({
+          category: 'incomplete-coverage',
+          ids: nav.incompleteCoverageIds,
+          label: 'incomplete coverage',
+          icon: <CoverageIcon />,
+          buttonText: `${nav.incompleteCoverageIds.length} Incomplete Coverage`,
+          buttonColor: 'error',
+        })}
+        <Button
+          size="small"
+          startIcon={dialogs.reviewLoading ? <CircularProgress size={14} /> : <ReviewIcon />}
+          onClick={() => dialogs.handleReview()}
+          disabled={!!dialogs.reviewLoading}
+        >
+          AI Review
+        </Button>
       </Box>
-      {tree.map(node => (
-        <TreeNodeRow
-          key={node.id}
-          node={node}
-          depth={0}
-          expanded={expanded}
-          ancestorIsMatched={false}
-          onToggle={toggleExpand}
-          onAccept={(regionId, divisionId) => acceptMutation.mutate({ regionId, divisionId })}
-          onAcceptTransfer={onAcceptTransfer}
-          onAcceptAndRejectRest={(regionId, divisionId) => acceptAndRejectRestMutation.mutate({ regionId, divisionId })}
-          onReject={(regionId, divisionId) => rejectMutation.mutate({ regionId, divisionId })}
-          onDBSearch={(regionId) => dbSearchOneMutation.mutate(regionId)}
-          onAIMatch={(regionId) => aiMatchOneMutation.mutate(regionId)}
-          onDismissChildren={(regionId) => dismissMutation.mutate(regionId)}
-          onSimplifyHierarchy={(regionId) => simplifyHierarchyMutation.mutate(regionId)}
-          onSimplifyChildren={(regionId) => simplifyChildrenMutation.mutate(regionId)}
-          onSmartSimplify={handleSmartSimplify}
-          onAISuggestChildren={handleAIReviewChildren}
-          aiSuggestingRegionId={aiSuggestingRegionId}
-          onCVMatch={handleCVMatch}
-          cvMatchingRegionId={cvMatchingRegionId}
-          onMapshapeMatch={handleMapshapeMatch}
-          mapshapeMatchingRegionId={mapshapeMatchingRegionId}
-          onSync={(regionId) => syncMutation.mutate(regionId)}
-          onHandleAsGrouping={(regionId) => groupingMutation.mutate(regionId)}
-          onGeocodeMatch={(regionId) => geocodeMatchMutation.mutate(regionId)}
-          onGeoshapeMatch={(regionId, scopeAncestorId) => geoshapeMatchMutation.mutate({ regionId, scopeAncestorId })}
-          onPointMatch={(regionId, scopeAncestorId) => pointMatchMutation.mutate({ regionId, scopeAncestorId })}
-          onResetMatch={(regionId) => resetMatchMutation.mutate(regionId)}
-          onRejectRemaining={(regionId) => rejectRemainingMutation.mutate(regionId)}
-          onAcceptAll={(assignments) => acceptAllMutation.mutate(assignments)}
-          onPreview={onPreview}
-          onPreviewTransfer={onPreviewTransfer}
-          onOpenMapPicker={handleOpenMapPicker}
-          onManualFix={(regionId, needsManualFix) => {
-            if (needsManualFix) {
-              // Find the node name for the dialog title
-              const findName = (nodes: MatchTreeNode[]): string => {
-                for (const n of nodes) {
-                  if (n.id === regionId) return n.name;
-                  const found = findName(n.children);
-                  if (found) return found;
-                }
-                return '';
-              };
-              setFixDialogState({ regionId, regionName: findName(tree!) });
-            } else {
-              manualFixMutation.mutate({ regionId, needsManualFix: false });
-            }
-          }}
-          isMutating={isMutating}
-          dbSearchingRegionId={dbSearchOneMutation.isPending ? (dbSearchOneMutation.variables ?? null) : null}
-          aiMatchingRegionId={aiMatchOneMutation.isPending ? (aiMatchOneMutation.variables ?? null) : null}
-          dismissingRegionId={dismissMutation.isPending ? (dismissMutation.variables ?? null) : null}
-          simplifyingRegionId={simplifyHierarchyMutation.isPending ? (simplifyHierarchyMutation.variables ?? null) : null}
-          simplifyingChildrenRegionId={simplifyChildrenMutation.isPending ? (simplifyChildrenMutation.variables ?? null) : null}
-          syncingRegionId={syncMutation.isPending ? (syncMutation.variables ?? null) : null}
-          groupingRegionId={groupingMutation.isPending ? (groupingMutation.variables ?? null) : null}
-          geocodeMatchingRegionId={geocodeMatchMutation.isPending ? (geocodeMatchMutation.variables ?? null) : null}
-          geoshapeMatchingRegionId={geoshapeMatchMutation.isPending ? (geoshapeMatchMutation.variables?.regionId ?? null) : null}
-          pointMatchingRegionId={pointMatchMutation.isPending ? (pointMatchMutation.variables?.regionId ?? null) : null}
-          geocodeProgress={geocodeProgress}
-          duplicateUrls={duplicateUrls}
-          syncedUrls={syncedUrls}
-          shadowsByRegionId={shadowsByRegionId}
-          onApproveShadow={onApproveShadow}
-          onRejectShadow={onRejectShadow}
-          skipAnimationRef={skipAnimationRef}
-        />
-      ))}
+
+      {/* Virtualized scroll container */}
+      <Box ref={nav.parentRef} sx={{ flex: 1, overflow: 'auto' }}>
+        <Box sx={{ height: nav.virtualizer.getTotalSize(), position: 'relative' }}>
+          {nav.virtualizer.getVirtualItems().map(virtualRow => {
+            const item = nav.flatItems[virtualRow.index];
+            return (
+              <Box
+                key={virtualRow.key}
+                ref={nav.virtualizer.measureElement}
+                data-index={virtualRow.index}
+                sx={{
+                  position: 'absolute',
+                  top: 0,
+                  left: 0,
+                  width: '100%',
+                  transform: `translateY(${virtualRow.start}px)`,
+                }}
+              >
+                {item.kind === 'node' ? (
+                  <TreeNodeRow
+                    node={item.node}
+                    depth={item.depth}
+                    expanded={nav.expanded}
+                    ancestorIsMatched={item.ancestorIsMatched}
+                    highlightedRegionId={nav.highlightedRegionId}
+                    onToggle={nav.toggleExpand}
+                    onAccept={handleAccept}
+                    onAcceptTransfer={onAcceptTransfer}
+                    onAcceptAndRejectRest={handleAcceptAndRejectRest}
+                    onReject={handleReject}
+                    onDBSearch={handleDBSearch}
+                    onAIMatch={handleAIMatch}
+                    onDismissChildren={handleDismissChildren}
+                    onSync={handleSync}
+                    onHandleAsGrouping={handleHandleAsGrouping}
+                    onGeocodeMatch={handleGeocodeMatch}
+                    onGeoshapeMatch={handleGeoshapeMatch}
+                    onPointMatch={handlePointMatch}
+                    onResetMatch={handleResetMatch}
+                    onRejectRemaining={handleRejectRemaining}
+                    onAcceptAll={handleAcceptAll}
+                    onPreviewUnion={onPreviewUnion}
+                    onPreviewTransfer={onPreviewTransfer}
+                    onAcceptSelected={handleAcceptSelected}
+                    onAcceptSelectedRejectRest={handleAcceptSelectedRejectRest}
+                    onRejectSelected={handleRejectSelected}
+                    onPreview={onPreview}
+                    onOpenMapPicker={handleOpenMapPicker}
+                    onMergeChild={handleMergeChild}
+                    mergingRegionId={pendingIds.mergingRegionId}
+                    onSmartFlatten={dialogs.handleSmartFlatten}
+                    flatteningRegionId={pendingIds.flatteningRegionId}
+                    onDismissHierarchyWarnings={handleDismissHierarchyWarnings}
+                    onAddChild={dialogs.handleAddChild}
+                    onRemoveRegion={dialogs.handleRemoveRegion}
+                    removingRegionId={pendingIds.removingRegionId}
+                    onCollapseToParent={handleCollapseToParent}
+                    collapsingRegionId={pendingIds.collapsingRegionId}
+                    onAutoResolve={handleAutoResolve}
+                    autoResolvingRegionId={pendingIds.autoResolvingRegionId}
+                    onReviewSubtree={handleReviewSubtree}
+                    reviewingRegionId={pendingIds.reviewingRegionId}
+                    onRename={handleRename}
+                    renamingRegionId={renamingRegionId}
+                    onReparent={handleReparent}
+                    reparentingRegionId={reparentingRegionId}
+                    onAISuggestChildren={dialogs.handleAISuggestChildren}
+                    aiSuggestingRegionId={dialogs.aiSuggestingRegionId}
+                    onManualDivisionSearch={dialogs.handleManualDivisionSearch}
+                    onPruneToLeaves={handlePruneToLeaves}
+                    pruningRegionId={pendingIds.pruningRegionId}
+                    onViewMap={onViewMap}
+                    onCVMatch={cvPipeline.handleCVMatch}
+                    cvMatchingRegionId={cvPipeline.cvMatchingRegionId}
+                    onMapshapeMatch={cvPipeline.handleMapshapeMatch}
+                    mapshapeMatchingRegionId={cvPipeline.mapshapeMatchingRegionId}
+                    onClearMembers={handleClearMembers}
+                    clearingMembersRegionId={pendingIds.clearingMembersRegionId}
+                    onSimplifyHierarchy={handleSimplifyHierarchy}
+                    simplifyingRegionId={pendingIds.simplifyingRegionId}
+                    onSimplifyChildren={handleSimplifyChildren}
+                    simplifyingChildrenRegionId={pendingIds.simplifyingChildrenRegionId}
+                    onSmartSimplify={dialogs.handleSmartSimplify}
+                    onCheckOverlap={handleCheckOverlap}
+                    checkingOverlapRegionId={pendingIds.checkingOverlapRegionId}
+                    coverageData={coverageData?.coverage}
+                    coverageLoading={coverageLoading}
+                    coverageDirtyIds={coverageDirtyIds}
+                    onCoverageClick={dialogs.handleCoverageClick}
+                    onContentResize={handleContentResize}
+                    onManualFix={handleManualFix}
+                    isMutating={isMutating}
+                    dbSearchingRegionId={pendingIds.dbSearchingRegionId}
+                    aiMatchingRegionId={pendingIds.aiMatchingRegionId}
+                    dismissingRegionId={pendingIds.dismissingRegionId}
+                    syncingRegionId={pendingIds.syncingRegionId}
+                    groupingRegionId={pendingIds.groupingRegionId}
+                    geocodeMatchingRegionId={pendingIds.geocodeMatchingRegionId}
+                    geoshapeMatchingRegionId={pendingIds.geoshapeMatchingRegionId}
+                    pointMatchingRegionId={pendingIds.pointMatchingRegionId}
+                    parentRegionMapUrl={parentRegionMapUrlById.get(item.node.id)}
+                    parentRegionMapName={parentRegionMapNameById.get(item.node.id)}
+                    geocodeProgress={geocodeProgress}
+                    duplicateUrls={duplicateUrls}
+                    syncedUrls={syncedUrls}
+                    shadowsByRegionId={nav.shadowsByRegionId}
+                    onApproveShadow={onApproveShadow}
+                    onRejectShadow={onRejectShadow}
+                  />
+                ) : (
+                  <ShadowCreateRow
+                    shadow={item.shadow}
+                    depth={item.depth}
+                    onApproveShadow={onApproveShadow}
+                    onRejectShadow={onRejectShadow}
+                    isMutating={isMutating}
+                  />
+                )}
+              </Box>
+            );
+          })}
+        </Box>
+      </Box>
+
+      {/* Dialogs rendered outside the scroll container */}
       {mapPickerState && (
         <MapImagePickerDialog
           open
@@ -787,213 +756,177 @@ export function WorldViewImportTree({ worldViewId, onPreview, onPreviewTransfer,
           </Button>
         }
       />
+      <Snackbar
+        open={simplifySnackbar !== null}
+        autoHideDuration={simplifySnackbar && simplifySnackbar.includes('\n') ? 15000 : 6000}
+        onClose={() => setSimplifySnackbar(null)}
+        message={simplifySnackbar}
+        slotProps={{ content: { sx: { whiteSpace: 'pre-line', maxWidth: 600 } } }}
+      />
       <ManualFixDialog
-        state={fixDialogState}
-        onClose={() => setFixDialogState(null)}
+        state={dialogs.fixDialogState}
+        onClose={() => dialogs.setFixDialogState(null)}
         onSubmit={(regionId, note) => manualFixMutation.mutate({ regionId, needsManualFix: true, fixNote: note })}
         isPending={manualFixMutation.isPending}
       />
-      {smartSimplifyDialog && (
+      <RemoveRegionDialog
+        state={removeDialogState}
+        onClose={() => setRemoveDialogState(null)}
+        onConfirm={(regionId, reparentChildren, reparentDivisions) => removeMutation.mutate({ regionId, reparentChildren, reparentDivisions })}
+        isPending={removeMutation.isPending}
+      />
+      {/* CV color match dialog with SSE progress + suggestions */}
+      <CvMatchDialog
+        cvMatchDialog={cvPipeline.cvMatchDialog}
+        setCVMatchDialog={cvPipeline.setCVMatchDialog}
+        onClose={() => cvPipeline.cancelCvMatch()}
+        highlightClusterId={cvPipeline.highlightClusterId}
+        setHighlightClusterId={cvPipeline.setHighlightClusterId}
+        worldViewId={worldViewId}
+        invalidateTree={invalidateTree}
+        aiModelOverride={cvPipeline.aiModelOverride}
+        setAiModelOverride={cvPipeline.setAiModelOverride}
+        modelPickerOpen={cvPipeline.modelPickerOpen}
+        setModelPickerOpen={cvPipeline.setModelPickerOpen}
+        modelPickerModels={cvPipeline.modelPickerModels}
+        setModelPickerModels={cvPipeline.setModelPickerModels}
+        modelPickerGlobal={cvPipeline.modelPickerGlobal}
+        setModelPickerGlobal={cvPipeline.setModelPickerGlobal}
+        modelPickerSelected={cvPipeline.modelPickerSelected}
+        setModelPickerSelected={cvPipeline.setModelPickerSelected}
+      />
+      <AddChildDialog
+        parentRegionId={dialogs.addChildDialogRegionId}
+        name={dialogs.addChildName}
+        onNameChange={dialogs.setAddChildName}
+        onClose={() => { dialogs.setAddChildDialogRegionId(null); dialogs.setAddChildName(''); }}
+        onSubmit={() => {
+          if (dialogs.addChildDialogRegionId && dialogs.addChildName.trim()) {
+            addChildMutation.mutate({ parentRegionId: dialogs.addChildDialogRegionId, name: dialogs.addChildName.trim() });
+            dialogs.setAddChildDialogRegionId(null);
+            dialogs.setAddChildName('');
+          }
+        }}
+        isPending={addChildMutation.isPending}
+      />
+      <SmartFlattenPreviewDialog
+        open={dialogs.flattenPreview != null}
+        regionName={dialogs.flattenPreview?.regionName ?? ''}
+        geometry={dialogs.flattenPreview?.geometry ?? null}
+        regionMapUrl={dialogs.flattenPreview?.regionMapUrl ?? null}
+        descendants={dialogs.flattenPreview?.descendants ?? 0}
+        divisions={dialogs.flattenPreview?.divisions ?? 0}
+        onConfirm={() => {
+          if (dialogs.flattenPreview) {
+            smartFlattenMutation.mutate(dialogs.flattenPreview.regionId);
+            dialogs.setFlattenPreview(null);
+          }
+        }}
+        onCancel={() => dialogs.setFlattenPreview(null)}
+        confirming={smartFlattenMutation.isPending}
+      />
+      {dialogs.smartSimplifyDialog && (
         <SmartSimplifyDialog
           open
-          onClose={() => setSmartSimplifyDialog(null)}
+          onClose={() => dialogs.setSmartSimplifyDialog(null)}
           worldViewId={worldViewId}
-          parentRegionId={smartSimplifyDialog.regionId}
-          parentRegionName={smartSimplifyDialog.regionName}
-          regionMapUrl={smartSimplifyDialog.regionMapUrl}
-          onApplied={() => invalidateTree()}
+          parentRegionId={dialogs.smartSimplifyDialog.regionId}
+          parentRegionName={dialogs.smartSimplifyDialog.regionName}
+          regionMapUrl={dialogs.smartSimplifyDialog.regionMapUrl}
+          onApplied={() => invalidateTree(dialogs.smartSimplifyDialog?.regionId)}
         />
       )}
-
-      <CvMatchDialog
-        cvMatchDialog={cvMatchDialog}
-        setCVMatchDialog={setCVMatchDialog}
-        onClose={cancelCvMatch}
+      {overlapDialog && (
+        <OverlapResolutionDialog
+          open
+          onClose={() => setOverlapDialog(null)}
+          worldViewId={worldViewId}
+          parentRegionId={overlapDialog.regionId}
+          parentRegionName={overlapDialog.regionName}
+          regionMapUrl={overlapDialog.regionMapUrl}
+          overlapData={overlapDialog.data}
+          onApplied={() => invalidateTree(overlapDialog.regionId)}
+        />
+      )}
+      <AISuggestChildrenDialog
+        state={dialogs.suggestChildrenResult}
+        onClose={() => dialogs.setSuggestChildrenResult(null)}
+        onToggle={(key) => {
+          dialogs.setSuggestChildrenResult(prev => {
+            if (!prev) return prev;
+            const next = new Set(prev.selected);
+            if (next.has(key)) next.delete(key);
+            else next.add(key);
+            return { ...prev, selected: next };
+          });
+        }}
+        onSubmit={handleSuggestChildrenSubmit}
+        isPending={false}
       />
-
-      {/* AI Review Children dialog */}
-      {aiReviewDialog && (
-        <AIReviewChildrenDialog
-          state={aiReviewDialog}
-          onClose={() => setAIReviewDialog(null)}
-          onToggle={(key) => {
-            setAIReviewDialog(prev => {
-              if (!prev) return prev;
-              const next = new Set(prev.selected);
-              if (next.has(key)) next.delete(key);
-              else next.add(key);
-              return { ...prev, selected: next };
-            });
-          }}
-          onSubmit={async () => {
-            if (!aiReviewDialog) return;
-            const { regionId: parentId, result, selected } = aiReviewDialog;
-            setAIReviewDialog(null);
-
-            // Batch all API calls, then invalidate once
-            const promises: Promise<unknown>[] = [];
-            for (const key of selected) {
-              const colonIdx = key.indexOf(':');
-              const type = key.slice(0, colonIdx);
-              const name = key.slice(colonIdx + 1);
-              const action = result.actions.find((a: ReviewChildAction) => a.type === type && a.name === name);
-              if (!action) continue;
-
-              if (action.type === 'add') {
-                promises.push(addChildRegion(
-                  worldViewId, parentId, action.name,
-                  action.sourceUrl ?? undefined, action.sourceExternalId ?? undefined,
-                ));
-              } else if (action.type === 'remove') {
-                const childId = tree ? findChildIdByName(tree, parentId, action.name) : undefined;
-                if (childId) {
-                  // Reparent both children AND assigned GADM divisions up to the parent;
-                  // otherwise CASCADE would silently delete `region_members` rows the admin
-                  // had already accepted.
-                  promises.push(removeRegionFromImport(worldViewId, childId, true, true));
-                }
-              } else if (action.type === 'rename') {
-                const childId = tree ? findChildIdByName(tree, parentId, action.name) : undefined;
-                if (childId) {
-                  promises.push(renameRegion(
-                    worldViewId, childId, action.newName ?? action.name,
-                    action.sourceUrl ?? undefined, action.sourceExternalId ?? undefined,
-                  ));
-                }
-              }
-            }
-
-            const results = await Promise.allSettled(promises);
-            const failures = results.filter(r => r.status === 'rejected');
-            if (failures.length > 0) {
-              for (const f of failures) {
-                console.error('[AI Review Children] action failed:', (f as PromiseRejectedResult).reason);
-              }
-              alert(`AI Review Children: ${failures.length} of ${results.length} action(s) failed. See browser console for details. The tree will refresh to reflect the partial result.`);
-            }
-            invalidateTree();
-          }}
+      <CoverageCompareDialog
+        data={dialogs.coverageCompare}
+        onClose={() => dialogs.setCoverageCompare(null)}
+        onAnalyzeGaps={dialogs.handleAnalyzeGaps}
+      />
+      {dialogs.gapAnalysis && (
+        <GapAnalysisDialog
+          state={dialogs.gapAnalysis}
+          tree={tree}
+          worldViewId={worldViewId}
+          highlightedGapId={dialogs.highlightedGapId}
+          setHighlightedGapId={dialogs.setHighlightedGapId}
+          gapMapSelectedRegionId={dialogs.gapMapSelectedRegionId}
+          setGapMapSelectedRegionId={dialogs.setGapMapSelectedRegionId}
+          onClose={() => { dialogs.setGapAnalysis(null); dialogs.setGapMapSelectedRegionId(null); invalidateTree(); }}
+          setLastMutatedRegionId={setLastMutatedRegionId}
+          acceptAllMutation={acceptAllMutation}
+          addChildMutation={addChildMutation}
+          isMutating={isMutating}
         />
       )}
+      <DivisionSearchDialog
+        state={dialogs.divisionSearchDialog}
+        onClose={() => dialogs.setDivisionSearchDialog(null)}
+        onSelect={(divisionId) => {
+          if (dialogs.divisionSearchDialog) {
+            setLastMutatedRegionId(dialogs.divisionSearchDialog.regionId);
+            acceptAllMutation.mutate([{
+              regionId: dialogs.divisionSearchDialog.regionId,
+              divisionId,
+            }]);
+            dialogs.setDivisionSearchDialog(null);
+          }
+        }}
+        query={dialogs.divSearchQuery}
+        results={dialogs.divSearchResults}
+        loading={dialogs.divSearchLoading}
+        onInputChange={dialogs.handleDivSearchInput}
+      />
+      <RenameRegionDialog
+        state={dialogs.renameDialog}
+        onClose={() => dialogs.setRenameDialog(null)}
+        onSubmit={dialogs.handleRenameSubmit}
+        onNameChange={(value) => dialogs.setRenameDialog(prev => prev ? { ...prev, newName: value } : prev)}
+      />
+      <ReparentRegionDialog
+        state={dialogs.reparentDialog}
+        onClose={() => dialogs.setReparentDialog(null)}
+        onSubmit={dialogs.handleReparentSubmit}
+        onParentChange={(parentId) => dialogs.setReparentDialog(prev => prev ? { ...prev, selectedParentId: parentId } : prev)}
+        flatRegionList={dialogs.flatRegionList}
+      />
+      {/* AI Hierarchy Review Drawer */}
+      <AIReviewDrawer
+        activeReviewKey={dialogs.activeReviewKey}
+        setActiveReviewKey={dialogs.setActiveReviewKey}
+        reviewReports={dialogs.reviewReports}
+        setReviewReports={dialogs.setReviewReports}
+        reviewLoading={dialogs.reviewLoading}
+        handleReview={dialogs.handleReview}
+        regionNameRegex={dialogs.regionNameRegex}
+        regionNameToId={dialogs.regionNameToId}
+        navigateToRegion={nav.navigateToRegion}
+      />
     </Box>
-  );
-}
-
-/** Dialog showing AI-reviewed children actions grouped by type */
-function AIReviewChildrenDialog({ state, onClose, onToggle, onSubmit }: {
-  state: {
-    regionId: number;
-    regionName: string;
-    result: AIReviewChildrenResult;
-    selected: Set<string>;
-  };
-  onClose: () => void;
-  onToggle: (key: string) => void;
-  onSubmit: () => void;
-}) {
-  const addActions = state.result.actions.filter((a: ReviewChildAction) => a.type === 'add');
-  const removeActions = state.result.actions.filter((a: ReviewChildAction) => a.type === 'remove');
-  const renameActions = state.result.actions.filter((a: ReviewChildAction) => a.type === 'rename');
-
-  const renderEnrichment = (action: ReviewChildAction) => {
-    if (action.type === 'remove' || !action.verified) return null;
-    return (
-      <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
-        {action.sourceUrl && (
-          <Typography variant="caption" color="text.secondary">
-            <LinkIcon sx={{ fontSize: 12, mr: 0.25, verticalAlign: 'middle' }} />
-            <MuiLink href={action.sourceUrl} target="_blank" rel="noopener" sx={{ fontSize: 'inherit' }}>
-              {decodeURIComponent(action.sourceUrl.split('/wiki/')[1] ?? '')}
-            </MuiLink>
-          </Typography>
-        )}
-        {action.sourceExternalId && (
-          <Typography variant="caption" color="text.secondary">
-            <MuiLink
-              href={`https://www.wikidata.org/wiki/${action.sourceExternalId}`}
-              target="_blank"
-              rel="noopener"
-              sx={{ fontSize: 'inherit' }}
-            >
-              {action.sourceExternalId}
-            </MuiLink>
-          </Typography>
-        )}
-      </Box>
-    );
-  };
-
-  const renderSection = (
-    title: string,
-    actions: ReviewChildAction[],
-    color: string,
-  ) => {
-    if (actions.length === 0) return null;
-    return (
-      <Box sx={{ mb: 2 }}>
-        <Typography variant="subtitle2" color={color} sx={{ mb: 0.5 }}>
-          {title} ({actions.length})
-        </Typography>
-        {actions.map((a) => {
-          const key = `${a.type}:${a.name}`;
-          return (
-            <Box key={key} sx={{ display: 'flex', alignItems: 'flex-start', gap: 1, py: 0.5 }}>
-              <Checkbox
-                size="small"
-                checked={state.selected.has(key)}
-                onChange={() => onToggle(key)}
-                sx={{ p: 0.25, mt: 0.25 }}
-              />
-              <Box sx={{ flex: 1 }}>
-                <Typography variant="body2">
-                  {a.type === 'rename' ? (
-                    <>{a.name} <ArrowForwardIcon sx={{ fontSize: 14, verticalAlign: 'middle', mx: 0.5 }} /> {a.newName}</>
-                  ) : (
-                    a.name
-                  )}
-                </Typography>
-                <Typography variant="caption" color="text.secondary">{a.reason}</Typography>
-                {renderEnrichment(a)}
-              </Box>
-            </Box>
-          );
-        })}
-      </Box>
-    );
-  };
-
-  return (
-    <Dialog open onClose={onClose} maxWidth="sm" fullWidth>
-      <DialogTitle>Review Children for &quot;{state.regionName}&quot;</DialogTitle>
-      <DialogContent>
-        {state.result.analysis && (
-          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-            {state.result.analysis}
-          </Typography>
-        )}
-        {state.result.actions.length === 0 && (
-          <Typography variant="body2">All children look correct — no changes suggested.</Typography>
-        )}
-        {renderSection('Add', addActions, 'success.main')}
-        {renderSection('Remove', removeActions, 'error.main')}
-        {renderSection('Rename', renameActions, 'warning.main')}
-        {state.result.stats && (
-          <Typography variant="caption" color="text.secondary" sx={{ mt: 2, display: 'block' }}>
-            {(state.result.stats.inputTokens + state.result.stats.outputTokens).toLocaleString()} tokens
-            {' · '}${state.result.stats.cost.toFixed(4)}
-          </Typography>
-        )}
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={onClose}>Cancel</Button>
-        <Button
-          variant="contained"
-          disabled={!state.selected.size}
-          onClick={onSubmit}
-        >
-          Apply {state.selected.size} Selected
-        </Button>
-      </DialogActions>
-    </Dialog>
   );
 }

--- a/frontend/src/components/admin/coverageResolveUtils.ts
+++ b/frontend/src/components/admin/coverageResolveUtils.ts
@@ -1,0 +1,46 @@
+/**
+ * Coverage Resolve Utilities
+ *
+ * Shared types, helper functions, and small sub-components used by
+ * the CoverageResolveDialog and its extracted sub-components.
+ */
+
+import type { SubtreeNode, CoverageGap } from '../../api/admin/worldViewImport';
+
+/** Flattened node for the gap tree -- either a gap root or a subtree descendant */
+export interface TreeNodeInfo {
+  divisionId: number;
+  name: string;
+  isGapRoot: boolean;
+  parentName: string | null;
+  hasChildren: boolean;
+  suggestion: CoverageGap['suggestion'] | null;
+}
+
+/** Find a node in a subtree by division ID */
+export function findSubtreeNode(nodes: SubtreeNode[], id: number): SubtreeNode | null {
+  for (const node of nodes) {
+    if (node.id === id) return node;
+    const found = findSubtreeNode(node.children, id);
+    if (found) return found;
+  }
+  return null;
+}
+
+/** Collect all descendant IDs from a subtree (recursive) */
+export function collectSubtreeIds(nodes: SubtreeNode[], out: Set<number>): void {
+  for (const node of nodes) {
+    out.add(node.id);
+    collectSubtreeIds(node.children, out);
+  }
+}
+
+/** Check if every branch in the subtree is covered (node itself applied, or all its leaves applied) */
+export function allLeavesApplied(nodes: SubtreeNode[], applied: Set<number>): boolean {
+  for (const node of nodes) {
+    if (applied.has(node.id)) continue; // this node is applied -- covers all descendants
+    if (node.children.length === 0) return false; // unapplied leaf
+    if (!allLeavesApplied(node.children, applied)) return false;
+  }
+  return nodes.length > 0;
+}

--- a/frontend/src/components/admin/importTreeLinkify.tsx
+++ b/frontend/src/components/admin/importTreeLinkify.tsx
@@ -4,64 +4,103 @@
  * Walks a React children tree (typically the output of react-markdown), scans
  * every text node for substrings that match the supplied region-name regex,
  * and replaces matches with clickable spans that call back into the tree
- * navigation. Non-text nodes are passed through unchanged.
+ * navigation. Non-text nodes are recursed into, so nested elements
+ * (e.g. <strong> inside <p>) are also processed.
  *
- * Used by the AI Review Drawer (rebuild/30 — AI management layer) so
- * paragraph/list/heading/strong markdown elements can deep-link into the
- * import-review tree without changing the AI's prompt format.
+ * Used by:
+ * - AIReviewDrawer (rebuild/30 — AI management layer): paragraph/list/heading/
+ *   strong markdown elements deep-link into the import-review tree without
+ *   changing the AI's prompt format.
+ * - Overlap resolution and smart flatten preview dialogs (rebuild/33 — CV UI
+ *   sections): region names in dialog copy link into the same tree.
  */
 
-import { Children, type ReactNode } from 'react';
+import { isValidElement, cloneElement, type ReactNode } from 'react';
 
+/** Recursively process React children tree, applying fn to strings and recursing into elements */
+export function flatMapChildren(
+  children: ReactNode,
+  fn: (child: string) => ReactNode | ReactNode[],
+): ReactNode {
+  if (children == null || typeof children === 'boolean') return children;
+  if (typeof children === 'string') return fn(children);
+  if (typeof children === 'number') return fn(String(children));
+  if (isValidElement(children)) {
+    const props = children.props as { children?: ReactNode };
+    if (props.children != null) {
+      return cloneElement(children, undefined, flatMapChildren(props.children, fn));
+    }
+    return children;
+  }
+  if (Array.isArray(children)) {
+    const result: ReactNode[] = [];
+    for (const child of children) {
+      const mapped = flatMapChildren(child, fn);
+      if (Array.isArray(mapped)) result.push(...mapped);
+      else result.push(mapped);
+    }
+    return result;
+  }
+  return children;
+}
+
+/**
+ * Recursively process React children to replace region-name substrings with
+ * clickable links. The regex may be plain (full-match used as the name) or
+ * have a single capture group (group 1 used as the name when present).
+ *
+ * Caveat: when a capture group is used, the captured text must be a contiguous
+ * suffix-or-equal of `match[0]` for the highlighted span to align. We compute
+ * `start` via `match[0].indexOf(match[1])`, which finds the FIRST occurrence —
+ * fine for the current callers that use `\b(name)\b` (no prefix/suffix in
+ * `match[0]`) but unreliable for regexes where the captured text could appear
+ * earlier inside the full match (e.g. `/(test)test/`). Tighten the regex if
+ * adding a new caller that doesn't fit this assumption.
+ */
 export function linkifyRegionNames(
   children: ReactNode,
   regex: RegExp,
   nameToId: Map<string, number>,
   onClick: (regionId: number) => void,
 ): ReactNode {
-  return Children.map(children, (child, idx) => {
-    if (typeof child !== 'string') return child;
-
+  return flatMapChildren(children, (text) => {
     regex.lastIndex = 0;
-    const matches = child.match(regex);
-    if (!matches || matches.length === 0) return child;
-
     const parts: ReactNode[] = [];
-    let cursor = 0;
-    for (let i = 0; i < matches.length; i++) {
-      const match = matches[i];
-      const start = child.indexOf(match, cursor);
-      if (start < 0) continue;
-      if (start > cursor) parts.push(child.slice(cursor, start));
-      const regionId = nameToId.get(match);
-      if (regionId !== undefined) {
-        parts.push(
-          <a
-            key={`rn-${idx}-${start}`}
-            role="button"
-            tabIndex={0}
-            style={{
-              color: 'rgb(21,101,192)',
-              cursor: 'pointer',
-              textDecoration: 'underline',
-            }}
-            onClick={(e) => { e.preventDefault(); onClick(regionId); }}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                onClick(regionId);
-              }
-            }}
-          >
-            {match}
-          </a>,
-        );
-      } else {
-        parts.push(match);
+    let lastIndex = 0;
+    let match: RegExpExecArray | null;
+    // Use a global-flag clone if the supplied regex isn't sticky/global so exec advances.
+    // eslint-disable-next-line security/detect-non-literal-regexp -- regex.source comes from a trusted RegExp passed by the parent component, not user input
+    const r = regex.global || regex.sticky ? regex : new RegExp(regex.source, `${regex.flags}g`);
+    while ((match = r.exec(text)) !== null) {
+      const name = match[1] ?? match[0];
+      const start = match.index + (match[1] != null ? match[0].indexOf(match[1]) : 0);
+      const regionId = nameToId.get(name);
+      if (regionId == null) {
+        // Avoid infinite loop on zero-length match
+        if (match.index === r.lastIndex) r.lastIndex++;
+        continue;
       }
-      cursor = start + match.length;
+      if (start > lastIndex) {
+        parts.push(text.slice(lastIndex, start));
+      }
+      parts.push(
+        <span
+          key={`${regionId}-${start}`}
+          role="button"
+          tabIndex={0}
+          onClick={() => onClick(regionId)}
+          onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick(regionId); } }}
+          style={{ color: '#1976d2', cursor: 'pointer', textDecoration: 'underline dotted', textUnderlineOffset: '2px' }}
+        >
+          {name}
+        </span>,
+      );
+      lastIndex = start + name.length;
+      // Avoid infinite loop on zero-length match
+      if (match.index === r.lastIndex) r.lastIndex++;
     }
-    if (cursor < child.length) parts.push(child.slice(cursor));
-    return parts.length > 0 ? parts : child;
+    if (parts.length === 0) return text;
+    if (lastIndex < text.length) parts.push(text.slice(lastIndex));
+    return parts;
   });
 }

--- a/frontend/src/components/admin/importTreeUtils.ts
+++ b/frontend/src/components/admin/importTreeUtils.ts
@@ -1,4 +1,9 @@
 import type { MatchTreeNode } from '../../api/admin/worldViewImport';
+import type { ShadowInsertion } from './treeNodeShared';
+
+export type FlatTreeItem =
+  | { kind: 'node'; node: MatchTreeNode; depth: number; ancestorIsMatched: boolean }
+  | { kind: 'shadow'; shadow: ShadowInsertion; depth: number };
 
 /**
  * Is a node blocking the Coverage Check?
@@ -49,27 +54,6 @@ export function countDirectChildrenResolved(children: MatchTreeNode[], ancestorH
   return { resolved, total: children.length };
 }
 
-/** Collect IDs of all ancestors on the path to blocking nodes */
-export function collectAncestorsOfUnresolved(nodes: MatchTreeNode[]): Set<number> {
-  const ids = new Set<number>();
-  function walk(node: MatchTreeNode, ancestorHasMembers: boolean): boolean {
-    let hasUnresolved = isUnresolved(node, ancestorHasMembers);
-    // Only direct matches count as ancestor coverage (they have region_members).
-    // children_matched has no direct assignments — its children need their own matching.
-    const nodeIsMatched = node.matchStatus === 'auto_matched' || node.matchStatus === 'manual_matched';
-    const childCovered = ancestorHasMembers || nodeIsMatched || node.memberCount > 0;
-    for (const child of node.children) {
-      if (walk(child, childCovered)) hasUnresolved = true;
-    }
-    if (hasUnresolved && node.children.length > 0) {
-      ids.add(node.id);
-    }
-    return hasUnresolved;
-  }
-  for (const root of nodes) walk(root, false);
-  return ids;
-}
-
 /** Collect IDs of all ancestors on the path to specific target node IDs */
 export function collectAncestorsOfIds(nodes: MatchTreeNode[], targetIds: Set<number>): Set<number> {
   const ids = new Set<number>();
@@ -85,4 +69,75 @@ export function collectAncestorsOfIds(nodes: MatchTreeNode[], targetIds: Set<num
   }
   for (const root of nodes) walk(root);
   return ids;
+}
+
+/** Collect IDs of all leaf-level unresolved nodes */
+export function findUnresolvedNodes(nodes: MatchTreeNode[]): number[] {
+  const result: number[] = [];
+  function walk(node: MatchTreeNode, ancestorHasMembers: boolean): void {
+    if (isUnresolved(node, ancestorHasMembers)) {
+      result.push(node.id);
+    }
+    const nodeIsMatched = node.matchStatus === 'auto_matched' || node.matchStatus === 'manual_matched';
+    const childCovered = ancestorHasMembers || nodeIsMatched || node.memberCount > 0;
+    for (const child of node.children) {
+      walk(child, childCovered);
+    }
+  }
+  for (const root of nodes) walk(root, false);
+  return result;
+}
+
+/** Collect IDs of nodes that have exactly one child (candidates for merge) */
+export function findSingleChildNodes(nodes: MatchTreeNode[]): number[] {
+  const result: number[] = [];
+  function walk(node: MatchTreeNode): void {
+    if (node.children.length === 1) {
+      result.push(node.id);
+    }
+    for (const child of node.children) walk(child);
+  }
+  for (const root of nodes) walk(root);
+  return result;
+}
+
+/** Collect IDs of nodes with unreviewed hierarchy warnings */
+export function findNodesWithWarnings(nodes: MatchTreeNode[]): number[] {
+  const result: number[] = [];
+  function walk(node: MatchTreeNode): void {
+    if (node.hierarchyWarnings.length > 0 && !node.hierarchyReviewed) {
+      result.push(node.id);
+    }
+    for (const child of node.children) walk(child);
+  }
+  for (const root of nodes) walk(root);
+  return result;
+}
+
+/** Flatten tree into visible items respecting expanded state, interleaving shadow insertions */
+export function flattenVisibleTree(
+  nodes: MatchTreeNode[],
+  expanded: Set<number>,
+  shadowsByRegionId: Map<number, ShadowInsertion[]>,
+): FlatTreeItem[] {
+  const result: FlatTreeItem[] = [];
+  function walk(node: MatchTreeNode, depth: number, ancestorIsMatched: boolean): void {
+    result.push({ kind: 'node', node, depth, ancestorIsMatched });
+    if (expanded.has(node.id)) {
+      const nodeIsMatched = node.matchStatus === 'auto_matched' || node.matchStatus === 'manual_matched';
+      const childAncestorMatched = ancestorIsMatched || nodeIsMatched || node.memberCount > 0;
+      for (const child of node.children) {
+        walk(child, depth + 1, childAncestorMatched);
+      }
+      // Append shadow insertions after expanded children
+      const shadows = shadowsByRegionId.get(node.id);
+      if (shadows) {
+        for (const shadow of shadows) {
+          result.push({ kind: 'shadow', shadow, depth: depth + 1 });
+        }
+      }
+    }
+  }
+  for (const root of nodes) walk(root, 0, false);
+  return result;
 }

--- a/frontend/src/components/admin/useCvMatchPipeline.ts
+++ b/frontend/src/components/admin/useCvMatchPipeline.ts
@@ -1,8 +1,8 @@
 /**
  * useCvMatchPipeline — Custom hook for the CV color-match / mapshape-match state machine.
  *
- * Owns all dialog state, SSE event handling, and review response callbacks for
- * the CV match workflow.
+ * Extracted from WorldViewImportTree.tsx. Owns all dialog state, SSE event handling,
+ * and review response callbacks for the CV match workflow.
  */
 
 import { useState, useCallback, useRef } from 'react';
@@ -16,10 +16,9 @@ import {
   type MatchTreeNode,
   type ClusterReviewCluster,
   type ClusterGeoInfo,
-  type SpatialAnomaly,
-  type AdjacencyEdge,
-  type BorderPath,
 } from '../../api/admin/worldViewImport';
+import type { SpatialAnomaly } from '../../api/admin/wvImportTreeOps';
+import type { AdjacencyEdge, BorderPath } from '../../api/admin/wvImportCvMatch';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 

--- a/frontend/src/components/admin/useImportTreeDialogs.ts
+++ b/frontend/src/components/admin/useImportTreeDialogs.ts
@@ -1,0 +1,528 @@
+/**
+ * useImportTreeDialogs — Custom hook for dialog state and handlers in the import tree.
+ *
+ * Extracted from WorldViewImportTree.tsx. Owns all dialog-related useState,
+ * callbacks for opening/submitting dialogs, and computed values used only by dialogs
+ * (flatRegionList, regionNameToId, regionNameRegex).
+ */
+
+import { useState, useCallback, useMemo, useRef } from 'react';
+import {
+  smartFlattenPreview,
+  aiSuggestChildren as apiAISuggestChildren,
+  getCoverageGeometry,
+  analyzeCoverageGaps as apiAnalyzeCoverageGaps,
+  type MatchTreeNode,
+  type AISuggestChildrenResult,
+  type CoverageGapDivision,
+  type SiblingRegionGeometry,
+} from '../../api/admin/worldViewImport';
+import { searchDivisions } from '../../api/divisions';
+import { runHierarchyReview } from '../../api/admin/ai';
+import { type StoredReport } from './AIReviewDrawer';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Recursively find a node by ID in the tree */
+function findNodeById(nodes: MatchTreeNode[], id: number): MatchTreeNode | null {
+  for (const n of nodes) {
+    if (n.id === id) return n;
+    const found = findNodeById(n.children, id);
+    if (found) return found;
+  }
+  return null;
+}
+
+/** Recursively find a node's name by ID */
+function findNameById(nodes: MatchTreeNode[], id: number): string {
+  for (const n of nodes) {
+    if (n.id === id) return n.name;
+    const found = findNameById(n.children, id);
+    if (found) return found;
+  }
+  return '';
+}
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface RenameDialogState {
+  regionId: number;
+  currentName: string;
+  newName: string;
+}
+
+export interface ReparentDialogState {
+  regionId: number;
+  regionName: string;
+  selectedParentId: number | null;
+}
+
+export interface SuggestChildrenState {
+  regionId: number;
+  regionName: string;
+  result: AISuggestChildrenResult;
+  selected: Set<string>;
+}
+
+export interface DivisionSearchDialogState {
+  regionId: number;
+  regionName: string;
+}
+
+export interface CoverageCompareState {
+  regionId: number;
+  regionName: string;
+  worldViewId: number;
+  loading: boolean;
+  parentGeometry: GeoJSON.Geometry | null;
+  childrenGeometry: GeoJSON.Geometry | null;
+  geoshapeGeometry?: GeoJSON.Geometry | null;
+}
+
+export interface GapAnalysisState {
+  regionId: number;
+  regionName: string;
+  loading: boolean;
+  gapDivisions: CoverageGapDivision[];
+  siblingRegions: SiblingRegionGeometry[];
+  regionMapUrl: string | null;
+}
+
+export interface FlattenPreviewState {
+  regionId: number;
+  regionName: string;
+  geometry: GeoJSON.Geometry | null;
+  regionMapUrl: string | null;
+  descendants: number;
+  divisions: number;
+}
+
+export interface SmartSimplifyState {
+  regionId: number;
+  regionName: string;
+  regionMapUrl: string | null;
+}
+
+export interface FlatRegionItem {
+  id: number;
+  name: string;
+  depth: number;
+}
+
+export interface UseImportTreeDialogsResult {
+  // Rename dialog
+  renameDialog: RenameDialogState | null;
+  setRenameDialog: React.Dispatch<React.SetStateAction<RenameDialogState | null>>;
+  handleRenameSubmit: () => void;
+
+  // Reparent dialog
+  reparentDialog: ReparentDialogState | null;
+  setReparentDialog: React.Dispatch<React.SetStateAction<ReparentDialogState | null>>;
+  handleReparentSubmit: () => void;
+
+  // AI suggest children
+  suggestChildrenResult: SuggestChildrenState | null;
+  setSuggestChildrenResult: React.Dispatch<React.SetStateAction<SuggestChildrenState | null>>;
+  aiSuggestingRegionId: number | null;
+  handleAISuggestChildren: (regionId: number) => Promise<void>;
+
+  // Division search
+  divisionSearchDialog: DivisionSearchDialogState | null;
+  setDivisionSearchDialog: React.Dispatch<React.SetStateAction<DivisionSearchDialogState | null>>;
+  divSearchQuery: string;
+  divSearchResults: Awaited<ReturnType<typeof searchDivisions>>;
+  divSearchLoading: boolean;
+  handleManualDivisionSearch: (regionId: number) => void;
+  handleDivSearchInput: (_e: unknown, value: string) => void;
+
+  // Add child
+  addChildDialogRegionId: number | null;
+  setAddChildDialogRegionId: React.Dispatch<React.SetStateAction<number | null>>;
+  addChildName: string;
+  setAddChildName: React.Dispatch<React.SetStateAction<string>>;
+  handleAddChild: (parentRegionId: number) => void;
+
+  // Coverage compare
+  coverageCompare: CoverageCompareState | null;
+  setCoverageCompare: React.Dispatch<React.SetStateAction<CoverageCompareState | null>>;
+  handleCoverageClick: (regionId: number) => void;
+
+  // Gap analysis
+  gapAnalysis: GapAnalysisState | null;
+  setGapAnalysis: React.Dispatch<React.SetStateAction<GapAnalysisState | null>>;
+  highlightedGapId: number | null;
+  setHighlightedGapId: React.Dispatch<React.SetStateAction<number | null>>;
+  gapMapSelectedRegionId: number | null;
+  setGapMapSelectedRegionId: React.Dispatch<React.SetStateAction<number | null>>;
+  handleAnalyzeGaps: (regionId: number) => Promise<void>;
+
+  // Flatten preview
+  flattenPreview: FlattenPreviewState | null;
+  setFlattenPreview: React.Dispatch<React.SetStateAction<FlattenPreviewState | null>>;
+  flattenPreviewLoading: number | null;
+  handleSmartFlatten: (regionId: number) => Promise<void>;
+
+  // Remove region
+  handleRemoveRegion: (regionId: number) => void;
+
+  // Manual fix
+  fixDialogState: { regionId: number; regionName: string } | null;
+  setFixDialogState: React.Dispatch<React.SetStateAction<{ regionId: number; regionName: string } | null>>;
+
+  // Review
+  reviewReports: Map<string, StoredReport>;
+  setReviewReports: React.Dispatch<React.SetStateAction<Map<string, StoredReport>>>;
+  activeReviewKey: string | null;
+  setActiveReviewKey: React.Dispatch<React.SetStateAction<string | null>>;
+  reviewLoading: { key: string; passInfo: string } | null;
+  handleReview: (regionId?: number, forceRegenerate?: boolean) => Promise<void>;
+
+  // Smart simplify
+  smartSimplifyDialog: SmartSimplifyState | null;
+  setSmartSimplifyDialog: React.Dispatch<React.SetStateAction<SmartSimplifyState | null>>;
+  handleSmartSimplify: (regionId: number) => void;
+
+  // Computed values for dialogs
+  flatRegionList: FlatRegionItem[];
+  regionNameToId: Map<string, number>;
+  regionNameRegex: RegExp | null;
+}
+
+interface UseImportTreeDialogsDeps {
+  renameMutation: { mutate: (args: { regionId: number; name: string }, opts?: { onSettled?: () => void }) => void };
+  reparentMutation: { mutate: (args: { regionId: number; newParentId: number | null }, opts?: { onSettled?: () => void }) => void };
+  setRemoveDialogState: React.Dispatch<React.SetStateAction<{
+    regionId: number;
+    regionName: string;
+    hasChildren: boolean;
+    hasDivisions: boolean;
+  } | null>>;
+  setUndoSnackbar: (value: { open: boolean; message: string; worldViewId: number } | null) => void;
+  invalidateTree: () => void;
+}
+
+export function useImportTreeDialogs(
+  worldViewId: number,
+  tree: MatchTreeNode[] | undefined,
+  deps: UseImportTreeDialogsDeps,
+): UseImportTreeDialogsResult {
+  const { renameMutation, reparentMutation, setRemoveDialogState, setUndoSnackbar, invalidateTree } = deps;
+
+  // ── Rename ─────────────────────────────────────────────────────────────────
+  const [renameDialog, setRenameDialog] = useState<RenameDialogState | null>(null);
+
+  const handleRenameSubmit = useCallback(() => {
+    if (!renameDialog || !renameDialog.newName.trim()) return;
+    renameMutation.mutate(
+      { regionId: renameDialog.regionId, name: renameDialog.newName.trim() },
+      { onSettled: () => setRenameDialog(null) },
+    );
+  }, [renameDialog, renameMutation]);
+
+  // ── Reparent ───────────────────────────────────────────────────────────────
+  const [reparentDialog, setReparentDialog] = useState<ReparentDialogState | null>(null);
+
+  const handleReparentSubmit = useCallback(() => {
+    if (!reparentDialog) return;
+    reparentMutation.mutate(
+      { regionId: reparentDialog.regionId, newParentId: reparentDialog.selectedParentId },
+      { onSettled: () => setReparentDialog(null) },
+    );
+  }, [reparentDialog, reparentMutation]);
+
+  // ── AI Suggest Children ────────────────────────────────────────────────────
+  const [suggestChildrenResult, setSuggestChildrenResult] = useState<SuggestChildrenState | null>(null);
+  const [aiSuggestingRegionId, setAISuggestingRegionId] = useState<number | null>(null);
+
+  const handleAISuggestChildren = useCallback(async (regionId: number) => {
+    const regionName = tree ? findNameById(tree, regionId) || 'Region' : 'Region';
+    setAISuggestingRegionId(regionId);
+    try {
+      const result = await apiAISuggestChildren(worldViewId, regionId);
+      // Pre-select add and rename, NOT remove (destructive)
+      const selected = new Set(
+        result.actions
+          .filter(a => a.type !== 'remove')
+          .map(a => `${a.type}:${a.name}`),
+      );
+      setSuggestChildrenResult({ regionId, regionName, result, selected });
+    } catch (err) {
+      console.error('AI review children failed:', err);
+      setUndoSnackbar({
+        open: true,
+        message: `Review children failed: ${err instanceof Error ? err.message : 'Unknown error'}`,
+        worldViewId,
+      });
+    } finally {
+      setAISuggestingRegionId(null);
+    }
+  }, [tree, worldViewId, setUndoSnackbar]);
+
+  // ── Division Search ────────────────────────────────────────────────────────
+  const [divisionSearchDialog, setDivisionSearchDialog] = useState<DivisionSearchDialogState | null>(null);
+  const [divSearchQuery, setDivSearchQuery] = useState('');
+  const [divSearchResults, setDivSearchResults] = useState<Awaited<ReturnType<typeof searchDivisions>>>([]);
+  const [divSearchLoading, setDivSearchLoading] = useState(false);
+
+  const handleManualDivisionSearch = useCallback((regionId: number) => {
+    const regionName = tree ? findNameById(tree, regionId) || 'Region' : 'Region';
+    setDivisionSearchDialog({ regionId, regionName });
+    setDivSearchQuery('');
+    setDivSearchResults([]);
+  }, [tree]);
+
+  const divSearchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Sequence number guards against stale in-flight responses overwriting newer
+  // results — a slow response for "a" arriving after "ab" must not clobber state.
+  const divSearchSeqRef = useRef(0);
+  const handleDivSearchInput = useCallback((_e: unknown, value: string) => {
+    setDivSearchQuery(value);
+    if (divSearchTimerRef.current) clearTimeout(divSearchTimerRef.current);
+    if (value.length < 2) {
+      divSearchSeqRef.current++;
+      setDivSearchResults([]);
+      setDivSearchLoading(false);
+      return;
+    }
+    setDivSearchLoading(true);
+    const mySeq = ++divSearchSeqRef.current;
+    divSearchTimerRef.current = setTimeout(async () => {
+      try {
+        const results = await searchDivisions(value, worldViewId, 30);
+        if (mySeq === divSearchSeqRef.current) setDivSearchResults(results);
+      } catch (err) {
+        console.error('Division search failed:', err);
+      } finally {
+        if (mySeq === divSearchSeqRef.current) setDivSearchLoading(false);
+      }
+    }, 300);
+  }, [worldViewId]);
+
+  // ── Add Child ──────────────────────────────────────────────────────────────
+  const [addChildDialogRegionId, setAddChildDialogRegionId] = useState<number | null>(null);
+  const [addChildName, setAddChildName] = useState('');
+
+  const handleAddChild = useCallback((parentRegionId: number) => {
+    setAddChildDialogRegionId(parentRegionId);
+  }, []);
+
+  // ── Coverage Compare ───────────────────────────────────────────────────────
+  const [coverageCompare, setCoverageCompare] = useState<CoverageCompareState | null>(null);
+
+  const handleCoverageClick = useCallback((regionId: number) => {
+    const name = tree ? findNameById(tree, regionId) || '' : '';
+    setCoverageCompare({ regionId, regionName: name, worldViewId, loading: true, parentGeometry: null, childrenGeometry: null, geoshapeGeometry: null });
+
+    getCoverageGeometry(worldViewId, regionId).then(data => {
+      setCoverageCompare(prev => prev?.regionId === regionId ? { ...prev, loading: false, ...data } : prev);
+    }).catch(() => {
+      setCoverageCompare(prev => prev?.regionId === regionId ? { ...prev, loading: false } : prev);
+    });
+  }, [tree, worldViewId]);
+
+  // ── Gap Analysis ───────────────────────────────────────────────────────────
+  const [gapAnalysis, setGapAnalysis] = useState<GapAnalysisState | null>(null);
+  const [highlightedGapId, setHighlightedGapId] = useState<number | null>(null);
+  const [gapMapSelectedRegionId, setGapMapSelectedRegionId] = useState<number | null>(null);
+
+  const handleAnalyzeGaps = useCallback(async (regionId: number) => {
+    const node = tree ? findNodeById(tree, regionId) : null;
+    const regionName = node?.name ?? 'Region';
+    const regionMapUrl = node?.regionMapUrl ?? null;
+    setGapAnalysis({ regionId, regionName, loading: true, gapDivisions: [], siblingRegions: [], regionMapUrl });
+
+    try {
+      const result = await apiAnalyzeCoverageGaps(worldViewId, regionId);
+      setGapAnalysis({ regionId, regionName, loading: false, gapDivisions: result.gapDivisions, siblingRegions: result.siblingRegions, regionMapUrl });
+    } catch (err) {
+      console.error('Coverage gap analysis failed:', err);
+      setGapAnalysis(prev => prev ? { ...prev, loading: false } : prev);
+    }
+  }, [tree, worldViewId]);
+
+  // ── Flatten Preview ────────────────────────────────────────────────────────
+  const [flattenPreview, setFlattenPreview] = useState<FlattenPreviewState | null>(null);
+  const [flattenPreviewLoading, setFlattenPreviewLoading] = useState<number | null>(null);
+
+  const handleSmartFlatten = useCallback(async (regionId: number) => {
+    const regionName = tree ? findNameById(tree, regionId) || 'Region' : 'Region';
+    setFlattenPreviewLoading(regionId);
+    try {
+      const data = await smartFlattenPreview(worldViewId, regionId);
+      if (data.unmatched) {
+        const names = data.unmatched.map(u => u.name).join(', ');
+        setUndoSnackbar({
+          open: true,
+          message: `Cannot flatten: ${data.unmatched.length} unmatched: ${names}`,
+          worldViewId,
+        });
+        invalidateTree();
+        return;
+      }
+      setFlattenPreview({
+        regionId,
+        regionName,
+        geometry: data.geometry ?? null,
+        regionMapUrl: data.regionMapUrl ?? null,
+        descendants: data.descendants ?? 0,
+        divisions: data.divisions ?? 0,
+      });
+    } catch (err) {
+      console.error('Smart flatten preview failed:', err);
+      setUndoSnackbar({
+        open: true,
+        message: `Preview failed: ${err instanceof Error ? err.message : 'Unknown error'}`,
+        worldViewId,
+      });
+    } finally {
+      setFlattenPreviewLoading(null);
+    }
+  }, [tree, worldViewId, invalidateTree, setUndoSnackbar]);
+
+  // ── Smart Simplify ─────────────────────────────────────────────────────────
+  const [smartSimplifyDialog, setSmartSimplifyDialog] = useState<SmartSimplifyState | null>(null);
+
+  const handleSmartSimplify = useCallback((regionId: number) => {
+    const node = tree ? findNodeById(tree, regionId) : null;
+    if (!node) return;
+    setSmartSimplifyDialog({
+      regionId,
+      regionName: node.name,
+      regionMapUrl: node.regionMapUrl ?? null,
+    });
+  }, [tree]);
+
+  // ── Remove Region ──────────────────────────────────────────────────────────
+  const handleRemoveRegion = useCallback((regionId: number) => {
+    const node = tree ? findNodeById(tree, regionId) : null;
+    if (!node) return;
+    setRemoveDialogState({
+      regionId,
+      regionName: node.name,
+      hasChildren: node.children.length > 0,
+      hasDivisions: node.memberCount > 0,
+    });
+  }, [tree, setRemoveDialogState]);
+
+  // ── Manual Fix ─────────────────────────────────────────────────────────────
+  const [fixDialogState, setFixDialogState] = useState<{ regionId: number; regionName: string } | null>(null);
+
+  // ── AI Review ──────────────────────────────────────────────────────────────
+  const [reviewReports, setReviewReports] = useState<Map<string, StoredReport>>(new Map());
+  const [activeReviewKey, setActiveReviewKey] = useState<string | null>(null);
+  const [reviewLoading, setReviewLoading] = useState<{ key: string; passInfo: string } | null>(null);
+
+  const handleReview = useCallback(async (regionId?: number, forceRegenerate = false) => {
+    const key = regionId != null ? `region-${regionId}` : 'full';
+
+    // If report already exists and not forcing regenerate, just open it
+    if (!forceRegenerate && reviewReports.has(key) && !reviewLoading) {
+      setActiveReviewKey(key);
+      return;
+    }
+
+    const scope = regionId ? 'Subtree review' : 'Full tree';
+    const passInfo = regionId ? 'Analyzing branch...' : 'Pass 1: surveying tree structure...';
+    setActiveReviewKey(key);
+    setReviewLoading({ key, passInfo });
+
+    try {
+      const result = await runHierarchyReview(worldViewId, regionId);
+      const stored: StoredReport = {
+        scope,
+        regionId: regionId ?? null,
+        report: result.report,
+        actions: (result.actions ?? []).map((a, i) => ({ ...a, id: a.id || `action-${i}`, completed: false })),
+        stats: result.stats,
+        generatedAt: new Date().toISOString(),
+      };
+      setReviewReports(prev => new Map(prev).set(key, stored));
+    } catch (err) {
+      const stored: StoredReport = {
+        scope,
+        regionId: regionId ?? null,
+        report: `Error: ${err instanceof Error ? err.message : 'Review failed'}`,
+        actions: [],
+        stats: null,
+        generatedAt: new Date().toISOString(),
+      };
+      setReviewReports(prev => new Map(prev).set(key, stored));
+    } finally {
+      setReviewLoading(null);
+    }
+  }, [worldViewId, reviewReports, reviewLoading]);
+
+  // ── Computed values for dialogs ────────────────────────────────────────────
+
+  // Flat list of all regions for reparent dialog Autocomplete
+  const flatRegionList = useMemo(() => {
+    if (!tree) return [];
+    const list: FlatRegionItem[] = [];
+    function walk(nodes: MatchTreeNode[], depth: number) {
+      for (const node of nodes) {
+        list.push({ id: node.id, name: node.name, depth });
+        if (node.children.length > 0) walk(node.children, depth + 1);
+      }
+    }
+    walk(tree, 0);
+    return list;
+  }, [tree]);
+
+  // Name -> ID map for clickable region names in review text
+  const regionNameToId = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const r of flatRegionList) {
+      // First occurrence wins (higher in tree = more likely intended)
+      if (!map.has(r.name)) map.set(r.name, r.id);
+    }
+    return map;
+  }, [flatRegionList]);
+
+  // Regex matching any region name (longest first to avoid partial matches)
+  const regionNameRegex = useMemo(() => {
+    if (regionNameToId.size === 0) return null;
+    const names = [...regionNameToId.keys()]
+      .filter(n => n.length >= 3) // skip very short names to avoid false positives
+      .sort((a, b) => b.length - a.length); // longest first
+    if (names.length === 0) return null;
+    const escaped = names.map(n => n.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+    // eslint-disable-next-line security/detect-non-literal-regexp -- built from escaped region names, not user input
+    return new RegExp(`\\b(${escaped.join('|')})\\b`, 'g');
+  }, [regionNameToId]);
+
+  return {
+    // Rename
+    renameDialog, setRenameDialog, handleRenameSubmit,
+    // Reparent
+    reparentDialog, setReparentDialog, handleReparentSubmit,
+    // AI suggest children
+    suggestChildrenResult, setSuggestChildrenResult, aiSuggestingRegionId, handleAISuggestChildren,
+    // Division search
+    divisionSearchDialog, setDivisionSearchDialog,
+    divSearchQuery, divSearchResults, divSearchLoading,
+    handleManualDivisionSearch, handleDivSearchInput,
+    // Add child
+    addChildDialogRegionId, setAddChildDialogRegionId, addChildName, setAddChildName, handleAddChild,
+    // Coverage compare
+    coverageCompare, setCoverageCompare, handleCoverageClick,
+    // Gap analysis
+    gapAnalysis, setGapAnalysis,
+    highlightedGapId, setHighlightedGapId,
+    gapMapSelectedRegionId, setGapMapSelectedRegionId,
+    handleAnalyzeGaps,
+    // Flatten preview
+    flattenPreview, setFlattenPreview, flattenPreviewLoading, handleSmartFlatten,
+    // Smart simplify
+    smartSimplifyDialog, setSmartSimplifyDialog, handleSmartSimplify,
+    // Remove region
+    handleRemoveRegion,
+    // Manual fix
+    fixDialogState, setFixDialogState,
+    // Review
+    reviewReports, setReviewReports,
+    activeReviewKey, setActiveReviewKey,
+    reviewLoading, handleReview,
+    // Computed
+    flatRegionList, regionNameToId, regionNameRegex,
+  };
+}

--- a/frontend/src/components/admin/useNavigationState.ts
+++ b/frontend/src/components/admin/useNavigationState.ts
@@ -1,0 +1,331 @@
+/**
+ * useNavigationState — Custom hook for tree navigation and virtualization.
+ *
+ * Extracted from WorldViewImportTree.tsx. Owns the expanded set, scroll management,
+ * category navigation (unresolved/warnings/single-child/incomplete-coverage),
+ * virtualizer setup, and highlight tracking.
+ */
+
+import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
+import { useVirtualizer } from '@tanstack/react-virtual';
+import type { MatchTreeNode, ChildrenCoverageResult } from '../../api/admin/worldViewImport';
+import type { ShadowInsertion } from './treeNodeShared';
+import {
+  collectAncestorsOfIds,
+  findUnresolvedNodes,
+  findSingleChildNodes,
+  findNodesWithWarnings,
+  flattenVisibleTree,
+  type FlatTreeItem,
+} from './importTreeUtils';
+
+export type NavCategory = 'unresolved' | 'warnings' | 'single-child' | 'incomplete-coverage';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyVirtualizer = ReturnType<typeof useVirtualizer<any, any>>;
+
+export interface UseNavigationStateResult {
+  // Expand/collapse
+  expanded: Set<number>;
+  toggleExpand: (id: number) => void;
+  expandAll: () => void;
+  collapseAll: () => void;
+  expandToShadows: () => void;
+
+  // Flat items + virtualizer
+  flatItems: FlatTreeItem[];
+  virtualizer: AnyVirtualizer;
+  parentRef: React.RefObject<HTMLDivElement | null>;
+
+  // Category navigation
+  activeNav: { category: NavCategory; idx: number } | null;
+  setActiveNav: React.Dispatch<React.SetStateAction<{ category: NavCategory; idx: number } | null>>;
+  navIdsMap: Record<NavCategory, number[]>;
+  navigateTo: (category: NavCategory, idx: number) => void;
+
+  // Highlight
+  highlightedRegionId: number | null;
+  navigateToRegion: (regionId: number) => void;
+
+  // Category ID lists (exposed for toolbar badge counts)
+  unresolvedIds: number[];
+  singleChildIds: number[];
+  warningIds: number[];
+  incompleteCoverageIds: number[];
+
+  // Shadow map (pre-computed, shared with TreeNodeRow)
+  shadowsByRegionId: Map<number, ShadowInsertion[]>;
+
+  // Scroll helpers
+  requestScrollTo: (targetId: number) => void;
+}
+
+/** Pick a single-char coverage key for virtualizer index: 'c' (coverage), 'g' (geoshape), or ''. */
+function coverageKeyChar(cov: number | undefined, geoCov: number | undefined): string {
+  if (cov != null) return 'c';
+  if (geoCov != null) return 'g';
+  return '';
+}
+
+export function useNavigationState(
+  tree: MatchTreeNode[] | undefined,
+  shadowInsertions: ShadowInsertion[] | undefined,
+  coverageData: ChildrenCoverageResult | undefined,
+): UseNavigationStateResult {
+  const [expanded, setExpanded] = useState<Set<number>>(new Set());
+  const parentRef = useRef<HTMLDivElement>(null);
+
+  const toggleExpand = useCallback((id: number) => {
+    setExpanded(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const allBranchIds = useMemo(() => {
+    if (!tree) return new Set<number>();
+    const ids = new Set<number>();
+    function walk(nodes: MatchTreeNode[]) {
+      for (const node of nodes) {
+        if (node.children.length > 0) {
+          ids.add(node.id);
+          walk(node.children);
+        }
+      }
+    }
+    walk(tree);
+    return ids;
+  }, [tree]);
+
+  // Compute per-region shadow map
+  const shadowsByRegionId = useMemo(() => {
+    const map = new Map<number, ShadowInsertion[]>();
+    for (const s of shadowInsertions ?? []) {
+      const arr = map.get(s.targetRegionId) ?? [];
+      arr.push(s);
+      map.set(s.targetRegionId, arr);
+    }
+    return map;
+  }, [shadowInsertions]);
+
+  // Flatten tree into visible items for the virtualizer
+  const flatItems = useMemo<FlatTreeItem[]>(() => {
+    if (!tree) return [];
+    return flattenVisibleTree(tree, expanded, shadowsByRegionId);
+  }, [tree, expanded, shadowsByRegionId]);
+
+  // Virtualizer for the flat list
+  const virtualizer = useVirtualizer({
+    count: flatItems.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 40,
+    overscan: 15,
+    getItemKey: (index) => {
+      // eslint-disable-next-line security/detect-object-injection -- index is a typed number from the virtualizer callback
+      const item = flatItems[index];
+      if (item.kind === 'node') {
+        const n = item.node;
+        // Include content-affecting fields so the virtualizer discards stale cached
+        // heights when row content changes (e.g., suggestions removed after accept).
+        // Without this, ResizeObserver intermittently misses height changes, leaving
+        // blank space where removed content used to be.
+        // Include coverage presence so key changes when async coverage data arrives,
+        // forcing the virtualizer to discard its stale cached height and re-measure.
+        const cov = coverageData?.coverage?.[String(n.id)];
+        const geoCov = coverageData?.geoshapeCoverage?.[String(n.id)];
+        const covKey = coverageKeyChar(cov, geoCov);
+        return `${n.id}:${n.matchStatus}:${n.suggestions.length}:${n.assignedDivisions.length}:${n.hierarchyReviewed}:${covKey}`;
+      }
+      return `shadow-${item.shadow.gapDivisionId}`;
+    },
+  });
+
+  /** Pending scroll target — useEffect on flatItems will scroll when the target becomes visible */
+  const pendingScrollRef = useRef<number | null>(null);
+  const flatItemsRef = useRef(flatItems);
+  flatItemsRef.current = flatItems;
+  const virtualizerRef = useRef(virtualizer);
+  virtualizerRef.current = virtualizer;
+
+  /** Request scroll to a node. Scrolls immediately if visible, else defers to useEffect. */
+  const requestScrollTo = useCallback((targetId: number) => {
+    const items = flatItemsRef.current;
+    const index = items.findIndex(item => item.kind === 'node' && item.node.id === targetId);
+    if (index >= 0) {
+      virtualizerRef.current.scrollToIndex(index, { align: 'center' });
+      pendingScrollRef.current = null;
+    } else {
+      pendingScrollRef.current = targetId;
+    }
+  }, []);
+
+  // When flatItems changes (expanded set updated), execute pending scroll
+  useEffect(() => {
+    if (pendingScrollRef.current == null) return;
+    const targetId = pendingScrollRef.current;
+    const index = flatItems.findIndex(item => item.kind === 'node' && item.node.id === targetId);
+    if (index >= 0) {
+      pendingScrollRef.current = null;
+      virtualizer.scrollToIndex(index, { align: 'center' });
+    }
+  }, [flatItems, virtualizer]);
+
+  const expandAll = useCallback(() => {
+    setExpanded(new Set(allBranchIds));
+  }, [allBranchIds]);
+
+  const collapseAll = useCallback(() => {
+    setExpanded(new Set());
+  }, []);
+
+  const expandToShadows = useCallback(() => {
+    if (!tree || !shadowInsertions?.length) return;
+    const targetIds = new Set(shadowInsertions.map(s => s.targetRegionId));
+    const ancestorIds = collectAncestorsOfIds(tree, targetIds);
+    setExpanded(new Set([...ancestorIds, ...targetIds]));
+    requestScrollTo(shadowInsertions[0].targetRegionId);
+  }, [tree, shadowInsertions, requestScrollTo]);
+
+  // Category ID lists for navigation
+  const unresolvedIds = useMemo(() => tree ? findUnresolvedNodes(tree) : [], [tree]);
+  const singleChildIds = useMemo(() => tree ? findSingleChildNodes(tree) : [], [tree]);
+  const warningIds = useMemo(() => tree ? findNodesWithWarnings(tree) : [], [tree]);
+
+  // Regions with children coverage < 99% (only containers with coverage data)
+  const incompleteCoverageIds = useMemo(() => {
+    if (!coverageData?.coverage) return [];
+    const ids: number[] = [];
+    for (const [key, pct] of Object.entries(coverageData.coverage)) {
+      if (pct < 0.99) ids.push(Number(key));
+    }
+    return ids;
+  }, [coverageData?.coverage]);
+
+  // Unified category navigation state
+  const [activeNav, setActiveNav] = useState<{ category: NavCategory; idx: number } | null>(null);
+
+  const navIdsMap: Record<NavCategory, number[]> = useMemo(() => ({
+    unresolved: unresolvedIds,
+    warnings: warningIds,
+    'single-child': singleChildIds,
+    'incomplete-coverage': incompleteCoverageIds,
+  }), [unresolvedIds, warningIds, singleChildIds, incompleteCoverageIds]);
+
+  // Region clicked from review drawer
+  const [reviewHighlightId, setReviewHighlightId] = useState<number | null>(null);
+
+  const highlightedRegionId = activeNav
+    ? navIdsMap[activeNav.category][activeNav.idx] ?? null
+    : reviewHighlightId;
+
+  const navigateTo = useCallback((category: NavCategory, idx: number) => {
+    // eslint-disable-next-line security/detect-object-injection -- category is a typed NavCategory union, navIdsMap is Record<NavCategory, number[]>
+    const ids = navIdsMap[category];
+    if (!tree || idx < 0 || idx >= ids.length) return;
+    setActiveNav({ category, idx });
+    // eslint-disable-next-line security/detect-object-injection -- idx bounds checked above against ids.length
+    const targetId = ids[idx];
+    const ancestorIds = collectAncestorsOfIds(tree, new Set([targetId]));
+    setExpanded(prev => new Set([...prev, ...ancestorIds, targetId]));
+    requestScrollTo(targetId);
+  }, [tree, navIdsMap, requestScrollTo]);
+
+  // When the nav list changes (item dismissed/resolved), clamp index and scroll to new current.
+  // Compare by content length, not reference — optimistic updates create new array refs
+  // with the same content, and reference comparison would trigger spurious scroll cycles.
+  const prevNavLengthRef = useRef<number | null>(null);
+  useEffect(() => {
+    if (!activeNav) {
+      prevNavLengthRef.current = null;
+      return;
+    }
+    const ids = navIdsMap[activeNav.category];
+    const prevLength = prevNavLengthRef.current;
+    prevNavLengthRef.current = ids.length;
+
+    if (ids.length === 0) {
+      setActiveNav(null);
+      return;
+    }
+
+    // List content actually changed (length changed after accept/reject/dismiss)
+    if (prevLength != null && prevLength !== ids.length) {
+      const clampedIdx = Math.min(activeNav.idx, ids.length - 1);
+      if (clampedIdx !== activeNav.idx) {
+        setActiveNav({ category: activeNav.category, idx: clampedIdx });
+      }
+      // Scroll to the (possibly new) item at this index
+      // eslint-disable-next-line security/detect-object-injection -- clampedIdx is derived via Math.min and bounded by ids.length
+      const targetId = ids[clampedIdx];
+      if (tree) {
+        const ancestorIds = collectAncestorsOfIds(tree, new Set([targetId]));
+        setExpanded(prev => new Set([...prev, ...ancestorIds, targetId]));
+        requestScrollTo(targetId);
+      }
+    } else if (activeNav.idx >= ids.length) {
+      setActiveNav({ category: activeNav.category, idx: ids.length - 1 });
+    }
+  }, [activeNav, navIdsMap, tree, requestScrollTo]);
+
+  // Navigate to a specific region by ID (expand ancestors, scroll, highlight)
+  const navigateToRegion = useCallback((regionId: number) => {
+    if (!tree) return;
+    setActiveNav(null);
+    setReviewHighlightId(regionId);
+    const ancestorIds = collectAncestorsOfIds(tree, new Set([regionId]));
+    setExpanded(prev => new Set([...prev, ...ancestorIds, regionId]));
+    requestScrollTo(regionId);
+  }, [tree, requestScrollTo]);
+
+  // Auto-expand tree ancestors when shadow insertions appear
+  const prevShadowCount = useRef(0);
+  useEffect(() => {
+    if (!tree || !shadowInsertions?.length) {
+      prevShadowCount.current = 0;
+      return;
+    }
+    if (prevShadowCount.current === shadowInsertions.length) return;
+    prevShadowCount.current = shadowInsertions.length;
+
+    const targetIds = new Set(shadowInsertions.map(s => s.targetRegionId));
+    const ancestorIds = collectAncestorsOfIds(tree, targetIds);
+    // Also expand the target nodes themselves (for create_region, shadows appear as children)
+    setExpanded(prev => new Set([...prev, ...ancestorIds, ...targetIds]));
+
+    requestScrollTo(shadowInsertions[0].targetRegionId);
+  }, [tree, shadowInsertions, requestScrollTo]);
+
+  return {
+    expanded,
+    toggleExpand,
+    expandAll,
+    collapseAll,
+    expandToShadows,
+
+    flatItems,
+    virtualizer,
+    parentRef,
+
+    activeNav,
+    setActiveNav,
+    navIdsMap,
+    navigateTo,
+
+    highlightedRegionId,
+    navigateToRegion,
+
+    unresolvedIds,
+    singleChildIds,
+    warningIds,
+    incompleteCoverageIds,
+
+    shadowsByRegionId,
+
+    requestScrollTo,
+  };
+}

--- a/frontend/src/components/admin/useTreeMutations.ts
+++ b/frontend/src/components/admin/useTreeMutations.ts
@@ -1,0 +1,748 @@
+/**
+ * WorldView Import Tree — Mutations Hook
+ *
+ * Extracts all useMutation hooks, invalidation logic, and mutation-owned state
+ * from WorldViewImportTree to keep the component focused on rendering.
+ */
+
+import { useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  acceptMatch,
+  acceptBatchMatches,
+  rejectSuggestion,
+  dbSearchOneRegion,
+  aiMatchOneRegion,
+  dismissChildren,
+  pruneToLeaves,
+  smartFlatten,
+  undoLastOperation,
+  syncInstances,
+  handleAsGrouping,
+  geocodeMatchRegion,
+  geoshapeMatchRegion,
+  pointMatchRegion,
+  resetMatchRegion,
+  clearRegionMembers,
+  rejectRemaining,
+  acceptAndRejectRest as acceptAndRejectRestApi,
+  acceptBatchAndRejectRest,
+  acceptWithTransfer,
+  rejectBatchSuggestions,
+  selectMapImage,
+  markManualFix,
+  mergeChildIntoParent,
+  addChildRegion,
+  dismissHierarchyWarnings,
+  removeRegionFromImport,
+  collapseToParent,
+  autoResolveChildren,
+  renameRegion,
+  reparentRegion,
+  getChildrenCoverage,
+  simplifyHierarchy,
+  simplifyChildren,
+  checkDivisionOverlap,
+  type MatchTreeNode,
+  type ChildrenCoverageResult,
+} from '../../api/admin/worldViewImport';
+// ─── Types shared between hook and component ─────────────────────────────────
+
+export interface MapPickerState {
+  regionId: number;
+  regionName: string;
+  candidates: string[];
+  currentSelection: string | null;
+  wikidataId: string | null;
+  pendingPreview?: {
+    divisionId: number;
+    name: string;
+    path?: string;
+    isAssigned: boolean;
+  };
+}
+
+/** Deps the hook needs from the component (all stable refs or setters) */
+export interface TreeMutationDeps {
+  onPreview: (divisionId: number, name: string, path?: string, regionMapUrl?: string, wikidataId?: string, regionId?: number, isAssigned?: boolean, regionMapLabel?: string, regionName?: string) => void;
+  /** Ref to current mapPickerState — needed by selectMapMutation to read pending preview */
+  mapPickerStateRef: React.RefObject<MapPickerState | null>;
+  setMapPickerState: React.Dispatch<React.SetStateAction<MapPickerState | null>>;
+  setRemoveDialogState: React.Dispatch<React.SetStateAction<{ regionId: number; regionName: string; hasChildren: boolean; hasDivisions: boolean } | null>>;
+  /** Called when division assignments change, so parent can mark coverage as stale */
+  onMatchChange?: () => void;
+}
+
+/** Decide new match status after a reject: prefer 'needs_review' if more suggestions exist,
+ * else 'manual_matched' if members remain, else 'no_candidates'. */
+function computeRejectStatus(remainingCount: number, memberCount: number): MatchTreeNode['matchStatus'] {
+  if (remainingCount > 0) return 'needs_review';
+  return memberCount > 0 ? 'manual_matched' : 'no_candidates';
+}
+
+export function useTreeMutations(worldViewId: number, deps: TreeMutationDeps) {
+  const queryClient = useQueryClient();
+
+  // ── Mutation-owned state ─────────────────────────────────────────────────
+  const [geocodeProgress, setGeocodeProgress] = useState<{
+    regionId: number;
+    message: string;
+    nextScope?: { ancestorId: number; ancestorName: string };
+    retryType?: 'geoshape' | 'point';
+  } | null>(null);
+  const [undoSnackbar, setUndoSnackbar] = useState<{
+    open: boolean;
+    message: string;
+    worldViewId: number;
+  } | null>(null);
+
+  // ── Shared invalidation helpers ──────────────────────────────────────────
+  const treeKey = ['admin', 'wvImport', 'matchTree', worldViewId] as const;
+  const coverageKey = ['admin', 'wvImport', 'childrenCoverage', worldViewId] as const;
+
+  /** Merge partial coverage data into the cache */
+  const mergeCoverage = (partial: ChildrenCoverageResult) => {
+    queryClient.setQueryData<ChildrenCoverageResult>(coverageKey, (old) => {
+      if (!old) return partial;
+      return {
+        coverage: { ...old.coverage, ...partial.coverage },
+        geoshapeCoverage: { ...old.geoshapeCoverage, ...partial.geoshapeCoverage },
+      };
+    });
+  };
+
+  /** Fetch coverage for ancestors of regionId, merging results incrementally.
+   * Each ancestor gets its own API call so deep regions update first. */
+  const refreshCoverage = (regionId?: number) => {
+    if (regionId == null) {
+      queryClient.invalidateQueries({ queryKey: coverageKey });
+      return;
+    }
+    // Walk up the cached tree to collect ancestor IDs (deepest first)
+    const treeData = queryClient.getQueryData<MatchTreeNode[]>(treeKey);
+    if (!treeData) {
+      // No tree cached — fall back to single request for all ancestors
+      getChildrenCoverage(worldViewId, regionId).then(mergeCoverage).catch(() => {
+        queryClient.invalidateQueries({ queryKey: coverageKey });
+      });
+      return;
+    }
+    // Build parent map and walk up
+    const parentOf = new Map<number, number | null>();
+    const walkTree = (nodes: MatchTreeNode[], parentId: number | null) => {
+      for (const n of nodes) {
+        parentOf.set(n.id, parentId);
+        walkTree(n.children, n.id);
+      }
+    };
+    walkTree(treeData, null);
+
+    const ancestorIds: number[] = [];
+    let current: number | null = regionId;
+    while (current != null) {
+      ancestorIds.push(current);
+      current = parentOf.get(current) ?? null;
+    }
+
+    // Fire individual requests per ancestor — each returns fast for its own level.
+    // Deepest ancestors are first in the array and their responses arrive sooner.
+    for (const id of ancestorIds) {
+      getChildrenCoverage(worldViewId, undefined, id).then(mergeCoverage).catch(() => {
+        // Individual failure is fine — other ancestors still update
+      });
+    }
+  };
+
+  const invalidateTree = (regionId?: number) => {
+    queryClient.invalidateQueries({ queryKey: ['admin', 'wvImport', 'matchTree', worldViewId] });
+    queryClient.invalidateQueries({ queryKey: ['admin', 'wvImport', 'matchStats', worldViewId] });
+    refreshCoverage(regionId);
+    deps.onMatchChange?.();
+  };
+
+  const invalidateStatsOnly = (regionId?: number) => {
+    queryClient.invalidateQueries({ queryKey: ['admin', 'wvImport', 'matchStats', worldViewId] });
+    refreshCoverage(regionId);
+    deps.onMatchChange?.();
+  };
+
+  /** Optimistically update a single node in the cached tree by regionId.
+   * Preserves object identity for unchanged branches so React.memo can skip re-renders. */
+  function optimisticTreeUpdate(
+    regionId: number,
+    updater: (node: MatchTreeNode) => MatchTreeNode,
+  ): MatchTreeNode[] | undefined {
+    const prev = queryClient.getQueryData<MatchTreeNode[]>(treeKey);
+    if (!prev) return undefined;
+    function walk(nodes: MatchTreeNode[]): MatchTreeNode[] {
+      let changed = false;
+      const result = nodes.map(n => {
+        if (n.id === regionId) { changed = true; return updater(n); }
+        if (n.children.length > 0) {
+          const newChildren = walk(n.children);
+          if (newChildren !== n.children) { changed = true; return { ...n, children: newChildren }; }
+        }
+        return n;
+      });
+      return changed ? result : nodes;
+    }
+    queryClient.setQueryData(treeKey, walk(prev));
+    return prev;
+  }
+
+  // ── Match review mutations (optimistic) ────────────────────────────────
+
+  const acceptMutation = useMutation({
+    mutationFn: ({ regionId, divisionId }: { regionId: number; divisionId: number }) =>
+      acceptMatch(worldViewId, regionId, divisionId),
+    onMutate: ({ regionId, divisionId }) => {
+      const prev = optimisticTreeUpdate(regionId, (node) => {
+        const accepted = node.suggestions.find(s => s.divisionId === divisionId);
+        const remaining = node.suggestions.filter(s => s.divisionId !== divisionId);
+        return {
+          ...node,
+          suggestions: remaining,
+          assignedDivisions: accepted
+            ? [...node.assignedDivisions, { divisionId: accepted.divisionId, name: accepted.name, path: accepted.path, hasCustomGeom: false }]
+            : node.assignedDivisions,
+          memberCount: node.memberCount + 1,
+          matchStatus: remaining.length > 0 ? 'needs_review' : 'manual_matched',
+        };
+      });
+      return { prev };
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.prev) queryClient.setQueryData(treeKey, context.prev);
+    },
+    onSuccess: (_data, { regionId }) => invalidateStatsOnly(regionId),
+  });
+
+  const rejectMutation = useMutation({
+    mutationFn: ({ regionId, divisionId }: { regionId: number; divisionId: number }) =>
+      rejectSuggestion(worldViewId, regionId, divisionId),
+    onMutate: ({ regionId, divisionId }) => {
+      const prev = optimisticTreeUpdate(regionId, (node) => {
+        const remaining = node.suggestions.filter(s => s.divisionId !== divisionId);
+        // Also remove from assignedDivisions (backend deletes from region_members too)
+        const wasAssigned = node.assignedDivisions.some(d => d.divisionId === divisionId);
+        const remainingAssigned = node.assignedDivisions.filter(d => d.divisionId !== divisionId);
+        const newMemberCount = wasAssigned ? node.memberCount - 1 : node.memberCount;
+        const newStatus = computeRejectStatus(remaining.length, newMemberCount);
+        return { ...node, suggestions: remaining, assignedDivisions: remainingAssigned, memberCount: newMemberCount, matchStatus: newStatus };
+      });
+      return { prev };
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.prev) queryClient.setQueryData(treeKey, context.prev);
+    },
+    onSuccess: (_data, { regionId }) => invalidateStatsOnly(regionId),
+  });
+
+  const rejectRemainingMutation = useMutation({
+    mutationFn: (regionId: number) => rejectRemaining(worldViewId, regionId),
+    onMutate: (regionId) => {
+      const prev = optimisticTreeUpdate(regionId, (node) => ({
+        ...node,
+        suggestions: [],
+        matchStatus: node.memberCount > 0 ? 'manual_matched' : 'no_candidates',
+      }));
+      return { prev };
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.prev) queryClient.setQueryData(treeKey, context.prev);
+    },
+    onSuccess: (_data, regionId) => invalidateStatsOnly(regionId),
+  });
+
+  const acceptAndRejectRestMutation = useMutation({
+    mutationFn: ({ regionId, divisionId }: { regionId: number; divisionId: number }) =>
+      acceptAndRejectRestApi(worldViewId, regionId, divisionId),
+    onMutate: ({ regionId, divisionId }) => {
+      const prev = optimisticTreeUpdate(regionId, (node) => {
+        const accepted = node.suggestions.find(s => s.divisionId === divisionId);
+        return {
+          ...node,
+          suggestions: [],
+          assignedDivisions: accepted
+            ? [...node.assignedDivisions, { divisionId: accepted.divisionId, name: accepted.name, path: accepted.path, hasCustomGeom: false }]
+            : node.assignedDivisions,
+          memberCount: node.memberCount + 1,
+          matchStatus: 'manual_matched',
+        };
+      });
+      return { prev };
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.prev) queryClient.setQueryData(treeKey, context.prev);
+    },
+    onSuccess: (_data, { regionId }) => invalidateStatsOnly(regionId),
+  });
+
+  const acceptAllMutation = useMutation({
+    mutationFn: (assignments: Array<{ regionId: number; divisionId: number }>) =>
+      acceptBatchMatches(worldViewId, assignments),
+    onSuccess: (_data, assignments) => invalidateTree(assignments[0]?.regionId),
+  });
+
+  const acceptSelectedMutation = useMutation({
+    mutationFn: ({ regionId, divisionIds }: { regionId: number; divisionIds: number[] }) =>
+      acceptBatchMatches(worldViewId, divisionIds.map(d => ({ regionId, divisionId: d }))),
+    onSuccess: (_data, { regionId }) => invalidateTree(regionId),
+  });
+
+  const acceptSelectedRejectRestMutation = useMutation({
+    mutationFn: ({ regionId, divisionIds }: { regionId: number; divisionIds: number[] }) =>
+      acceptBatchAndRejectRest(worldViewId, regionId, divisionIds),
+    onSuccess: (_data, { regionId }) => invalidateTree(regionId),
+  });
+
+  const rejectSelectedMutation = useMutation({
+    mutationFn: ({ regionId, divisionIds }: { regionId: number; divisionIds: number[] }) =>
+      rejectBatchSuggestions(worldViewId, regionId, divisionIds),
+    onSuccess: (_data, { regionId }) => invalidateTree(regionId),
+  });
+
+  const acceptTransferMutation = useMutation({
+    mutationFn: ({ regionId, divisionIds, donorRegionId, donorDivisionId, transferType }: {
+      regionId: number; divisionIds: number[]; donorRegionId: number; donorDivisionId: number; transferType: 'direct' | 'split';
+    }) => acceptWithTransfer(worldViewId, regionId, divisionIds, donorRegionId, donorDivisionId, transferType),
+    onSuccess: (_data, { regionId }) => {
+      invalidateTree(regionId);
+      deps.onMatchChange?.();
+    },
+  });
+
+  // ── Search mutations ─────────────────────────────────────────────────────
+
+  const dbSearchOneMutation = useMutation({
+    mutationFn: (regionId: number) => dbSearchOneRegion(worldViewId, regionId),
+    onSuccess: (_data, regionId) => invalidateTree(regionId),
+  });
+
+  const aiMatchOneMutation = useMutation({
+    mutationFn: (regionId: number) => aiMatchOneRegion(worldViewId, regionId),
+    onSuccess: (_data, regionId) => invalidateTree(regionId),
+  });
+
+  const geocodeMatchMutation = useMutation({
+    mutationFn: (regionId: number) => geocodeMatchRegion(worldViewId, regionId),
+    onMutate: (regionId) => {
+      setGeocodeProgress({ regionId, message: 'Geocoding via Nominatim...' });
+    },
+    onSuccess: (data, regionId) => {
+      if (data.geocodedName) {
+        const radiusMsg = data.searchRadiusKm
+          ? ` within ${data.searchRadiusKm}km`
+          : ' (exact)';
+        setGeocodeProgress({
+          regionId,
+          message: data.found > 0
+            ? `Found ${data.found} division(s)${radiusMsg}`
+            : `No divisions found — ${data.geocodedName}`,
+        });
+      } else {
+        setGeocodeProgress({ regionId, message: 'Not found in Nominatim' });
+      }
+      invalidateTree(regionId);
+      setTimeout(() => setGeocodeProgress(null), 4000);
+    },
+    onError: () => {
+      setGeocodeProgress(null);
+    },
+  });
+
+  const geoshapeMatchMutation = useMutation({
+    mutationFn: ({ regionId, scopeAncestorId }: { regionId: number; scopeAncestorId?: number }) =>
+      geoshapeMatchRegion(worldViewId, regionId, scopeAncestorId),
+    onMutate: ({ regionId }) => {
+      setGeocodeProgress({ regionId, message: 'Matching by geoshape...' });
+    },
+    onSuccess: (data, { regionId }) => {
+      const coverageMsg = data.totalCoverage != null
+        ? ` (${Math.round(data.totalCoverage * 100)}% coverage)`
+        : '';
+      if (data.found > 0) {
+        setGeocodeProgress({
+          regionId,
+          message: `Covering set: ${data.found} division(s)${coverageMsg}`,
+        });
+        setTimeout(() => setGeocodeProgress(null), 4000);
+      } else if (data.nextScope) {
+        setGeocodeProgress({
+          regionId,
+          message: `No matches in ${data.scopeAncestorName ?? 'current'} scope`,
+          nextScope: data.nextScope,
+          retryType: 'geoshape',
+        });
+        // Do NOT auto-dismiss — user needs to decide
+      } else {
+        setGeocodeProgress({
+          regionId,
+          message: 'No geoshape matches found',
+        });
+        setTimeout(() => setGeocodeProgress(null), 4000);
+      }
+      invalidateTree(regionId);
+    },
+    onError: () => {
+      setGeocodeProgress(null);
+    },
+  });
+
+  const pointMatchMutation = useMutation({
+    mutationFn: ({ regionId, scopeAncestorId }: { regionId: number; scopeAncestorId?: number }) =>
+      pointMatchRegion(worldViewId, regionId, scopeAncestorId),
+    onMutate: ({ regionId }) => {
+      setGeocodeProgress({ regionId, message: 'Matching by markers...' });
+    },
+    onSuccess: (data, { regionId }) => {
+      if (data.found > 0) {
+        setGeocodeProgress({
+          regionId,
+          message: `Found ${data.found} division(s) from markers`,
+        });
+        setTimeout(() => setGeocodeProgress(null), 4000);
+      } else if (data.nextScope) {
+        setGeocodeProgress({
+          regionId,
+          message: `No marker matches in ${data.scopeAncestorName ?? 'current'} scope`,
+          nextScope: data.nextScope,
+          retryType: 'point',
+        });
+      } else {
+        setGeocodeProgress({
+          regionId,
+          message: 'No divisions found from markers',
+        });
+        setTimeout(() => setGeocodeProgress(null), 4000);
+      }
+      invalidateTree(regionId);
+    },
+    onError: () => {
+      setGeocodeProgress(null);
+    },
+  });
+
+  const resetMatchMutation = useMutation({
+    mutationFn: (regionId: number) => resetMatchRegion(worldViewId, regionId),
+    onSuccess: () => invalidateTree(),
+  });
+
+  const clearMembersMutation = useMutation({
+    mutationFn: (regionId: number) => clearRegionMembers(worldViewId, regionId),
+    onMutate: (regionId) => {
+      const prev = optimisticTreeUpdate(regionId, (node) => ({
+        ...node,
+        assignedDivisions: [],
+        memberCount: 0,
+        matchStatus: node.suggestions.length > 0 ? 'needs_review' : 'no_candidates',
+      }));
+      return { prev };
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.prev) queryClient.setQueryData(treeKey, context.prev);
+    },
+    onSuccess: (_data, regionId) => invalidateStatsOnly(regionId),
+  });
+
+  const simplifyHierarchyMutation = useMutation({
+    mutationFn: (regionId: number) => simplifyHierarchy(worldViewId, regionId),
+    onSuccess: (_data, regionId) => invalidateTree(regionId),
+  });
+
+  const simplifyChildrenMutation = useMutation({
+    mutationFn: (parentRegionId: number) => simplifyChildren(worldViewId, parentRegionId),
+    onSuccess: () => invalidateTree(),
+  });
+
+  const overlapCheckMutation = useMutation({
+    mutationFn: (parentRegionId: number) => checkDivisionOverlap(worldViewId, parentRegionId),
+  });
+
+  // ── Hierarchy mutations ──────────────────────────────────────────────────
+
+  const dismissMutation = useMutation({
+    mutationFn: (regionId: number) => dismissChildren(worldViewId, regionId),
+    onSuccess: (data) => {
+      invalidateTree();
+      if (data.undoAvailable) {
+        setUndoSnackbar({
+          open: true,
+          message: `Dismissed ${data.dismissed} descendant(s)`,
+          worldViewId,
+        });
+      }
+    },
+  });
+
+  const pruneMutation = useMutation({
+    mutationFn: (regionId: number) => pruneToLeaves(worldViewId, regionId),
+    onSuccess: (data) => {
+      invalidateTree();
+      if (data.undoAvailable) {
+        setUndoSnackbar({
+          open: true,
+          message: `Pruned ${data.pruned} grandchildren+ (kept direct children as leaves)`,
+          worldViewId,
+        });
+      }
+    },
+  });
+
+  const syncMutation = useMutation({
+    mutationFn: (regionId: number) => syncInstances(worldViewId, regionId),
+    onSuccess: () => invalidateTree(),
+  });
+
+  const groupingMutation = useMutation({
+    mutationFn: (regionId: number) => handleAsGrouping(worldViewId, regionId),
+    onSuccess: (data, regionId) => {
+      invalidateTree(regionId);
+      if (data.undoAvailable) {
+        setUndoSnackbar({
+          open: true,
+          message: `Matched ${data.matched}/${data.total} children`,
+          worldViewId,
+        });
+      }
+    },
+  });
+
+  const mergeMutation = useMutation({
+    mutationFn: (regionId: number) => mergeChildIntoParent(worldViewId, regionId),
+    onSuccess: () => invalidateTree(),
+  });
+
+  const smartFlattenMutation = useMutation({
+    mutationFn: (regionId: number) => smartFlatten(worldViewId, regionId),
+    onSuccess: (data) => {
+      if (data.unmatched) {
+        const names = data.unmatched.map(u => u.name).join(', ');
+        setUndoSnackbar({
+          open: true,
+          message: `Cannot flatten: ${data.unmatched.length} unmatched: ${names}`,
+          worldViewId,
+        });
+        invalidateTree();
+        return;
+      }
+      invalidateTree();
+      if (data.undoAvailable) {
+        setUndoSnackbar({
+          open: true,
+          message: `Absorbed ${data.absorbed} children (${data.divisions} divisions)`,
+          worldViewId,
+        });
+      }
+    },
+  });
+
+  const removeMutation = useMutation({
+    mutationFn: ({ regionId, reparentChildren, reparentDivisions }: { regionId: number; reparentChildren: boolean; reparentDivisions?: boolean }) =>
+      removeRegionFromImport(worldViewId, regionId, reparentChildren, reparentDivisions),
+    onSuccess: () => {
+      deps.setRemoveDialogState(null);
+      invalidateTree();
+    },
+  });
+
+  const collapseToParentMutation = useMutation({
+    mutationFn: (regionId: number) => collapseToParent(worldViewId, regionId),
+    onSuccess: (data) => {
+      invalidateTree();
+      if (data.undoAvailable) {
+        setUndoSnackbar({
+          open: true,
+          message: `Cleared ${data.collapsed} descendant(s), found ${data.parentSuggestions} suggestion(s) for parent`,
+          worldViewId,
+        });
+      }
+    },
+  });
+
+  const autoResolveMutation = useMutation({
+    mutationFn: (regionId: number) => autoResolveChildren(worldViewId, regionId),
+    onSuccess: (data) => {
+      invalidateTree();
+      if (data.undoAvailable) {
+        const parts: string[] = [];
+        if (data.resolved > 0) parts.push(`${data.resolved} auto-matched`);
+        if (data.review > 0) parts.push(`${data.review} to review`);
+        if (data.failed.length > 0) parts.push(`${data.failed.length} unmatched`);
+        setUndoSnackbar({
+          open: true,
+          message: `Auto-resolve: ${parts.join(', ')} (${data.total} total)`,
+          worldViewId,
+        });
+      }
+    },
+  });
+
+  const renameMutation = useMutation({
+    mutationFn: ({ regionId, name, sourceUrl, sourceExternalId }: {
+      regionId: number;
+      name: string;
+      sourceUrl?: string;
+      sourceExternalId?: string;
+    }) =>
+      renameRegion(worldViewId, regionId, name, sourceUrl, sourceExternalId),
+    onSuccess: () => invalidateTree(),
+  });
+
+  const reparentMutation = useMutation({
+    mutationFn: ({ regionId, newParentId }: { regionId: number; newParentId: number | null }) =>
+      reparentRegion(worldViewId, regionId, newParentId),
+    onSuccess: () => invalidateTree(),
+  });
+
+  const undoMutation = useMutation({
+    mutationFn: () => undoLastOperation(worldViewId),
+    onSuccess: () => {
+      setUndoSnackbar(null);
+      invalidateTree();
+    },
+  });
+
+  // ── Map image & manual fix ───────────────────────────────────────────────
+
+  const selectMapMutation = useMutation({
+    mutationFn: ({ regionId, imageUrl }: { regionId: number; imageUrl: string | null }) =>
+      selectMapImage(worldViewId, regionId, imageUrl),
+    onSuccess: (_data, variables) => {
+      const pickerState = deps.mapPickerStateRef.current;
+      const pending = pickerState?.pendingPreview;
+      const wikidataId = pickerState?.wikidataId;
+      const pickerRegionId = pickerState?.regionId;
+      deps.setMapPickerState(null);
+      invalidateTree();
+      if (pending) {
+        deps.onPreview(
+          pending.divisionId,
+          pending.name,
+          pending.path,
+          variables.imageUrl ?? undefined,
+          wikidataId ?? undefined,
+          pickerRegionId,
+          pending.isAssigned,
+        );
+      }
+    },
+  });
+
+  const manualFixMutation = useMutation({
+    mutationFn: ({ regionId, needsManualFix, fixNote }: { regionId: number; needsManualFix: boolean; fixNote?: string }) =>
+      markManualFix(worldViewId, regionId, needsManualFix, fixNote),
+    onSuccess: () => invalidateTree(),
+  });
+
+  // ── Hierarchy mutations (add child, dismiss warnings) ───────────────────
+
+  const addChildMutation = useMutation({
+    mutationFn: ({ parentRegionId, name, sourceUrl, sourceExternalId }: {
+      parentRegionId: number;
+      name: string;
+      sourceUrl?: string;
+      sourceExternalId?: string;
+    }) =>
+      addChildRegion(worldViewId, parentRegionId, name, sourceUrl, sourceExternalId),
+    onSuccess: () => invalidateTree(),
+  });
+
+  const dismissWarningsMutation = useMutation({
+    mutationFn: (regionId: number) => dismissHierarchyWarnings(worldViewId, regionId),
+    onMutate: (regionId) => {
+      const treeKey = ['admin', 'wvImport', 'matchTree', worldViewId] as const;
+      const prev = queryClient.getQueryData<MatchTreeNode[]>(treeKey);
+      if (prev) {
+        function markReviewed(nodes: MatchTreeNode[]): MatchTreeNode[] {
+          return nodes.map(n => {
+            if (n.id === regionId) return { ...n, hierarchyReviewed: true };
+            if (n.children.length > 0) return { ...n, children: markReviewed(n.children) };
+            return n;
+          });
+        }
+        queryClient.setQueryData(treeKey, markReviewed(prev));
+      }
+      return { prev };
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin', 'wvImport', 'matchStats', worldViewId] });
+    },
+    onError: (_err, _regionId, context) => {
+      if (context?.prev) {
+        queryClient.setQueryData(['admin', 'wvImport', 'matchTree', worldViewId], context.prev);
+      }
+    },
+  });
+
+  // ── Aggregate pending state ──────────────────────────────────────────────
+
+  const isMutating =
+    acceptMutation.isPending || rejectMutation.isPending || acceptAndRejectRestMutation.isPending ||
+    dismissMutation.isPending || pruneMutation.isPending || syncMutation.isPending || groupingMutation.isPending ||
+    geocodeMatchMutation.isPending || geoshapeMatchMutation.isPending || pointMatchMutation.isPending || resetMatchMutation.isPending || clearMembersMutation.isPending || rejectRemainingMutation.isPending ||
+    acceptAllMutation.isPending || acceptSelectedMutation.isPending || acceptSelectedRejectRestMutation.isPending || rejectSelectedMutation.isPending || acceptTransferMutation.isPending ||
+    selectMapMutation.isPending || manualFixMutation.isPending ||
+    mergeMutation.isPending || smartFlattenMutation.isPending || addChildMutation.isPending ||
+    dismissWarningsMutation.isPending || removeMutation.isPending || collapseToParentMutation.isPending ||
+    autoResolveMutation.isPending ||
+    renameMutation.isPending || reparentMutation.isPending ||
+    simplifyHierarchyMutation.isPending ||
+    simplifyChildrenMutation.isPending ||
+    overlapCheckMutation.isPending;
+
+  return {
+    // Mutations
+    acceptMutation,
+    rejectMutation,
+    rejectRemainingMutation,
+    acceptAndRejectRestMutation,
+    acceptAllMutation,
+    acceptSelectedMutation,
+    acceptSelectedRejectRestMutation,
+    rejectSelectedMutation,
+    acceptTransferMutation,
+    onAcceptTransfer: (regionId: number, divisionId: number, conflict: { type: 'direct' | 'split'; donorRegionId: number; donorDivisionId: number }) =>
+      acceptTransferMutation.mutate({
+        regionId,
+        divisionIds: [divisionId],
+        donorRegionId: conflict.donorRegionId,
+        donorDivisionId: conflict.donorDivisionId,
+        transferType: conflict.type,
+      }),
+    dbSearchOneMutation,
+    aiMatchOneMutation,
+    geocodeMatchMutation,
+    geoshapeMatchMutation,
+    pointMatchMutation,
+    resetMatchMutation,
+    clearMembersMutation,
+    dismissMutation,
+    pruneMutation,
+    syncMutation,
+    groupingMutation,
+    mergeMutation,
+    smartFlattenMutation,
+    removeMutation,
+    collapseToParentMutation,
+    autoResolveMutation,
+    undoMutation,
+    selectMapMutation,
+    manualFixMutation,
+    addChildMutation,
+    dismissWarningsMutation,
+    renameMutation,
+    reparentMutation,
+    simplifyHierarchyMutation,
+    simplifyChildrenMutation,
+    overlapCheckMutation,
+    renamingRegionId: renameMutation.isPending ? (renameMutation.variables?.regionId ?? null) : null,
+    reparentingRegionId: reparentMutation.isPending ? (reparentMutation.variables?.regionId ?? null) : null,
+    // State
+    geocodeProgress,
+    undoSnackbar,
+    setUndoSnackbar,
+    isMutating,
+    invalidateTree,
+  };
+}


### PR DESCRIPTION
## Description

Combines two original branches (rebuild/33 — CV UI sections, rebuild/34 — tree refactor hooks) into a single PR because the tree-refactor hooks consume API exports + components introduced by the UI sections. Shipping them separately would require either temporary stubs or shipping rebuild/34 in a state that doesn't typecheck.

**8 commits** (after merging the previously-shipped api/admin sub-file split #371):

**rebuild/33 — CV UI sections (5 commits):**

1. \`feat(frontend): CV preview + cluster review + match map sections\` — extracts \`CvGeoPreviewSection\`, \`CvClusterSuggestionsSection\`, \`CvClusterReviewSection\` from the giant \`CvMatchDialog.tsx\`; adds \`CvMatchMap\` overlay
2. \`feat(frontend): coverage gap tree + map preview + gap analysis\` — adds \`GapAnalysis\` component, coverage-gap tree drilldown, geometry preview integration
3. \`feat(frontend): overlap resolution + smart flatten preview dialogs + linkify utils\` — adds \`OverlapResolutionDialog\`, \`SmartFlattenPreviewDialog\`; reconciles \`importTreeLinkify\` to support both plain and capture-group regexes (HEAD's plain-regex API used by \`AIReviewDrawer\` + new capture-group consumers)
4. \`feat(frontend): update CV match dialog, coverage resolve, tree nodes, import review\` — wires up the new sections, adds \`hierarchyWarnings\` / \`hierarchyReviewed\` to \`MatchTreeNode\`, \`hierarchy_warnings_count\` to \`MatchStats\`; extends \`worldViewImport\` sub-files with new tree-mutation / coverage / cv-match API functions
5. \`fix(frontend): update DivisionPreviewDialog with new props (feat parity)\` — adds \`regionMapLabel\` / \`regionName\` props for the new callsites

**rebuild/34 — tree refactor hooks (3 commits):**

6. \`refactor(frontend): extract ImportTreeDialogs + useImportTreeDialogs hook\` — pulls the dialog soup out of \`WorldViewImportTree.tsx\` into a focused hook + component
7. \`refactor(frontend): extract useTreeMutations + useNavigationState hooks\` — extracts the mutation orchestration and the active-region/breadcrumb state into hooks
8. \`refactor(frontend): WorldViewImportTree consumes new hooks (size reduction)\` — final \`WorldViewImportTree.tsx\` consumes all three hooks; large size reduction

## Related Issues

Stacked on PR #371 (api/admin sub-file split). rebuild/36 (component splits — \`CustomSubdivisionDialog\`, \`ExperienceList\` helpers) is unrelated and will ship separately.

## How Was This Tested?

- [x] \`npm run check\` — clean (only pre-existing \`Unused eslint-disable\` warnings)
- [x] \`npm run knip\` — clean (5 ignore-list entries removed since their files are now consumed; \`react-markdown\` removed from ignoreDependencies)
- [x] \`TEST_REPORT_LOCAL=1 npm test\` — 301/301 pass (181 backend + 120 frontend)
- [x] \`npm run security:all\` — Semgrep 0 findings, 0 vulnerabilities
- [ ] Manual e2e against the UI pending (CV match dialog, overlap resolution, smart-flatten preview, gap analysis)

## Checklist

- [x] Pre-commit gates green
- [x] DCO sign-off on every commit
- [x] Atomic commits, no \"address review\" noise
- [x] OWASP ASVS 5.0 Level 2 — frontend changes only; auth flows unchanged

## Additional Comments

This PR is large (~5k LOC) because it has to combine two originally-separate branches. The commit boundary still distinguishes the UI work (commits 1-5) from the refactor (commits 6-8), so the PR is readable commit-by-commit. The reordering rationale is in the description above and in PR #371.