### PR TITLE
fix(wv-import): make resetMatch atomic (#335)

### DIFF
--- a/backend/src/controllers/admin/wvImportAIController.resetMatch.test.ts
+++ b/backend/src/controllers/admin/wvImportAIController.resetMatch.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Response } from 'express';
+import type { AuthenticatedRequest } from '../../middleware/auth.js';
+
+const { mockPoolQuery, mockClientQuery, mockClientRelease, mockPoolConnect } = vi.hoisted(() => {
+  const clientQuery = vi.fn();
+  const clientRelease = vi.fn();
+  return {
+    mockPoolQuery: vi.fn(),
+    mockClientQuery: clientQuery,
+    mockClientRelease: clientRelease,
+    mockPoolConnect: vi.fn(async () => ({ query: clientQuery, release: clientRelease })),
+  };
+});
+
+vi.mock('../../db/index.js', () => ({
+  pool: { query: mockPoolQuery, connect: mockPoolConnect },
+}));
+
+// Stub other heavy imports the controller pulls in but resetMatch doesn't use.
+vi.mock('openai', () => ({ default: class { } }));
+vi.mock('../../services/worldViewImport/aiMatcher.js', () => ({
+  startAIMatching: vi.fn(), getAIMatchProgress: vi.fn(), cancelAIMatch: vi.fn(),
+  aiMatchSingleRegion: vi.fn(), dbSearchSingleRegion: vi.fn(), geocodeMatchRegion: vi.fn(),
+}));
+vi.mock('../../services/ai/openaiService.js', () => ({ isOpenAIAvailable: vi.fn(), getOpenAIClient: vi.fn() }));
+vi.mock('../../services/ai/aiSettingsService.js', () => ({ getModelForFeature: vi.fn() }));
+vi.mock('../../services/ai/pricingService.js', () => ({ calculateCost: vi.fn() }));
+vi.mock('../../services/ai/chatCompletion.js', () => ({ chatCompletion: vi.fn() }));
+vi.mock('../../services/ai/aiUsageLogger.js', () => ({ logAIUsage: vi.fn() }));
+vi.mock('../../services/wikivoyageExtract/fetcher.js', () => ({ WikivoyageFetcher: class { } }));
+
+import { resetMatch } from './wvImportAIController.js';
+
+function makeReq(overrides: { worldViewId?: string; regionId?: number } = {}): AuthenticatedRequest {
+  return {
+    params: { worldViewId: overrides.worldViewId ?? '31' },
+    body: { regionId: overrides.regionId ?? 100 },
+  } as unknown as AuthenticatedRequest;
+}
+
+function makeRes(): Response & { _status?: number; _body?: unknown } {
+  const res = {} as Response & { _status?: number; _body?: unknown };
+  res.status = vi.fn((code: number) => { res._status = code; return res; }) as unknown as Response['status'];
+  res.json = vi.fn((body: unknown) => { res._body = body; return res; }) as unknown as Response['json'];
+  return res;
+}
+
+describe('resetMatch (#335 — atomicity)', () => {
+  beforeEach(() => {
+    mockPoolQuery.mockReset();
+    mockClientQuery.mockReset();
+    mockClientRelease.mockReset();
+    mockPoolConnect.mockClear();
+    mockClientQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+  });
+
+  it('runs the three writes inside a single BEGIN/COMMIT transaction', async () => {
+    mockPoolQuery.mockResolvedValueOnce({ rows: [{ id: 100 }], rowCount: 1 });
+
+    const res = makeRes();
+    await resetMatch(makeReq(), res);
+
+    const sqlCalls = mockClientQuery.mock.calls.map(c => (c[0] as string).trim().split('\n')[0]);
+    expect(sqlCalls[0]).toBe('BEGIN');
+    expect(sqlCalls.at(-1)).toBe('COMMIT');
+    expect(sqlCalls.filter(s => /^DELETE FROM region_members/.test(s))).toHaveLength(1);
+    expect(sqlCalls.filter(s => /^DELETE FROM region_match_suggestions/.test(s))).toHaveLength(1);
+    expect(sqlCalls.filter(s => /UPDATE region_import_state SET match_status/.test(s))).toHaveLength(1);
+    expect(sqlCalls).not.toContain('ROLLBACK');
+    expect(res._body).toEqual({ reset: true });
+  });
+
+  it('ROLLBACKs and returns 500 if any write throws (no half-applied state)', async () => {
+    mockPoolQuery.mockResolvedValueOnce({ rows: [{ id: 100 }], rowCount: 1 });
+    // BEGIN ok, first DELETE ok, second DELETE blows up
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // BEGIN
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // DELETE region_members
+      .mockRejectedValueOnce(new Error('connection terminated unexpectedly')) // DELETE suggestions
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }); // ROLLBACK
+
+    const res = makeRes();
+    await resetMatch(makeReq(), res);
+
+    const sqlCalls = mockClientQuery.mock.calls.map(c => (c[0] as string).trim().split('\n')[0]);
+    expect(sqlCalls).toContain('ROLLBACK');
+    expect(sqlCalls).not.toContain('COMMIT');
+    expect(res._status).toBe(500);
+    expect(res._body).toMatchObject({ error: expect.stringMatching(/connection terminated/) });
+  });
+
+  it('always releases the client (try/finally)', async () => {
+    mockPoolQuery.mockResolvedValueOnce({ rows: [{ id: 100 }], rowCount: 1 });
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // BEGIN
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }); // ROLLBACK
+
+    await resetMatch(makeReq(), makeRes());
+    expect(mockClientRelease).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns 404 without opening a connection when region not found', async () => {
+    mockPoolQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    const res = makeRes();
+    await resetMatch(makeReq(), res);
+
+    expect(mockPoolConnect).not.toHaveBeenCalled();
+    expect(mockClientQuery).not.toHaveBeenCalled();
+    expect(res._status).toBe(404);
+  });
+
+  it('returns 500 (not an unhandled rejection) when pool.connect() itself fails', async () => {
+    mockPoolQuery.mockResolvedValueOnce({ rows: [{ id: 100 }], rowCount: 1 });
+    mockPoolConnect.mockRejectedValueOnce(new Error('pool exhausted'));
+
+    const res = makeRes();
+    await resetMatch(makeReq(), res);
+
+    expect(mockClientQuery).not.toHaveBeenCalled();
+    expect(mockClientRelease).not.toHaveBeenCalled();
+    expect(res._status).toBe(500);
+    expect(res._body).toMatchObject({ error: expect.stringMatching(/pool exhausted/) });
+  });
+
+  it('still returns 500 when ROLLBACK itself throws (dead connection)', async () => {
+    // Without the inner try around ROLLBACK, the original handler-level error
+    // would propagate and the 500 response would never be sent — reproducing
+    // the same hang #335 was filed for.
+    mockPoolQuery.mockResolvedValueOnce({ rows: [{ id: 100 }], rowCount: 1 });
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // BEGIN
+      .mockRejectedValueOnce(new Error('connection terminated unexpectedly')) // first DELETE
+      .mockRejectedValueOnce(new Error('connection is closed')); // ROLLBACK also fails
+
+    const res = makeRes();
+    await resetMatch(makeReq(), res);
+
+    expect(res._status).toBe(500);
+    expect(res._body).toMatchObject({ error: expect.stringMatching(/connection terminated/) });
+    expect(mockClientRelease).toHaveBeenCalledTimes(1);
+  });
+});

