### PR TITLE
Enforce strict linter suppression policy

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -98,6 +98,31 @@ jobs:
             5. **Calibrate severity.** Critical / Major / Minor / Note based
                on blast radius, exploitability, recoverability — NOT on
                visual prominence.
+            6. **Suppression hygiene.** Treat every NEW linter suppression
+               this PR adds (`eslint-disable*`, `@ts-ignore`,
+               `@ts-expect-error`, `nosemgrep`, `# noqa`, `lgtm[rule]`,
+               etc.) as a red flag and verify it against
+               `docs/tech/development-guide.md` § Linter Suppressions:
+                 a. **Mechanical** — must be inline (no file-level or
+                    block-level `/* eslint-disable rule */ ... /* eslint-enable */`),
+                    must name the rule explicitly, and must end with
+                    `-- <reason>` explaining what makes the spot safe.
+                    Any violation of these → flag as Major.
+                 b. **Substantive (the harder question)** — ask whether
+                    the suppression is silencing a real issue the PR
+                    introduced. If the warning could have been fixed by
+                    changing the code (renaming a variable, restructuring
+                    logic, narrowing types, validating input), the fix
+                    belongs in the code — not in a disable comment. Flag
+                    any suppression that looks like "added to make CI
+                    green" rather than "this is genuinely safe and the
+                    linter is wrong here" as Major. Trust the linter's
+                    intent unless the `-- reason` clearly explains why
+                    the rule is wrong in this specific spot.
+                 c. **Pre-existing suppressions** that the PR moves or
+                    edits (without changing intent) are NOT flagged — only
+                    *newly added* suppressions and substantive *changes*
+                    to existing reasons get this treatment.
 
             ## ANALYSIS METHODOLOGY (phases)
 
@@ -130,6 +155,13 @@ jobs:
               concurrent state handling
             - **Refactoring hygiene** — dead code left behind, unused imports,
               redundant guards, leftover commented code
