### PR TITLE
fix(geoshape-cache): serialise fetch slots to fix concurrency race (#346)

### DIFF
--- a/backend/src/services/worldViewImport/geoshapeCache.test.ts
+++ b/backend/src/services/worldViewImport/geoshapeCache.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock the DB pool — the rate-limiter helper doesn't touch it, but the module
+// imports it at top level.
+vi.mock('../../db/index.js', () => ({ pool: { query: vi.fn() } }));
+
+const FETCH_DELAY_MS = 1500;
+
+async function freshAcquireFetchSlot(): Promise<() => Promise<void>> {
+  // Reset module state so each test sees a cold rate limiter.
+  vi.resetModules();
+  const mod = await import('./geoshapeCache.js');
+  return mod.acquireFetchSlot;
+}
+
+describe('acquireFetchSlot — concurrency-safe rate limiter (#346)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('first slot is acquired immediately (no cold-start delay)', async () => {
+    const acquire = await freshAcquireFetchSlot();
+    const start = Date.now();
+    await acquire();
+    expect(Date.now() - start).toBeLessThan(50); // microtask only, no setTimeout
+  });
+
+  it('two concurrent calls serialise: second waits FETCH_DELAY_MS after first', async () => {
+    const acquire = await freshAcquireFetchSlot();
+    const order: number[] = [];
+
+    const p1 = acquire().then(() => order.push(1));
+    const p2 = acquire().then(() => order.push(2));
+
+    // Flush microtasks so the first IIFE runs to completion.
+    await vi.advanceTimersByTimeAsync(0);
+    expect(order).toEqual([1]);
+
+    // Without advancing time past the delay, second call must NOT have fired.
+    // (The race the previous bare-variable form had: both would fire here.)
+    await vi.advanceTimersByTimeAsync(FETCH_DELAY_MS - 1);
+    expect(order).toEqual([1]);
+
+    // Cross the delay boundary — second call resolves.
+    await vi.advanceTimersByTimeAsync(1);
+    await Promise.all([p1, p2]);
+    expect(order).toEqual([1, 2]);
+  });
+
+  it('N concurrent calls each serialise FETCH_DELAY_MS apart', async () => {
+    const acquire = await freshAcquireFetchSlot();
+    const order: number[] = [];
+    const ps = [1, 2, 3, 4].map(i => acquire().then(() => order.push(i)));
+
+    // First fires on microtask
+    await vi.advanceTimersByTimeAsync(0);
+    expect(order).toEqual([1]);
+
+    // Each subsequent call needs an additional FETCH_DELAY_MS
+    for (let i = 2; i <= 4; i++) {
+      await vi.advanceTimersByTimeAsync(FETCH_DELAY_MS);
+      expect(order).toEqual(Array.from({ length: i }, (_, k) => k + 1));
+    }
+
+    await Promise.all(ps);
+  });
+
+  it('a call made well after the previous fetch fires immediately (no needless delay)', async () => {
+    const acquire = await freshAcquireFetchSlot();
+    await acquire();
+
+    // Real-time analogue: a long gap between fetches.
+    await vi.advanceTimersByTimeAsync(FETCH_DELAY_MS * 5);
+
+    // Next call should fire on a microtask, not wait an extra delay.
+    let resolved = false;
+    const p = acquire().then(() => { resolved = true; });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(resolved).toBe(true);
+    await p;
+  });
+});

--- a/backend/src/services/worldViewImport/geoshapeCache.ts
+++ b/backend/src/services/worldViewImport/geoshapeCache.ts
@@ -5,7 +5,34 @@ const GEOSHAPE_URL = 'https://maps.wikimedia.org/geoshape';
 const USER_AGENT = 'TrackYourRegions/1.0 (https://github.com/nikolay/track-your-regions)';
 const FETCH_DELAY_MS = 1500;
 
+// Serialising rate limiter shared by both fetch entry points (#346).
+//
+// The previous bare-variable form (`let lastFetchTime = 0`) was racy: two
+// concurrent calls both observed the variable at the same value, both
+// computed elapsed >= FETCH_DELAY_MS, both skipped the delay and fired
+// simultaneously — defeating the limiter.
+//
+// fetchChain serialises slot acquisition: every caller awaits the previous
+// caller's slot before checking elapsed time, so the (read elapsed → maybe
+// wait → write lastFetchTime) sequence runs strictly one at a time.
+//
+// Preserves the original optimisation: a cold first call (or one made well
+// after the previous fetch) still fires without artificial delay.
 let lastFetchTime = 0;