--- a/backend/src/controllers/admin/wvImportAIController.ts
+++ b/backend/src/controllers/admin/wvImportAIController.ts
@@ -7,6 +7,7 @@
 
 import { Response } from 'express';
 import OpenAI from 'openai';
+import type { PoolClient } from 'pg';
 import { pool } from '../../db/index.js';
 import type { AuthenticatedRequest } from '../../middleware/auth.js';
 import {
@@ -203,7 +204,7 @@ export async function resetMatch(req: AuthenticatedRequest, res: Response): Prom
   const { regionId } = req.body;
   console.log(`[WV Import] POST /matches/${worldViewId}/reset-match — regionId=${regionId}`);
 
-  // Verify region belongs to this world view
+  // Verify region belongs to this world view (read-only, no transaction needed)
   const region = await pool.query(
     'SELECT id FROM regions WHERE id = $1 AND world_view_id = $2',
     [regionId, worldViewId],
@@ -213,22 +214,37 @@ export async function resetMatch(req: AuthenticatedRequest, res: Response): Prom
     return;
   }
 
-  // Also remove any region_members assignments for this region
-  await pool.query(`DELETE FROM region_members WHERE region_id = $1`, [regionId]);
-
-  // Delete all suggestions (both accepted and rejected)
-  await pool.query(
-    `DELETE FROM region_match_suggestions WHERE region_id = $1`,
-    [regionId],
-  );
-
-  // Reset match status
-  await pool.query(
-    `UPDATE region_import_state SET match_status = 'no_candidates' WHERE region_id = $1`,
-    [regionId],
-  );
-
-  res.json({ reset: true });
+  // The three writes must succeed or fail together. Without a transaction,
+  // a transient DB error between writes leaves region_members deleted but
+  // suggestions/import_state untouched (#335).
+  //
+  // pool.connect() is INSIDE the try so a connect failure also produces a
+  // 500 response (not an unhandled rejection). ROLLBACK is wrapped because
+  // a dead connection makes ROLLBACK throw — its exception would otherwise
+  // skip the 500 response and reproduce the original hang. PostgreSQL
+  // auto-rolls back when the connection drops, so data integrity is intact
+  // either way.
+  let client: PoolClient | null = null;
+  try {
+    client = await pool.connect();
+    await client.query('BEGIN');
+    await client.query('DELETE FROM region_members WHERE region_id = $1', [regionId]);
+    await client.query('DELETE FROM region_match_suggestions WHERE region_id = $1', [regionId]);
+    await client.query(
+      `UPDATE region_import_state SET match_status = 'no_candidates' WHERE region_id = $1`,
+      [regionId],
+    );
+    await client.query('COMMIT');
+    res.json({ reset: true });
+  } catch (err) {
+    if (client) {
+      try { await client.query('ROLLBACK'); } catch { /* connection dead; PG auto-rolls back */ }
+    }
+    console.error(`[WV Import] Reset match failed:`, err);
+    res.status(500).json({ error: err instanceof Error ? err.message : 'Reset match failed' });
+  } finally {
+    client?.release();
+  }
 }
 
 /**


### PR DESCRIPTION
## Description

`resetMatch` in `backend/src/controllers/admin/wvImportAIController.ts:201` ran three sequential writes outside a transaction and without a try/catch:

```ts
await pool.query(`DELETE FROM region_members WHERE region_id = $1`, [regionId]);
await pool.query(`DELETE FROM region_match_suggestions WHERE region_id = $1`, [regionId]);
await pool.query(`UPDATE region_import_state SET match_status = 'no_candidates' WHERE region_id = $1`, [regionId]);
```

A transient DB failure between writes left the region in a half-applied state (`region_members` deleted but suggestions / import_state untouched), and the handler returned no response — the client hung until timeout. Peer handlers in the same file (`dbSearchOne`, `geocodeMatch`, …) already wrap their work in try/catch with sanitised 500 responses; this one was missed.

**Fix.** Wrap the three writes in a single transaction on a dedicated client. `pool.query()` checks out a random connection each time, so multi-statement transactions need explicit `pool.connect()` (documented in `CLAUDE.md`). On error, `ROLLBACK` and return 500 with a sanitised message matching the peer-handler pattern. Client is released in `finally`.

The 404 fast-path (region not in this world view) stays outside the transaction since it is read-only — no point consuming a connection just to reject the request.

## Related Issues
Closes: #335

## How Was This Tested?

- New `backend/src/controllers/admin/wvImportAIController.resetMatch.test.ts` (4 tests) locks in the atomicity contract:
  - `BEGIN`/`COMMIT` bracket the writes on the success path, no `ROLLBACK`.
  - `ROLLBACK` fires + 500 returned + no `COMMIT` when any write throws.
  - `client.release()` always called (try/finally).
  - 404 fast-path does not call `pool.connect()`.
- `npm run check` — passes (exit 0).
- `TEST_REPORT_LOCAL=1 npm test` — 305/305 (incl. 4 new) pass.
- `npm run test:py` — 1/1 pass.
- `/security-check` — no new findings on the two changed files. `err.message` exposure matches existing peer-handler pattern (`dbSearchOne`, `geocodeMatch`), not a regression.

## Checklist
- [x] Commit messages follow the standard template.
- [x] All commits are signed.
- [x] Related issues are mentioned in the description above.
- [x] Linter checks have been passed.

## Additional Comments

Discovered originally by Claude PR Review on #334 (the spine refactor that moved this handler from `worldViewImportController.ts` to `wvImportAIController.ts`); flagged as pre-existing and out of scope at the time.