+            - **Suppression hygiene** — new linter suppressions added by this
+              PR (see CRITICAL INSTRUCTION #6). Two failure modes: mechanical
+              (file-level disable, missing `-- reason`, missing rule name) and
+              substantive (suppression masks a real fixable issue rather than
+              a genuine linter false positive). The latter is the more common
+              and more dangerous failure mode — verify each new suppression's
+              reason actually justifies the suppression.
             - **Convention adherence** — code reuse (shared components/utils),
               file-size limits, dev-guide patterns, commit hygiene
 

--- a/backend/src/auth/strategies/apple.ts
+++ b/backend/src/auth/strategies/apple.ts
@@ -42,7 +42,7 @@ export function configureAppleStrategy(): void {
         scope: ['name', 'email'],
         passReqToCallback: true,
       },
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- passport-apple callback signature is untyped (matches @ts-expect-error import at line 2)
       async (req: any, accessToken: string, refreshToken: string, idToken: any, profile: any, done: any) => {
         try {
           // Apple provides user info in the request body on first auth only

--- a/backend/src/controllers/admin/aiHierarchyReviewController.ts
+++ b/backend/src/controllers/admin/aiHierarchyReviewController.ts
@@ -121,7 +121,7 @@ async function queryTree(
 
   // Process from deepest first (rows are ordered depth ASC, so reverse)
   for (let i = rows.length - 1; i >= 0; i--) {
-    // eslint-disable-next-line security/detect-object-injection -- loop-counter index into typed TreeRow[] array
+
     const row = rows[i];
     if (row.child_count === 0) {
       // Leaf node

--- a/backend/src/controllers/admin/wvImportMapshapeController.ts
+++ b/backend/src/controllers/admin/wvImportMapshapeController.ts
@@ -6,10 +6,6 @@
  * color-coded region assignments.
  */
 
-/* eslint-disable security/detect-object-injection -- CV pipeline match controller:
- * bracket accesses index mapshape-result / group / assignment arrays by loop
- * counter or internal integer index. No user-controlled keys in this file. */
-
 import { Response } from 'express';
 import type { AuthenticatedRequest } from '../../middleware/auth.js';
 import { pool } from '../../db/index.js';

--- a/backend/src/controllers/admin/wvImportMatchBorderTrace.ts
+++ b/backend/src/controllers/admin/wvImportMatchBorderTrace.ts
@@ -6,7 +6,7 @@
  * smooth borders that match the "Detected clusters" preview exactly.
  */
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- OpenCV.js (__cv global) has no TypeScript types
 const G = globalThis as unknown as { __cv?: any };
 
 // =============================================================================

--- a/backend/src/controllers/admin/wvImportMatchMeanshift.ts
+++ b/backend/src/controllers/admin/wvImportMatchMeanshift.ts
@@ -94,7 +94,7 @@ function meanShiftPixel(
 }
 
 function meanShiftFilter(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- OpenCV.js (cv / cv.Mat / cv.MatVector / ccStats) has no TypeScript types
   cv: any,
   srcBuf: Buffer,
   width: number,
@@ -277,7 +277,7 @@ function collectWaterEdgeSeeds(
  * from those seeds using RGB distance.
  */
 function floodFillWater(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- OpenCV.js (cv / cv.Mat / cv.MatVector / ccStats) has no TypeScript types
   cv: any,
   buf: Buffer,
   width: number,
@@ -341,7 +341,7 @@ function floodFillWater(
  * this is a second layer for gray "islands" unreachable from corners.
  */
 function detectGrayBackground(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- OpenCV.js (cv / cv.Mat / cv.MatVector / ccStats) has no TypeScript types
   cv: any,
   buf: Buffer,
   width: number,
@@ -488,7 +488,7 @@ function replaceRoadPixels(colorBuf: Buffer, tp: number, TW: number): void {
  * border lines. Returns a 0/1 Uint8Array of the same shape.
  */
 function openGrayMask(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- OpenCV.js (cv / cv.Mat / cv.MatVector / ccStats) has no TypeScript types
   cv: any,
   bgMaskGrayRaw: Uint8Array,
   TW: number,
@@ -696,9 +696,9 @@ function findBorderTouchingCCs(
  * Find the biggest CC label (by area) among labels 1..numCC-1.
  */
 function findMainCC(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- OpenCV.js (cv / cv.Mat / cv.MatVector / ccStats) has no TypeScript types
   cv: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- OpenCV.js (cv / cv.Mat / cv.MatVector / ccStats) has no TypeScript types
   ccStats: any,
   numCC: number,
 ): { mainCC: number; mainSize: number } {
@@ -745,9 +745,9 @@ function shouldKeepCC(
  * Remove pixels belonging to foreign-land CCs from `countryMask` and return count removed.
  */
 function stripForeignCCs(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- OpenCV.js (cv / cv.Mat / cv.MatVector / ccStats) has no TypeScript types
   cv: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- OpenCV.js (cv / cv.Mat / cv.MatVector / ccStats) has no TypeScript types
   ccStats: any,
   ccData: Int32Array,
   countryMask: Uint8Array,
@@ -787,7 +787,7 @@ function stripForeignCCs(
  * (foreign land) while keeping interior CCs and large border CCs. Mutates `countryMask`.
  */
 function removeForeignLand(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- OpenCV.js (cv / cv.Mat / cv.MatVector / ccStats) has no TypeScript types
   cv: any,
   countryMask: Uint8Array,
   TW: number,

--- a/backend/src/controllers/admin/wvImportMatchShared.ts
+++ b/backend/src/controllers/admin/wvImportMatchShared.ts
@@ -287,10 +287,10 @@ interface MatchingDumpParams {
 
 /** Write post-review matching state to `data/matching-dumps/<regionSlug>/` for offline replay.
  * Paths are built from a sanitized region slug under a fixed base — not user-controlled input. */
-/* eslint-disable security/detect-non-literal-fs-filename -- paths are internally constructed from sanitized region slug under fixed base dir, not user-controlled */
 function dumpMatchingState(p: MatchingDumpParams): void {
   const safeName = p.regionName.replace(/[^a-zA-Z0-9_-]/g, '_').toLowerCase();
   const dumpDir = `data/matching-dumps/${safeName}`;
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- dumpDir is fixed prefix + sanitized regionName (alphanumerics/_/- only)
   if (!existsSync(dumpDir)) mkdirSync(dumpDir, { recursive: true });
   const dump = {
     regionId: p.regionId,
@@ -314,14 +314,18 @@ function dumpMatchingState(p: MatchingDumpParams): void {
     externalBorder: p.externalBorder,
     internalBorder: p.internalBorder,
   };
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- path is sanitized dumpDir + literal filename
   writeFileSync(`${dumpDir}/gadm-data.json`, JSON.stringify(dump, null, 2));
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- path is sanitized dumpDir + literal filename
   writeFileSync(`${dumpDir}/pixel-labels.b64`, Buffer.from(p.pixelLabels).toString('base64'));
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- path is sanitized dumpDir + literal filename
   writeFileSync(`${dumpDir}/country-mask.b64`, Buffer.from(p.countryMask).toString('base64'));
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- path is sanitized dumpDir + literal filename
   writeFileSync(`${dumpDir}/icp-mask.b64`, Buffer.from(p.icpMask).toString('base64'));
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- path is sanitized dumpDir + literal filename
   writeFileSync(`${dumpDir}/source.png`, p.mapBuffer);
   console.log(`[DUMP] Post-review matching state saved to ${dumpDir}/`);
 }
-/* eslint-enable security/detect-non-literal-fs-filename */
 
 // =============================================================================
 // Python matching path

--- a/backend/src/middleware/errorHandler.ts
+++ b/backend/src/middleware/errorHandler.ts
@@ -61,7 +61,7 @@ export function errorHandler(
 }
 
 // Validation middleware factory
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- generic ZodSchema<any> wrapper; per-route schemas are concrete and type-safe
 export function validate(schema: ZodSchema<any>, source: 'body' | 'query' | 'params' = 'body') {
   return (req: Request, _res: Response, next: NextFunction): void => {
     const data = req[source];

--- a/backend/src/services/ai/chatCompletion.ts
+++ b/backend/src/services/ai/chatCompletion.ts
@@ -39,7 +39,7 @@ function stripKnownUnsupportedParams(
   if (!known || known.size === 0) return params;
   const cleaned = { ...params };
   for (const p of known) {
-    // eslint-disable-next-line security/detect-object-injection -- p is an OpenAI param name from the internal unsupportedParams registry, not user input
+
     delete (cleaned as unknown as Record<string, unknown>)[p];
   }
   return cleaned;
@@ -88,7 +88,7 @@ async function retryWithoutParam(
   console.log(`[AI] Model "${model}" does not support "${badParam}" — retrying without it`);
 
   const retryParams = { ...cleanParams };
-  // eslint-disable-next-line security/detect-object-injection -- badParam is the specific OpenAI param name that caused the 400, extracted from the API error response
+
   delete (retryParams as unknown as Record<string, unknown>)[badParam];
   const t1 = performance.now();
   const result = await client.chat.completions.create(retryParams);

--- a/backend/src/services/ai/openaiShared.ts
+++ b/backend/src/services/ai/openaiShared.ts
@@ -275,7 +275,7 @@ async function callResponsesAPIWithWebSearch(
 ): Promise<RawModelResult> {
   try {
     console.log(`   🌐 Using web search model: ${webSearchModel}`);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- OpenAI SDK at this version doesn't expose typed `responses.create` (web_search_preview tool path)
     const response = await (openai as any).responses.create({
       model: webSearchModel,
       tools: [{ type: 'web_search_preview' }],

--- a/backend/src/services/ai/pricingService.ts
+++ b/backend/src/services/ai/pricingService.ts
@@ -37,7 +37,7 @@ export function loadPricing(): void {
 
     // Skip header
     for (let i = 1; i < lines.length; i++) {
-      // eslint-disable-next-line security/detect-object-injection -- loop-counter index into string[] (CSV lines)
+
       const line = lines[i].trim();
       if (!line) continue;
 

--- a/backend/src/services/sync/imageService.ts
+++ b/backend/src/services/sync/imageService.ts
@@ -5,8 +5,6 @@
  * Images are stored in /data/images/experiences/{source}/{external_id}.jpg
  */
 
-/* eslint-disable security/detect-non-literal-fs-filename -- All paths are built from sanitized source names and external IDs, not user input */
-
 import { existsSync } from 'fs';
 import { join } from 'path';
 
@@ -37,5 +35,6 @@ export function getImageUrl(sourceName: string, externalId: string): string {
  */
 export function imageExists(sourceName: string, externalId: string): boolean {
   const filePath = getImagePath(sourceName, externalId);
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- filePath is built from sanitized sourceName/externalId joined under fixed IMAGES_BASE_DIR
   return existsSync(filePath);
 }

--- a/backend/src/services/wikivoyageExtract/__tests__/treeBuilder.test.ts
+++ b/backend/src/services/wikivoyageExtract/__tests__/treeBuilder.test.ts
@@ -10,7 +10,7 @@ function createMockFetcher(responses: Record<string, Record<string, unknown>>) {
   return {
     apiGet: vi.fn(async (params: Record<string, string | number>) => {
       const key = JSON.stringify(params, Object.keys(params).sort());
-      // eslint-disable-next-line security/detect-object-injection -- test fixture: key is a JSON-stringified params object, lookup is read-only
+
       return responses[key] ?? { error: { code: 'not_found' } };
     }),
     save: vi.fn(),

--- a/backend/src/services/wikivoyageExtract/aiInterviewer.ts
+++ b/backend/src/services/wikivoyageExtract/aiInterviewer.ts
@@ -111,7 +111,7 @@ function buildRegionSummary(regions: RegionPreview[]): string {
       if (r.children.length > 0) {
         // Annotate children with page existence
         const childParts = r.children.map(c => {
-          // eslint-disable-next-line security/detect-object-injection -- c is a child name iterated from r.children (same object's own structure); read-only lookup into sibling childPageExists map
+
           const exists = r.childPageExists?.[c];
           if (exists === false) return `${c} [no page]`;
           return c;

--- a/backend/src/services/wikivoyageExtract/cache.ts
+++ b/backend/src/services/wikivoyageExtract/cache.ts
@@ -6,7 +6,6 @@
  * Auto-saves every 200 writes.
  */
 
-/* eslint-disable security/detect-non-literal-fs-filename -- paths are internally constructed, not user-controlled */
 import fs from 'fs';
 import path from 'path';
 import type { CacheStore } from './types.js';
@@ -25,7 +24,9 @@ export class FileCache {
   /** Load cache from disk */
   private load(): void {
     try {
+      // eslint-disable-next-line security/detect-non-literal-fs-filename -- this.filePath is set by the caller (internal services), not by user input
       if (fs.existsSync(this.filePath)) {
+        // eslint-disable-next-line security/detect-non-literal-fs-filename -- this.filePath is set by the caller (internal services), not by user input
         const data = fs.readFileSync(this.filePath, 'utf-8');
         this.store = JSON.parse(data) as CacheStore;
         console.log(`[WV Cache] Loaded ${Object.keys(this.store).length} cached responses from ${this.filePath}`);
@@ -66,11 +67,15 @@ export class FileCache {
     if (!this.dirty) return;
     try {
       const dir = path.dirname(this.filePath);
+      // eslint-disable-next-line security/detect-non-literal-fs-filename -- dir derived from internal this.filePath, not user input
       if (!fs.existsSync(dir)) {
+        // eslint-disable-next-line security/detect-non-literal-fs-filename -- dir derived from internal this.filePath, not user input
         fs.mkdirSync(dir, { recursive: true });
       }
       const tmpPath = path.join(dir, `.wv-cache-${Date.now()}-${Math.random().toString(36).slice(2)}.tmp`);
+      // eslint-disable-next-line security/detect-non-literal-fs-filename -- tmpPath built from internal dir + literal prefix + Date.now()/Math.random
       fs.writeFileSync(tmpPath, JSON.stringify(this.store, null, 0));
+      // eslint-disable-next-line security/detect-non-literal-fs-filename -- both paths are internal (tmpPath built locally, this.filePath set by caller)
       fs.renameSync(tmpPath, this.filePath);
       this.dirty = false;
     } catch (err) {

--- a/backend/src/services/wikivoyageExtract/decisionSummary.ts
+++ b/backend/src/services/wikivoyageExtract/decisionSummary.ts
@@ -63,7 +63,7 @@ export function formatDecisionSummary(decisions: DecisionEntry[], totalPagesProc
 
     const uniqueDecisions = [...new Set(entries.map(e => e.decision))].join('/');
     lines.push(`${maker} → ${uniqueDecisions} (${entries.length}):`);
-    // eslint-disable-next-line security/detect-object-injection -- maker is a typed DecisionMaker union ('coverage_gate'|'country_depth'|...); MAKER_LABELS is a module-level const
+
     lines.push(`  ${MAKER_LABELS[maker]}`);
 
     // Show detail per page for coverage_gate and country_depth (stats matter)

--- a/backend/src/services/wikivoyageExtract/index.ts
+++ b/backend/src/services/wikivoyageExtract/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable security/detect-non-literal-fs-filename -- cache dir paths are validated (no user input) */
 /**
  * Wikivoyage Extraction Service
  *
@@ -40,10 +39,13 @@ export interface CacheEntry {
 /** List all cache files with metadata */
 export function listCaches(): CacheEntry[] {
   try {
+
     if (!existsSync(CACHE_DIR)) return [];
+
     return readdirSync(CACHE_DIR)
       .filter(f => f.startsWith('wikivoyage-cache') && f.endsWith('.json'))
       .map(f => {
+        // eslint-disable-next-line security/detect-non-literal-fs-filename -- f comes from readdirSync of CACHE_DIR; joined with the same constant dir
         const stats = statSync(path.join(CACHE_DIR, f));
         return { name: f, sizeBytes: stats.size, modifiedAt: stats.mtime.toISOString() };
       })
@@ -72,7 +74,9 @@ export function deleteCache(name: string): boolean {
   const filePath = safeCachePath(name);
   if (filePath === null) return false;
   try {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- filePath validated by safeCachePath: must match wikivoyage-cache*.json under CACHE_DIR
     if (existsSync(filePath)) {
+      // eslint-disable-next-line security/detect-non-literal-fs-filename -- filePath validated by safeCachePath
       unlinkSync(filePath);
       return true;
     }
@@ -83,12 +87,15 @@ export function deleteCache(name: string): boolean {
 /** Snapshot the current cache with a timestamped name */
 function snapshotCache(): void {
   try {
+
     if (!existsSync(DEFAULT_CACHE_PATH)) return;
     const now = new Date();
     const ts = now.toISOString().replace(/[:.]/g, '-').slice(0, 16); // 2026-02-26T15-30
     const snapshotName = `wikivoyage-cache-${ts}.json`;
     const snapshotPath = path.join(CACHE_DIR, snapshotName);
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- snapshotPath built from CACHE_DIR + literal prefix + ISO timestamp
     if (!existsSync(snapshotPath)) {
+
       copyFileSync(DEFAULT_CACHE_PATH, snapshotPath);
       console.log(`[WV Cache] Snapshot saved: ${snapshotName}`);
     }
@@ -116,7 +123,9 @@ export function startExtraction(config: Partial<ExtractionConfig> & { cacheFile?
   if (config.cacheFile === 'none') {
     // Clean fetch: delete default cache
     try {
+      // eslint-disable-next-line security/detect-non-literal-fs-filename -- cachePath defaults to DEFAULT_CACHE_PATH constant; if overridden, comes from internal config, not user input
       if (existsSync(cachePath)) {
+        // eslint-disable-next-line security/detect-non-literal-fs-filename -- same as above
         unlinkSync(cachePath);
         console.log(`[WV Extract] Deleted cache at ${cachePath} (clean fetch)`);
       }
@@ -128,9 +137,11 @@ export function startExtraction(config: Partial<ExtractionConfig> & { cacheFile?
     // silent fallback would run extraction against the wrong cache while
     // reporting a successful start to the admin.
     const sourcePath = safeCachePath(config.cacheFile);
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- sourcePath validated by safeCachePath (matches wikivoyage-cache*.json under CACHE_DIR)
     if (sourcePath === null || !existsSync(sourcePath)) {
       throw new Error(`Cache snapshot not found or invalid: ${config.cacheFile}`);
     }
+
     copyFileSync(sourcePath, cachePath);
     console.log(`[WV Extract] Loaded cache from snapshot: ${config.cacheFile}`);
   }

--- a/backend/src/services/wikivoyageExtract/parser.ts
+++ b/backend/src/services/wikivoyageExtract/parser.ts
@@ -6,7 +6,6 @@
  * re.findall → matchAll().
  */
 
-/* eslint-disable security/detect-non-literal-regexp, security/detect-unsafe-regex -- patterns built from static keyword arrays, not user input */
 import type { WikiSection, RegionEntry, MapshapeEntry } from './types.js';
 
 const COMMONS_FILE_URL = 'https://commons.wikimedia.org/wiki/Special:FilePath/';
@@ -32,12 +31,14 @@ const WIKILINK_DISPLAY_MAX = 500;
  * Matches [[Target]] or [[Target|Display]], capturing Target in group 1.
  * Bounded repetition prevents pathological backtracking on malformed input.
  */
+
 const WIKILINK_RE_GLOBAL = new RegExp(
   `\\[\\[([^|\\]]{1,${WIKILINK_TARGET_MAX}})(?:\\|[^\\]]{0,${WIKILINK_DISPLAY_MAX}})?\\]\\]`,
   'g',
 );
 
 /** Single-match version of {@link WIKILINK_RE_GLOBAL}. */
+
 const WIKILINK_RE_SINGLE = new RegExp(
   `\\[\\[([^|\\]]{1,${WIKILINK_TARGET_MAX}})(?:\\|[^\\]]{0,${WIKILINK_DISPLAY_MAX}})?\\]\\]`,
 );
@@ -88,6 +89,7 @@ export function stripHtmlComments(text: string): string {
 const HARD_SKIP = [
   'locator', 'flag', 'coat', 'seal', 'emblem', 'logo', 'icon', 'banner',
 ];
+// eslint-disable-next-line security/detect-non-literal-regexp -- alternation built from module-level HARD_SKIP keyword array, escaped via escapeRegex
 const hardSkipRe = new RegExp(`\\b(?:${HARD_SKIP.map(escapeRegex).join('|')})\\b`);
 
 /** Soft-skip patterns — blocks weak keyword matches */
@@ -102,6 +104,7 @@ const SKIP_WORDS = [
   'harbour', 'tower', 'palace', 'cathedral', 'basilica',
   'monastery', 'fortress', 'lighthouse',
 ];
+// eslint-disable-next-line security/detect-non-literal-regexp -- alternation built from module-level SKIP_WORDS keyword array, escaped via escapeRegex
 const skipRe = new RegExp(`\\b(?:${SKIP_WORDS.map(escapeRegex).join('|')})\\b`);
 
 /** Strong map keywords — substring match */
@@ -116,6 +119,7 @@ const WEAK_MAP_KEYWORDS = [
   'comarca', 'comarcas', 'departement', 'departements',
   'department', 'departments',
 ];
+// eslint-disable-next-line security/detect-non-literal-regexp -- alternation built from module-level WEAK_MAP_KEYWORDS array, escaped via escapeRegex
 const weakRe = new RegExp(`\\b(?:${WEAK_MAP_KEYWORDS.map(escapeRegex).join('|')})\\b`);
 
 function escapeRegex(s: string): string {
@@ -216,6 +220,7 @@ export function extractImageCandidates(wikitext: string, maxCandidates = 15): st
   const imgHardSkip = [
     'flag', 'coat', 'seal', 'emblem', 'logo', 'icon', 'banner', 'wikivoyage',
   ];
+  // eslint-disable-next-line security/detect-non-literal-regexp -- alternation built from local imgHardSkip literal array, escaped via escapeRegex
   const imgHardSkipRe = new RegExp(`\\b(?:${imgHardSkip.map(escapeRegex).join('|')})\\b`);
 
   const mapKeywords = [
@@ -226,6 +231,7 @@ export function extractImageCandidates(wikitext: string, maxCandidates = 15): st
     'oblast', 'oblasts', 'department', 'departments',
     'administrative', 'division', 'divisions',
   ];
+  // eslint-disable-next-line security/detect-non-literal-regexp -- alternation built from local mapKeywords literal array, escaped via escapeRegex
   const mapKwRe = new RegExp(`\\b(?:${mapKeywords.map(escapeRegex).join('|')})\\b`);
 
   const seen = new Set<string>();
@@ -267,11 +273,11 @@ const STD_COLORS: Record<string, string> = {
 function findBalancedMapshapeEnd(text: string, startIdx: number): number {
   let depth = 0;
   for (let i = startIdx; i < text.length - 1; i++) {
-    // eslint-disable-next-line security/detect-object-injection -- loop-counter string index scan
+
     if (text[i] === '{' && text[i + 1] === '{') {
       depth++;
       i++;
-    // eslint-disable-next-line security/detect-object-injection -- loop-counter string index scan
+
     } else if (text[i] === '}' && text[i + 1] === '}') {
       depth--;
       if (depth === 0) return i;
@@ -303,6 +309,7 @@ function extractMapshapeTitle(resolved: string): string {
   return raw
     .trim()
     .replace(
+      // eslint-disable-next-line security/detect-unsafe-regex -- bounded character classes ({1,500} and {0,500}) with non-overlapping anchors; no nested quantifiers
       /\[\[([^\]|]{1,500})(?:\|[^\]]{0,500})?\]\]/g,
       '$1',
     );
@@ -457,11 +464,12 @@ function buildRegionItemsLookup(cleanText: string): Map<string, string[]> {
  */
 function stripParentheticalAnnotations(nameText: string): string {
   // Matches `(` + one-or-more wikilinks (each followed by optional ", " or whitespace) + `)`.
-  const closed =
-    /\s{0,5}\((?:\[\[[^\]]{0,500}\]\](?:[,\s]{1,10})?){1,10}\)/g;
-  // Matches a trailing unclosed `(` + wikilink run (no closing `)`).
-  const unclosed =
-    /\s{0,5}\((?:\[\[[^\]]{0,500}\]\](?:[,\s]{1,10})?){1,10}$/;
+  // All repetitions bounded ({0,5}, {0,500}, {1,10}, outer {1,10}); ']]' literal grounds inner backtracking.
+  // eslint-disable-next-line security/detect-unsafe-regex -- bounded as documented above
+  const closed = /\s{0,5}\((?:\[\[[^\]]{0,500}\]\](?:[,\s]{1,10})?){1,10}\)/g;
+  // Matches a trailing unclosed `(` + wikilink run (no closing `)`). Same bounded structure as `closed`.
+  // eslint-disable-next-line security/detect-unsafe-regex -- bounded as documented above
+  const unclosed = /\s{0,5}\((?:\[\[[^\]]{0,500}\]\](?:[,\s]{1,10})?){1,10}$/;
   return nameText.replace(closed, '').replace(unclosed, '');
 }
 
@@ -550,8 +558,9 @@ export function parseRegionlist(wikitext: string): {
   //   - one or more [[wikilinks]] optionally interleaved with plain text, OR
   //   - a single non-delimited run of plain text up to the next pipe/brace/newline.
   // Both the wikilink body and the plain-text interleave are capped.
-  const namePattern =
-    /region(\d{1,4})name\s*=\s*(\[\[[^\]]{0,500}\]\](?:[^|\n}]{0,200}\[\[[^\]]{0,500}\]\]){0,10}|[^|\n}]{1,500})/g;
+  // All repetitions bounded ({1,4}, {0,500}, {0,200}, {0,10}, {1,500}); literal anchors (`region`, `name=`, `]]`) prevent overlapping matches.
+  // eslint-disable-next-line security/detect-unsafe-regex -- bounded as documented above
+  const namePattern = /region(\d{1,4})name\s*=\s*(\[\[[^\]]{0,500}\]\](?:[^|\n}]{0,200}\[\[[^\]]{0,500}\]\]){0,10}|[^|\n}]{1,500})/g;
 
   const regions: RegionEntry[] = [];
   for (const m of cleanText.matchAll(namePattern)) {

--- a/backend/src/services/worldViewImport/aiMatcher.ts
+++ b/backend/src/services/worldViewImport/aiMatcher.ts
@@ -76,7 +76,7 @@ function extractFencedJson(content: string): string {
   if (first < 0) return content;
   let start = first + FENCE.length;
   if (content.startsWith('json', start)) start += 'json'.length;
-  // eslint-disable-next-line security/detect-object-injection -- numeric string-index scan to skip whitespace
+
   while (start < content.length && /\s/.test(content[start])) start++;
   const end = content.indexOf(FENCE, start);
   if (end < 0) return content;

--- a/backend/src/services/worldViewImport/geoshapeCoverage.ts
+++ b/backend/src/services/worldViewImport/geoshapeCoverage.ts
@@ -369,7 +369,7 @@ function findNextScopeAfter(
   startIndex: number,
 ): { ancestorId: number; ancestorName: string } | undefined {
   for (let i = startIndex; i < ancestors.length; i++) {
-    // eslint-disable-next-line security/detect-object-injection -- loop-counter index into typed AncestorRow[]
+
     const row = ancestors[i];
     if (rowHasDivisions(row)) {
       return { ancestorId: row.id, ancestorName: row.name };
@@ -386,7 +386,7 @@ function resolveScopeFromRequestedAncestor(
   const idx = ancestors.findIndex(a => a.id === scopeAncestorId);
   if (idx < 0) return { scopeDivisionIds: [] };
 
-  // eslint-disable-next-line security/detect-object-injection -- idx is from findIndex on the same typed AncestorRow[]
+
   const row = ancestors[idx];
   if (!rowHasDivisions(row)) {
     return { scopeDivisionIds: [] };
@@ -404,7 +404,7 @@ function resolveScopeFromNearestAncestor(ancestors: AncestorRow[]): ScopeInfo {
   const idx = ancestors.findIndex(rowHasDivisions);
   if (idx < 0) return { scopeDivisionIds: [] };
 
-  // eslint-disable-next-line security/detect-object-injection -- idx is from findIndex on the same typed AncestorRow[]
+
   const row = ancestors[idx];
   return {
     scopeDivisionIds: row.division_ids ?? [],

--- a/backend/src/services/worldViewImport/matcherUtils.ts
+++ b/backend/src/services/worldViewImport/matcherUtils.ts
@@ -72,7 +72,7 @@ export function isPrefixMatch(a: string, b: string): boolean {
     const sParts = shorter.split('-');
     const lParts = longer.split('-');
     if (sParts.length === lParts.length) {
-      // eslint-disable-next-line security/detect-object-injection -- .every callback index into same-length string[] (split on same delimiter)
+
       return sParts.every((sp, i) => lParts[i].startsWith(sp) || sp.startsWith(lParts[i]));
     }
   }

--- a/backend/src/types/auth.ts
+++ b/backend/src/types/auth.ts
@@ -143,8 +143,8 @@ export type ResendVerificationInput = z.infer<typeof resendVerificationSchema>;
 // Express Augmentation
 // =============================================================================
 
-/* eslint-disable @typescript-eslint/no-namespace */
 declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace -- Express augmentation requires `namespace` syntax; module augmentation cannot extend Express.User
   namespace Express {
     interface User {
       id: number;
@@ -157,4 +157,3 @@ declare global {
     }
   }
 }
-/* eslint-enable @typescript-eslint/no-namespace */

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -363,6 +363,7 @@ export const wvExtractStartSchema = z.object({
   cacheFile: z
     .string()
     .max(128)
+    // eslint-disable-next-line security/detect-unsafe-regex -- anchored at both ends; inner [A-Za-z0-9_-]+ is non-overlapping with the literal `.json` suffix, so no catastrophic backtracking
     .regex(/^(none|wikivoyage-cache(-[A-Za-z0-9_-]+)?\.json)$/)
     .nullable()
     .optional(),
@@ -373,6 +374,7 @@ export const wvCacheNameParamSchema = z.object({
   name: z
     .string()
     .max(128)
+    // eslint-disable-next-line security/detect-unsafe-regex -- anchored; inner [A-Za-z0-9_-]+ is non-overlapping with the literal `.json` suffix, so no catastrophic backtracking
     .regex(/^wikivoyage-cache(-[A-Za-z0-9_-]+)?\.json$/),
 });
 
@@ -396,7 +398,7 @@ export const wvExtractAnswerSchema = z.object({
 // =============================================================================
 
 /** Recursive schema for ImportTreeNode */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Zod recursive schemas require z.ZodType<any> annotation; runtime shape is concrete (see z.object below)
 const importTreeNodeSchema: z.ZodType<any> = z.lazy(() =>
   z.object({
     name: z.string().min(1).max(500),

--- a/docs/tech/development-guide.md
+++ b/docs/tech/development-guide.md
@@ -338,6 +338,61 @@ For the full reference with examples, see [maplibre-patterns.md](maplibre-patter
 - Don't create deep directory nesting. Two levels max (`components/feature/file.ts`).
 - Don't scatter extracted files across unrelated directories.
 
+## Linter Suppressions
+
+Suppressions hide real issues over time. Treat each one as a deliberate exception that needs a written justification — like a `// HACK` in a code review.
+
+### The rules
+
+1. **No file-level or block-level disables.** Never write `/* eslint-disable rule */` at the top of a file or `/* eslint-disable rule */` … `/* eslint-enable rule */` around a block. They suppress the rule for everything that follows, including new code added later that the original author never reviewed.
+2. **Always inline (one line, one suppression).** Use `// eslint-disable-next-line <rule>` or trailing `// eslint-disable-line <rule>`. Each disabled site is reviewed on its own.
+3. **Always include a `-- reason`.** Every suppression must end with `-- <why>` explaining *what* makes the flagged code safe in this specific spot. The reason is what makes the suppression auditable.
+4. **Name every rule explicitly.** Never use a bare `// eslint-disable-next-line` — that disables every rule on the next line and is far too broad. Always name each rule you intend to suppress. A single comment may list multiple rules (e.g. `// eslint-disable-next-line rule-a, rule-b -- reason`), but each rule must be named, and the `-- reason` must justify *all* of them.
+5. **Same policy for every linter.** TypeScript (`@ts-expect-error`, `@ts-ignore`), Semgrep (`nosemgrep`), Ruff (`# noqa`), CodeQL (`lgtm[rule]`) — all follow the same inline-with-reason rule. Prefer `@ts-expect-error` over `@ts-ignore` (it errors when no longer needed).
+6. **Config-level rule disables need a comment.** If you turn a rule `'off'` in `eslint.config.mjs` (or equivalent), add an inline comment naming why (see `security/detect-object-injection` in `backend/eslint.config.mjs` for the pattern).
+
+### Examples
+
+```typescript
+// ✅ GOOD — inline, single rule, with reason
+// eslint-disable-next-line security/detect-non-literal-fs-filename -- filePath validated by safeCachePath: must match wikivoyage-cache*.json under CACHE_DIR
+unlinkSync(filePath);
+
+// ✅ GOOD — TypeScript suppression with reason, prefer @ts-expect-error
+// @ts-expect-error -- passport-apple types are incomplete; module ships without callback typings
+import AppleStrategy from 'passport-apple';
+
+// ❌ BAD — file-level, hides everything that follows
+/* eslint-disable security/detect-non-literal-fs-filename */
+
+// ❌ BAD — no rule named, suppresses every rule on the next line
+// eslint-disable-next-line
+const x: any = doSomething();
+
+// ❌ BAD — no reason, future readers can't tell if the suppression is still valid
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const cv: any = loadOpenCV();
+```
+
+### Writing a good reason
+
+The reason should answer "why is this safe right now?" Not just restate the rule.
+
+| Reason | Verdict |
+|---|---|
+| `-- false positive` | ❌ Useless — every suppression's author thinks it's a false positive |
+| `-- ignore` | ❌ Useless |
+| `-- needed for OpenCV.js` | ⚠️ Vague — *why* is OpenCV.js different? |
+| `-- OpenCV.js (cv / cv.Mat) has no TypeScript types` | ✅ Specific and actionable |
+| `-- filePath validated by safeCachePath: must match wikivoyage-cache*.json under CACHE_DIR` | ✅ Names the upstream guard that makes the call safe |
+| `-- bounded character classes between literal anchors; no nested quantifiers, so no catastrophic backtracking` | ✅ Explains the regex-safety reasoning the rule missed |
+
+### When the rule is wrong everywhere
+
+If a rule produces enough false positives that you'd suppress it in dozens of places, disable it in the config (`eslint.config.mjs`) with an inline comment naming why — don't sprinkle disables. The current `security/detect-object-injection: 'off'` is an example: it's globally noisy with TypeScript, so it's off at config level rather than suppressed inline 100+ times.
+
+But: don't reach for config-level disable just because a rule is *occasionally* annoying. Inline-with-reason is the default; config-level is the escape hatch when a rule has no signal at all in this codebase.
+
 ## Refactoring Hygiene
 
 When modifying existing code, always clean up leftovers from the change. These are the most common sources of CodeQL quality findings:

--- a/frontend/src/components/ExperienceList/ExperienceExpandedDetails.tsx
+++ b/frontend/src/components/ExperienceList/ExperienceExpandedDetails.tsx
@@ -131,7 +131,7 @@ export function ExperienceExpandedDetails({
     const firstSegs = segmented[0];
     let commonLen = 0;
     for (let i = 0; i < firstSegs.length; i++) {
-      // eslint-disable-next-line security/detect-object-injection -- loop-counter index into string[] (path segments); same i used on both arrays
+
       if (segmented.every(s => s[i] === firstSegs[i])) {
         commonLen = i + 1;
       } else {
@@ -139,7 +139,7 @@ export function ExperienceExpandedDetails({
       }
     }
     return new Map(outOfRegionLocs.map((l, idx) => {
-      // eslint-disable-next-line security/detect-object-injection -- idx is .map() callback index into same-length typed array
+
       const segs = segmented[idx];
       const trimmed = segs.slice(commonLen).join(' > ');
       return [l.id, trimmed || l.regionPath];

--- a/frontend/src/components/ExperienceList/VisitedStatusButton.tsx
+++ b/frontend/src/components/ExperienceList/VisitedStatusButton.tsx
@@ -26,7 +26,7 @@ export function VisitedStatusButton({
     visited: { label: 'All Visited', color: 'success' as const },
   };
 
-  // eslint-disable-next-line security/detect-object-injection -- visitedStatus is a typed union ('none'|'partial'|'visited'); statusConfig is a const map
+
   const config = statusConfig[visitedStatus];
   let statusIcon: React.ReactElement | undefined;
   if (visitedStatus === 'visited') {

--- a/frontend/src/components/WorldViewEditor/components/GeometryMapPanel.tsx
+++ b/frontend/src/components/WorldViewEditor/components/GeometryMapPanel.tsx
@@ -133,7 +133,7 @@ export function GeometryMapPanel({
         .then((status) => setDisplayGeomStatus(status))
         .catch(() => setDisplayGeomStatus(null));
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- only refetch when dialog opens or world view changes; setDisplayGeomStatus is stable
   }, [open, worldView.id]);
 
   // --- Callbacks ---
@@ -147,7 +147,7 @@ export function GeometryMapPanel({
     } catch (e) {
       console.error('Failed to start computation:', e);
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- regions.length is the relevant trigger (we display "Starting... 0/N"); the regions array reference itself changes too often
   }, [worldView.id, regions.length, skipSnapping]);
 
   const handleCancelComputation = useCallback(async () => {
@@ -184,7 +184,7 @@ export function GeometryMapPanel({
     } finally {
       setIsComputingSingleRegion(false);
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- setComputeProgressLogs/setIsComputingSingleRegion setters are stable; deps listed are the actual trigger inputs
   }, [selectedRegion, forceRecompute, skipSnapping, onSelectedRegionChange, onInvalidateQueries]);
 
   const handleRedefineBoundaries = useCallback(async () => {
@@ -214,7 +214,7 @@ export function GeometryMapPanel({
       console.error('Failed to reset:', e);
       alert('Failed to reset boundaries');
     } finally { setIsResettingToGADM(false); }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- setIsResettingToGADM setter is stable; deps listed are the actual trigger inputs
   }, [selectedRegion, onSelectedRegionChange, onInvalidateQueries]);
 
   const handleBoundaryConfirm = useCallback(async (geometry: GeoJSON.Polygon | GeoJSON.MultiPolygon) => {

--- a/frontend/src/components/WorldViewEditor/components/dialogs/CustomSubdivisionDialog/AIDivisionList.tsx
+++ b/frontend/src/components/WorldViewEditor/components/dialogs/CustomSubdivisionDialog/AIDivisionList.tsx
@@ -82,7 +82,7 @@ export function AIDivisionList({
 
   const getGroupColorByName = useCallback((groupName: string) => {
     const index = groupNames.indexOf(groupName);
-    // eslint-disable-next-line security/detect-object-injection -- index from groupNames.indexOf; groupNames and subdivisionGroups are parallel arrays built in the same hook
+
     return index >= 0 ? getGroupColor(subdivisionGroups[index], index) : '#666';
   }, [groupNames, subdivisionGroups]);
 
@@ -346,7 +346,7 @@ export function AIDivisionList({
                         Assign to:
                       </Typography>
                       {groupNames.map((groupName, idx) => {
-                        // eslint-disable-next-line security/detect-object-injection -- idx is .map() callback index into parallel array subdivisionGroups
+
                         const gc = getGroupColor(subdivisionGroups[idx], idx);
                         return (
                           <Button

--- a/frontend/src/components/WorldViewEditor/components/dialogs/CustomSubdivisionDialog/useAISuggestions.ts
+++ b/frontend/src/components/WorldViewEditor/components/dialogs/CustomSubdivisionDialog/useAISuggestions.ts
@@ -256,7 +256,7 @@ export function useAISuggestions({
         );
         if (divIndex === -1) continue;
 
-        // eslint-disable-next-line security/detect-object-injection -- divIndex is from findIndex on same newUnassigned[]
+
         const division = newUnassigned[divIndex];
 
         const groupIndex = newGroups.findIndex(
@@ -265,7 +265,7 @@ export function useAISuggestions({
         if (groupIndex === -1) continue;
 
         newUnassigned.splice(divIndex, 1);
-        // eslint-disable-next-line security/detect-object-injection -- groupIndex is from findIndex on same newGroups[]
+
         newGroups[groupIndex].members.push(division);
         assignedCount++;
       }
@@ -294,7 +294,7 @@ export function useAISuggestions({
 
     const targetGroupIndex = newGroups.findIndex(g => g.name === groupName);
     if (targetGroupIndex !== -1) {
-      // eslint-disable-next-line security/detect-object-injection -- targetGroupIndex is from findIndex on same newGroups[]
+
       newGroups[targetGroupIndex].members.push(division);
     }
 

--- a/frontend/src/components/WorldViewEditor/components/dialogs/CustomSubdivisionDialog/useImageColorPicker.ts
+++ b/frontend/src/components/WorldViewEditor/components/dialogs/CustomSubdivisionDialog/useImageColorPicker.ts
@@ -174,7 +174,7 @@ export function useImageColorPicker({
       eyedropperAbortRef.current?.abort();
       const controller = new AbortController();
       eyedropperAbortRef.current = controller;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- EyeDropper API is not in TypeScript DOM lib yet (Chrome 95+); presence guarded by `'EyeDropper' in window` above
       const dropper = new (window as any).EyeDropper();
       dropper.open({ signal: controller.signal })
         .then((result: { sRGBHex: string }) => {

--- a/frontend/src/components/admin/AISettingsPanel.tsx
+++ b/frontend/src/components/admin/AISettingsPanel.tsx
@@ -101,7 +101,7 @@ function formatDate(iso: string): string {
 }
 
 function sessionCostInfo(model: AIModelOption, featureKey: string): { cost: string; session: string; tooltip: string } | null {
-  // eslint-disable-next-line security/detect-object-injection -- featureKey iterated from FEATURE_KEYS (module-level const); SESSION_ESTIMATES is a module-level const map
+
   const est = SESSION_ESTIMATES[featureKey];
   if (!est) return null;
   const cost = (est.inputTokens / 1_000_000) * model.inputPer1M + (est.outputTokens / 1_000_000) * model.outputPer1M;
@@ -193,7 +193,7 @@ export function AISettingsPanel() {
               </TableHead>
               <TableBody>
                 {FEATURE_KEYS.map(key => {
-                  // eslint-disable-next-line security/detect-object-injection -- key iterated from FEATURE_KEYS (module-level const); settingsData.settings is a typed Record<FeatureKey, string>
+
                   const currentValue = settingsData?.settings[key] ?? 'gpt-4.1-mini';
                   const models = settingsData?.models ?? [];
                   const currentModel = models.find(m => m.id === currentValue);
@@ -201,9 +201,7 @@ export function AISettingsPanel() {
                   return (
                     <TableRow key={key}>
                       <TableCell>
-                        {/* eslint-disable-next-line security/detect-object-injection -- key iterated from FEATURE_KEYS (module-level const) */}
                         <Tooltip title={FEATURE_LABELS[key]?.description ?? ''} placement="right">
-                          {/* eslint-disable-next-line security/detect-object-injection -- key iterated from FEATURE_KEYS (module-level const) */}
                           <span>{FEATURE_LABELS[key]?.label ?? key}</span>
                         </Tooltip>
                       </TableCell>

--- a/frontend/src/components/admin/CvClusterReviewSection.tsx
+++ b/frontend/src/components/admin/CvClusterReviewSection.tsx
@@ -253,7 +253,7 @@ export function CvClusterReviewSection({ cvMatchDialog, setCVMatchDialog }: CvCl
         sx={{ mt: 1.5 }}
         onClick={async () => {
           const merges: Record<number, number> = {};
-          // eslint-disable-next-line security/detect-object-injection -- from/to are integer cluster IDs from the internal Map<number,number>
+
           for (const [from, to] of cr.merges) merges[from] = to;
           const excludes = [...cr.excludes];
           setCVMatchDialog(prev => prev ? {

--- a/frontend/src/components/admin/CvGeoPreviewSection.tsx
+++ b/frontend/src/components/admin/CvGeoPreviewSection.tsx
@@ -87,7 +87,7 @@ function buildWvLabelData(wvPreview: GeoJSON.FeatureCollection): GeoJSON.Feature
   const labelFeatures: GeoJSON.Feature[] = [];
   for (const f of wvPreview.features) {
     try {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- turf.centroid's overload signature rejects generic GeoJSON.Feature; runtime accepts it
       const centroid = turf.centroid(f as any);
       labelFeatures.push({
         type: 'Feature',

--- a/frontend/src/components/admin/CvMatchMap.tsx
+++ b/frontend/src/components/admin/CvMatchMap.tsx
@@ -18,7 +18,7 @@ export function mergeGeometries(geoms: GeoJSON.Geometry[]): GeoJSON.Geometry | n
   try {
     let result = turf.feature(geoms[0] as GeoJSON.Polygon | GeoJSON.MultiPolygon);
     for (let i = 1; i < geoms.length; i++) {
-      // eslint-disable-next-line security/detect-object-injection -- loop-counter index into typed GeoJSON.Geometry[]
+
       const merged = turf.union(turf.featureCollection([result, turf.feature(geoms[i] as GeoJSON.Polygon | GeoJSON.MultiPolygon)]));
       if (merged) result = merged;
     }
@@ -66,7 +66,7 @@ export interface CvMatchMapProps {
 }
 
 /** Describe the hovered feature's status for the hover tooltip line. */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- f is a hovered MapLibre feature with dynamic properties (clusterId/regionName/confidence/etc) that vary by source layer
 function describeHoveredFeature(f: any): string {
   if (f.preAssigned) return `Already assigned to ${f.regionName ?? 'parent region'}`;
   if (f.dismissed) return 'Dismissed';
@@ -96,7 +96,7 @@ function assignLabel(isDismissed: boolean, needsManualAssign: boolean): string {
 function SelectedFeaturePanel({
   selectedFeature, geoPreview, onAccept, onReject, onClusterReassign, setSelectedId,
 }: {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- selectedFeature is a MapLibre feature object with dynamic properties (varies by source layer); typed access happens inside the panel
   selectedFeature: any;
   geoPreview: CvMatchMapProps['geoPreview'];
   onAccept?: CvMatchMapProps['onAccept'];
@@ -239,7 +239,7 @@ export function CvMatchMap({ geoPreview, onAccept, onReject, onClusterReassign, 
   // Paint mode: pick a cluster, then click divisions to assign them
   const [paintClusterId, setPaintClusterId] = useState<number | null>(null);
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- MapLibre StyleExpression types don't accept tuple literals cleanly; runtime shape matches the layer paint contract
   const fillColorExpr: any = ['get', 'color'];
 
   // Region label points: one per cluster at the centroid of that cluster's divisions

--- a/frontend/src/components/admin/GapAnalysis.tsx
+++ b/frontend/src/components/admin/GapAnalysis.tsx
@@ -142,9 +142,9 @@ export function GapAssignSelect({ subtreeRegions, defaultRegionId, mapSelectedRe
       // Find if this is the last item before next same-or-shallower depth
       let isLast = true;
       for (let j = i + 1; j < subtreeRegions.length; j++) {
-        // eslint-disable-next-line security/detect-object-injection -- loop-counter index into typed subtreeRegions[] array
+
         if (subtreeRegions[j].depth <= r.depth) {
-          // eslint-disable-next-line security/detect-object-injection -- same loop-counter index
+
           isLast = subtreeRegions[j].depth < r.depth;
           break;
         }
@@ -166,7 +166,7 @@ export function GapAssignSelect({ subtreeRegions, defaultRegionId, mapSelectedRe
       >
         <option value="">Assign to...</option>
         {subtreeRegions.map((r, i) => (
-          // eslint-disable-next-line security/detect-object-injection -- i is .map() callback index into parallel arrays regionPaths and treeLabels
+
           <option key={r.id} value={r.id} title={regionPaths[i]}>{treeLabels[i]}</option>
         ))}
       </TextField>

--- a/frontend/src/components/admin/ImportTreeDialogs.tsx
+++ b/frontend/src/components/admin/ImportTreeDialogs.tsx
@@ -337,7 +337,7 @@ export function CoverageCompareDialog({ data, onClose, onAnalyzeGaps }: {
       features: allGeometries.map(g => ({ type: 'Feature' as const, properties: {}, geometry: g })),
     };
     return turf.bbox(fc) as [number, number, number, number];
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- allGeometries is derived from these three deps each render; recomputing only when geometries actually change
   }, [data?.parentGeometry, data?.childrenGeometry, data?.geoshapeGeometry]);
 
   const fitToAll = useCallback((mapRef: React.RefObject<MapRef | null>) => {
@@ -832,7 +832,7 @@ export function GapAnalysisDialog({ state, tree, worldViewId, highlightedGapId, 
     if (state.loading || !localModified.current) {
       setLocalState(state);
     }
-  }, [state?.regionId, state?.loading]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [state?.regionId, state?.loading]); // eslint-disable-line react-hooks/exhaustive-deps -- intentionally exclude `state` itself; we only want to resync on region change or loading transitions, not on every state mutation
 
   const effectiveState = localState?.regionId === state?.regionId ? localState : state;
 

--- a/frontend/src/components/admin/OverlapResolutionDialog.tsx
+++ b/frontend/src/components/admin/OverlapResolutionDialog.tsx
@@ -217,7 +217,7 @@ export function OverlapResolutionDialog({
   }, [open, worldViewId, parentRegionId, overlaps.length]);
 
   // Selected overlap
-  // eslint-disable-next-line security/detect-object-injection -- selectedIndex is a typed number|null state; overlaps[] is the source of all valid indices
+
   const selected = selectedIndex != null ? overlaps[selectedIndex] : null;
 
   // Color map: regionId → color

--- a/frontend/src/components/admin/SmartSimplifyDialog.tsx
+++ b/frontend/src/components/admin/SmartSimplifyDialog.tsx
@@ -157,9 +157,9 @@ export function SmartSimplifyDialog({
   }, [open, worldViewId, parentRegionId]);
 
   // Derived: the active selection (either a GADM move or a spatial anomaly)
-  // eslint-disable-next-line security/detect-object-injection -- selectedMoveIndex is a typed number|null state; moves[] is the source of valid indices
+
   const selectedMove = moves && selectedMoveIndex != null ? moves[selectedMoveIndex] : null;
-  // eslint-disable-next-line security/detect-object-injection -- selectedAnomalyIndex is a typed number|null state; spatialAnomalies[] is the source of valid indices
+
   const selectedAnomaly = spatialAnomalies && selectedAnomalyIndex != null ? spatialAnomalies[selectedAnomalyIndex] : null;
 
   // Active division IDs to show on the map (from whichever selection is active)
@@ -263,7 +263,7 @@ export function SmartSimplifyDialog({
   // Handle Apply
   const handleApply = useCallback(async () => {
     if (moves == null || selectedMoveIndex == null) return;
-    // eslint-disable-next-line security/detect-object-injection -- selectedMoveIndex is a typed number state, moves[] is the source of valid indices
+
     const move = moves[selectedMoveIndex];
     if (!move) return;
 
@@ -305,7 +305,7 @@ export function SmartSimplifyDialog({
   // Handle Apply Anomaly
   const handleApplyAnomaly = useCallback(async (index: number) => {
     if (!spatialAnomalies) return;
-    // eslint-disable-next-line security/detect-object-injection -- index is a typed number param from a click handler on spatialAnomalies[]
+
     const anomaly = spatialAnomalies[index];
     const memberRowIds = anomaly.divisions
       .map(d => d.memberRowId)

--- a/frontend/src/components/admin/TreeNodeRow.tsx
+++ b/frontend/src/components/admin/TreeNodeRow.tsx
@@ -356,7 +356,7 @@ function scalarPropsEqual(prev: TreeNodeRowProps, next: TreeNodeRowProps): boole
 
 function loadingStatesEqual(prev: TreeNodeRowProps, next: TreeNodeRowProps, id: number): boolean {
   for (const key of LOADING_KEYS) {
-    // eslint-disable-next-line security/detect-object-injection -- key iterated from LOADING_KEYS (module-level const string[]); prev/next are typed TreeNodeRowProps
+
     if ((prev[key] === id) !== (next[key] === id)) return false;
   }
   return true;

--- a/frontend/src/components/admin/WorldViewImportPanel.tsx
+++ b/frontend/src/components/admin/WorldViewImportPanel.tsx
@@ -95,7 +95,7 @@ function RegionChildrenList({ childNames, childPageExists }: { childNames: strin
   return (
     <>
       {childNames.map((c, ci) => {
-        // eslint-disable-next-line security/detect-object-injection -- c is iterated from childNames (same component tree); read-only lookup in typed Record<string, boolean>
+
         const hasPage = childPageExists?.[c];
         return (
           <span key={ci}>

--- a/frontend/src/components/admin/useNavigationState.ts
+++ b/frontend/src/components/admin/useNavigationState.ts
@@ -21,7 +21,7 @@ import {
 
 export type NavCategory = 'unresolved' | 'warnings' | 'single-child' | 'incomplete-coverage';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- generic alias for any concrete useVirtualizer<TItem, TElement> return; consumers pass typed virtualizers
 type AnyVirtualizer = ReturnType<typeof useVirtualizer<any, any>>;
 
 export interface UseNavigationStateResult {
@@ -126,7 +126,7 @@ export function useNavigationState(
     estimateSize: () => 40,
     overscan: 15,
     getItemKey: (index) => {
-      // eslint-disable-next-line security/detect-object-injection -- index is a typed number from the virtualizer callback
+
       const item = flatItems[index];
       if (item.kind === 'node') {
         const n = item.node;
@@ -224,11 +224,11 @@ export function useNavigationState(
     : reviewHighlightId;
 
   const navigateTo = useCallback((category: NavCategory, idx: number) => {
-    // eslint-disable-next-line security/detect-object-injection -- category is a typed NavCategory union, navIdsMap is Record<NavCategory, number[]>
+
     const ids = navIdsMap[category];
     if (!tree || idx < 0 || idx >= ids.length) return;
     setActiveNav({ category, idx });
-    // eslint-disable-next-line security/detect-object-injection -- idx bounds checked above against ids.length
+
     const targetId = ids[idx];
     const ancestorIds = collectAncestorsOfIds(tree, new Set([targetId]));
     setExpanded(prev => new Set([...prev, ...ancestorIds, targetId]));
@@ -260,7 +260,7 @@ export function useNavigationState(
         setActiveNav({ category: activeNav.category, idx: clampedIdx });
       }
       // Scroll to the (possibly new) item at this index
-      // eslint-disable-next-line security/detect-object-injection -- clampedIdx is derived via Math.min and bounded by ids.length
+
       const targetId = ids[clampedIdx];
       if (tree) {
         const ancestorIds = collectAncestorsOfIds(tree, new Set([targetId]));

--- a/frontend/src/components/discover/DiscoverExperienceView.tsx
+++ b/frontend/src/components/discover/DiscoverExperienceView.tsx
@@ -476,7 +476,7 @@ export function DiscoverExperienceView({
       map.remove();
       mapRef.current = null;
     };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- map init is mount-only; recreating on dep change would destroy/recreate the MapLibre instance every render
   }, []);
 
   // ── ResizeObserver: call map.resize() when container changes ──

--- a/frontend/src/components/discover/ExperienceDetailPanel.tsx
+++ b/frontend/src/components/discover/ExperienceDetailPanel.tsx
@@ -390,7 +390,7 @@ function LocationsSection({
       if (!expanded) setExpanded(true);
       virtualizer.scrollToIndex(idx, { align: 'center', behavior: 'smooth' });
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- only respond to hover changes; depending on filteredLocations/expanded/virtualizer would re-scroll on unrelated re-renders
   }, [hoveredLocationId]);
 
   return (

--- a/frontend/src/components/shared/LocationPicker.tsx
+++ b/frontend/src/components/shared/LocationPicker.tsx
@@ -188,7 +188,7 @@ export function LocationPicker({ value, onChange, name, onPlaceSelect }: Locatio
       map.remove();
       mapRef.current = null;
     };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- map init/cleanup is mount-only; later effects sync marker/value changes
   }, []);
 
   // Sync marker with value changes

--- a/frontend/src/utils/coordinateParser.ts
+++ b/frontend/src/utils/coordinateParser.ts
@@ -25,7 +25,7 @@ function isValidCoords(lat: number, lng: number): boolean {
 }
 
 /** Try to parse a DMS component like "48°51'24\"N" or "48°51'24.5\"N" */
-// eslint-disable-next-line security/detect-unsafe-regex
+// eslint-disable-next-line security/detect-unsafe-regex -- bounded character classes between literal anchors (°, ′/', ″/", NSEW); no nested/overlapping quantifiers, so no catastrophic backtracking
 const DMS_PATTERN = /(-?\d+)[°]\s*(\d+)[′']\s*(\d+(?:\.\d+)?)[″"]\s*([NSEW])/i;
 
 /** Try to parse a decimal+direction component like "48.8566N" */


### PR DESCRIPTION
## Summary

- Audited every linter suppression in the project and made each one inline + reasoned
- Removed all 7 file/block-level `eslint-disable` directives, converted to per-line disables with explicit `-- reason` comments
- Added missing `-- reason` to ~25 inline disables (OpenCV.js untyped, Zod recursive schema, mount-only effects, passport-apple callback, EyeDropper API gap, MapLibre dynamic feature shape, etc.)
- Auto-removed ~40 dead disables for the globally-off `security/detect-object-injection` rule
- Addressed 6 previously-hidden `security/detect-unsafe-regex` warnings in `parser.ts` and `types/index.ts` — all bounded patterns, now justified inline
- Codified the policy in `docs/tech/development-guide.md` so the same hygiene applies to new code

## Why

A suppression hides a real linter finding. Without a `-- reason`, future readers can't tell whether the suppression is still valid, whether the underlying code changed, or whether the rule is now actually correct. File-level disables make it worse — they silently cover any new code added below them. This PR makes every suppression auditable.

## Final state
- 0 file-level / block-level disables in `backend/src` or `frontend/src`
- 82 inline disables remain — all with `-- reason`
- `npm run check` → 0 errors, 0 warnings
- `TEST_REPORT_LOCAL=1 npm test` → 181/181 pass

## Test plan
- [ ] CI lint job is green (no errors, no warnings)
- [ ] CI test suite passes
- [ ] Spot-check 2-3 changed files to confirm the inline disables read sensibly and the reasons are accurate
- [ ] Skim the new "Linter Suppressions" section in `docs/tech/development-guide.md` for clarity

🤖 Generated with [Claude Code](https://claude.com/claude-code)