+let fetchChain: Promise<void> = Promise.resolve();
+
+export async function acquireFetchSlot(): Promise<void> {
+  const prev = fetchChain;
+  fetchChain = (async () => {
+    await prev;
+    const elapsed = Date.now() - lastFetchTime;
+    if (elapsed < FETCH_DELAY_MS) {
+      await new Promise(resolve => setTimeout(resolve, FETCH_DELAY_MS - elapsed));
+    }
+    lastFetchTime = Date.now();
+  })();
+  return fetchChain;
+}
 
 /**
  * Get or fetch a Wikidata geoshape geometry.
@@ -22,13 +49,7 @@ export async function getOrFetchGeoshape(wikidataId: string): Promise<boolean> {
     return !cached.rows[0].not_available;
   }
 
-  // Rate limit
-  const now = Date.now();
-  const elapsed = now - lastFetchTime;
-  if (elapsed < FETCH_DELAY_MS) {
-    await new Promise(resolve => setTimeout(resolve, FETCH_DELAY_MS - elapsed));
-  }
-  lastFetchTime = Date.now();
+  await acquireFetchSlot();
 
   // Fetch from Wikimedia
   try {
@@ -124,13 +145,7 @@ export async function getOrFetchCommonsMapGeoshape(commonsFile: string): Promise
     return { available: !cached.rows[0].not_available };
   }
 
-  // Rate limit
-  const now = Date.now();
-  const elapsed = now - lastFetchTime;
-  if (elapsed < FETCH_DELAY_MS) {
-    await new Promise(resolve => setTimeout(resolve, FETCH_DELAY_MS - elapsed));
-  }
-  lastFetchTime = Date.now();
+  await acquireFetchSlot();
 
   try {
     const url = `https://commons.wikimedia.org/wiki/Data:${encodeURIComponent(commonsFile)}?action=raw`;


### PR DESCRIPTION
## Description

`backend/src/services/worldViewImport/geoshapeCache.ts` used a bare module-level `let lastFetchTime = 0` as its rate limiter. Two concurrent callers both observed the variable at the same value, both computed `elapsed >= FETCH_DELAY_MS`, and both fired immediately — defeating the 1500ms Wikimedia rate limit. Node.js is single-threaded so the window is narrow, but the `await` on the cache lookup yields, letting a second caller enter the limiter before the first writes `lastFetchTime`.

The bug affected both fetch entry points (`getOrFetchGeoshape` and `getOrFetchCommonsMapGeoshape`) which share the global. Two top-level calls in quick succession (admin double-clicks geoshape-match, or the composite fallback loops through `getOrFetchGeoshape` while another top-level call is in flight) could bypass the limiter.

**Fix.** Introduce `acquireFetchSlot()`, a Promise-chain serialiser that both functions await. Each caller waits for the previous slot's delay before checking elapsed time, so the `(read elapsed → maybe wait → write lastFetchTime)` sequence runs strictly one at a time.

Design choice: preserves the original optimisation. A cold first call (or one made well after the previous fetch — `lastFetchTime` far enough in the past) still fires immediately, without the artificial 1500ms delay the issue's suggested snippet would have introduced as a side-effect.

## Related Issues
Closes: #346

## How Was This Tested?

- New `backend/src/services/worldViewImport/geoshapeCache.test.ts` (4 tests, vitest fake timers):
  - First slot fires immediately (no cold-start delay).
  - Two concurrent calls serialise: second blocked until exactly `FETCH_DELAY_MS` has passed.
  - N=4 concurrent calls each separated by `FETCH_DELAY_MS`.
  - A call made well after the previous fetch fires immediately (idle-recovery optimisation preserved).
- `npm run check` — passes (exit 0).
- `TEST_REPORT_LOCAL=1 npm test` — 316/316 (incl. 4 new) pass.
- `npm run test:py` — 1/1 pass.
- `/security-check` — no findings on the two changed files.

## Checklist
- [x] Commit messages follow the standard template.
- [x] All commits are signed.
- [x] Related issues are mentioned in the description above.
- [x] Linter checks have been passed.

## Additional Comments

Discovered originally by Claude PR Review on #345. The issue author flagged it as low-priority (admin-only path, narrow race window), so this PR sticks to the minimum needed change — no broader refactor of the cache file.

The `acquireFetchSlot` helper is exported only for the test suite. The two callers always go through it; no external code uses it directly.