### PR TITLE
fix(world-view): preserve custom boundary on invalidate (#283)

### DIFF
--- a/backend/src/controllers/worldView/helpers.test.ts
+++ b/backend/src/controllers/worldView/helpers.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../db/index.js', () => ({
+  pool: { query: vi.fn().mockResolvedValue({ rows: [] }) },
+}));
+
+import { pool } from '../../db/index.js';
+import { invalidateRegionGeometry } from './helpers.js';
+
+const mockedQuery = pool.query as unknown as ReturnType<typeof vi.fn>;
+
+describe('invalidateRegionGeometry', () => {
+  beforeEach(() => {
+    mockedQuery.mockClear();
+  });
+
+  it('skips rows with is_custom_boundary IS TRUE — regression for #283', async () => {
+    // The bug: invalidateRegionGeometry's recursive CTE includes the starting
+    // region itself. Without the IS NOT TRUE guard, calling addMembers right
+    // after createRegion(customGeometry) would null the just-created custom
+    // shape and reset is_custom_boundary, then a subsequent recompute would
+    // produce the merged-from-members geometry — losing the user's drawing.
+    await invalidateRegionGeometry(42);
+
+    expect(mockedQuery).toHaveBeenCalledTimes(1);
+    const [sql, params] = mockedQuery.mock.calls[0] as [string, unknown[]];
+    expect(params).toEqual([42]);
+    expect(sql).toMatch(/is_custom_boundary IS NOT TRUE/);
+    expect(sql).not.toMatch(/is_custom_boundary\s*=\s*false/);
+  });
+
+  it('still nulls geom + simplified columns', async () => {
+    await invalidateRegionGeometry(7);
+    const [sql] = mockedQuery.mock.calls[0] as [string];
+    expect(sql).toMatch(/geom\s*=\s*NULL/);
+    expect(sql).toMatch(/geom_3857\s*=\s*NULL/);
+    expect(sql).toMatch(/geom_simplified_low\s*=\s*NULL/);
+    expect(sql).toMatch(/geom_simplified_medium\s*=\s*NULL/);
+  });
+
+  it('walks ancestors via the recursive CTE', async () => {
+    await invalidateRegionGeometry(1);
+    const [sql] = mockedQuery.mock.calls[0] as [string];
+    expect(sql).toMatch(/WITH RECURSIVE ancestors/);
+    expect(sql).toMatch(/cg\.id\s*=\s*a\.parent_region_id/);
+  });
+
+  it('swallows lock/deadlock errors (concurrent invalidation safe)', async () => {
+    mockedQuery.mockRejectedValueOnce(new Error('could not obtain lock on row in relation "regions"'));
+    await expect(invalidateRegionGeometry(99)).resolves.toBeUndefined();
+
+    mockedQuery.mockRejectedValueOnce(new Error('deadlock detected'));
+    await expect(invalidateRegionGeometry(99)).resolves.toBeUndefined();
+  });
+
+  it('rethrows non-lock errors', async () => {
+    mockedQuery.mockRejectedValueOnce(new Error('relation "regions" does not exist'));
+    await expect(invalidateRegionGeometry(99)).rejects.toThrow('does not exist');
+  });
+});

--- a/backend/src/controllers/worldView/helpers.ts
+++ b/backend/src/controllers/worldView/helpers.ts
@@ -19,10 +19,15 @@ export async function ensureRegionMember(regionId: number, divisionId: number): 
 }
 
 /**
- * Clear cached geometry for a region and all its ancestors
- * This ensures that when a child region changes, parent regions are also recalculated
- * Also clears is_custom_boundary since the old geometry is being discarded
- * NOTE: This also clears simplified geometry columns to prevent stale simplified data
+ * Clear cached geometry for a region and all its ancestors so the next render
+ * recomputes them from members.
+ *
+ * Skips rows with is_custom_boundary = true: those geometries are user-drawn,
+ * not derived from members, so member or structural changes must not silently
+ * wipe them. The explicit way to drop a custom boundary is resetRegionToGADM
+ * in geometryCompute.ts. (See #283: without this guard, calling addMembers
+ * right after createRegion(customGeometry) clobbered the just-created custom
+ * shape because the recursive CTE includes the starting region itself.)
  */
 export async function invalidateRegionGeometry(regionId: number): Promise<void> {
   // Gracefully handle lock/deadlock errors if concurrent operations touch the same regions
@@ -42,9 +47,9 @@ export async function invalidateRegionGeometry(regionId: number): Promise<void> 
       SET geom = NULL,
           geom_3857 = NULL,
           geom_simplified_low = NULL,
-          geom_simplified_medium = NULL,
-          is_custom_boundary = false
+          geom_simplified_medium = NULL
       WHERE id IN (SELECT id FROM ancestors)
+        AND is_custom_boundary IS NOT TRUE
     `, [regionId]);
   } catch (err: unknown) {
     // If we get a lock error, just log and continue - another operation is handling it


### PR DESCRIPTION
## Description

`invalidateRegionGeometry`'s recursive CTE in `backend/src/controllers/worldView/helpers.ts` walks ancestors *starting from the region itself*, then unconditionally sets `geom = NULL` and `is_custom_boundary = false` on every walked row. Any region with a user-drawn custom boundary therefore loses it whenever any operation on it (or any descendant) calls `invalidateRegionGeometry`.

The bug actually fires at **create-region time**, not at delete-with-reparent time as #283's repro suggests:

- Frontend `handleCreateRegionFromStaged` (`WorldViewEditor.tsx:197`) calls `createRegion({ customGeometry })` which inserts with `is_custom_boundary = true`, then chains `addMembers` in `onSuccess`.
- Backend `addDivisionsToRegion` (`regionMemberMutations.ts:238`) ends with `invalidateRegionGeometry(regionId)` — silently clobbering the custom shape one statement after it was set.
- The user observes the loss after a later parent delete because that's when TanStack Query refetches the now-stale `geom` and renders the merged-from-members shape.

The same bug affects every operation that calls `invalidateRegionGeometry` on a custom-boundary region (add/remove member, move member, parent change, WV-import transfer/simplify) — not just delete-with-reparent.

**Fix.** One SQL change in `helpers.ts`:

- Drop `is_custom_boundary = false` from the SET clause.
- Add `AND is_custom_boundary IS NOT TRUE` to the WHERE clause.

Custom boundaries are user-explicit and not derived from members, so member or structural changes must not silently wipe them. The legitimate path to drop a custom boundary remains `resetRegionToGADM` in `geometryCompute.ts` (unchanged). Docstring updated to explain the rule and reference #283.

## Related Issues
Closes: #283

## How Was This Tested?

- New `backend/src/controllers/worldView/helpers.test.ts` (5 tests) locks in: SQL contains `is_custom_boundary IS NOT TRUE`; SQL no longer SETs `is_custom_boundary = false`; recursive-CTE walk preserved; lock/deadlock tolerance preserved.
- Verified end-to-end against the dev DB with the original bug repro: custom-boundary region preserved through invalidate, non-custom regions still nulled (full repro SQL in [#283 comment](https://github.com/uncovering-world/track-your-regions/issues/283#issuecomment-4420358313)).
- `npm run check` — passes.
- `TEST_REPORT_LOCAL=1 npm test` — 306/306 (incl. 5 new) pass.
- `npm run test:py` — 1/1 pass.
- `/security-check` — no findings on the two changed files.
- Manual UI verification still pending: create parent → stage divisions → create child with custom geometry → verify the custom shape persists after add-members and after delete-parent-with-reparent.

## Checklist
- [x] Commit messages follow the standard template.
- [x] All commits are signed.
- [x] Related issues are mentioned in the description above.
- [x] Linter checks have been passed.

## Additional Comments

The earlier #321 (rate limiting on division routes) was closed as a misreading of the code — `/api/divisions/*` is mounted with `requireAuth, requireAdmin` at `routes/index.ts:33`. The actual public-route limit concern (corp-NAT/shared-IP collisions on `publicReadLimiter`/`searchLimiter`) is now tracked separately as #379. Neither is related to this PR.