### PR TITLE
fix(world-view): replace ensureSubregion advisory lock with unique index + ON CONFLICT (#378)

### DIFF
--- a/backend/src/controllers/worldView/helpers.test.ts
+++ b/backend/src/controllers/worldView/helpers.test.ts
@@ -5,7 +5,7 @@ vi.mock('../../db/index.js', () => ({
 }));
 
 import { pool } from '../../db/index.js';
-import { invalidateRegionGeometry } from './helpers.js';
+import { invalidateRegionGeometry, ensureRegionMember } from './helpers.js';
 
 const mockedQuery = pool.query as unknown as ReturnType<typeof vi.fn>;
 
@@ -56,5 +56,33 @@ describe('invalidateRegionGeometry', () => {
   it('rethrows non-lock errors', async () => {
     mockedQuery.mockRejectedValueOnce(new Error('relation "regions" does not exist'));
     await expect(invalidateRegionGeometry(99)).rejects.toThrow('does not exist');
+  });
+});
+
+describe('ensureRegionMember — explicit ON CONFLICT arbiter (#378)', () => {
+  beforeEach(() => {
+    mockedQuery.mockClear();
+    mockedQuery.mockResolvedValue({ rows: [] });
+  });
+
+  it('pins the conflict arbiter to the partial unique index (custom_geom IS NULL)', async () => {
+    // A bare `ON CONFLICT DO NOTHING` works today (only one unique constraint on
+    // region_members), but pinning the arbiter to the partial index prevents a
+    // future unique constraint from silently changing the dedupe semantics.
+    await ensureRegionMember(10, 20);
+
+    expect(mockedQuery).toHaveBeenCalledTimes(1);
+    const [sql, params] = mockedQuery.mock.calls[0] as [string, unknown[]];
+    expect(params).toEqual([10, 20]);
+    expect(sql).toMatch(/ON CONFLICT\s*\(\s*region_id\s*,\s*division_id\s*\)\s*WHERE\s+custom_geom\s+IS\s+NULL\s+DO\s+NOTHING/i);
+    // Regression: must not regress to the bare form.
+    expect(sql).not.toMatch(/ON CONFLICT\s+DO\s+NOTHING\b/i);
+  });
+
+  it('inserts only the (region_id, division_id) columns, not custom_geom', async () => {
+    await ensureRegionMember(1, 2);
+    const [sql] = mockedQuery.mock.calls[0] as [string];
+    expect(sql).toMatch(/INSERT INTO region_members\s*\(\s*region_id\s*,\s*division_id\s*\)/i);
+    expect(sql).not.toMatch(/custom_geom\s*[,)]/i); // not in column list or values
   });
 });

--- a/backend/src/controllers/worldView/helpers.ts
+++ b/backend/src/controllers/worldView/helpers.ts
@@ -11,9 +11,14 @@ import { pool } from '../../db/index.js';
  * (see db/init/01-schema.sql) so concurrent callers can't double-insert.
  */
 export async function ensureRegionMember(regionId: number, divisionId: number): Promise<void> {
+  // Explicit arbiter pins the dedupe to the partial unique index. A bare
+  // `ON CONFLICT DO NOTHING` works today, but only because the partial index
+  // happens to be the only unique constraint on this table; pinning the
+  // arbiter prevents a future unique constraint from silently changing what
+  // counts as a duplicate.
   await pool.query(
     `INSERT INTO region_members (region_id, division_id) VALUES ($1, $2)
-     ON CONFLICT DO NOTHING`,
+     ON CONFLICT (region_id, division_id) WHERE custom_geom IS NULL DO NOTHING`,
     [regionId, divisionId],
   );
 }

--- a/backend/src/controllers/worldView/regionCrud.ts
+++ b/backend/src/controllers/worldView/regionCrud.ts
@@ -440,7 +440,7 @@ async function moveDivisionMembershipsForParentChange(
       await client.query(
         `INSERT INTO region_members (region_id, division_id)
          SELECT $1, did FROM unnest($2::int[]) AS t(did)
-         ON CONFLICT DO NOTHING`,
+         ON CONFLICT (region_id, division_id) WHERE custom_geom IS NULL DO NOTHING`,
         [newParentId, moved.rows.map(r => r.division_id)],
       );
     }
@@ -549,7 +549,7 @@ export async function deleteRegion(req: Request, res: Response): Promise<void> {
         await pool.query(`
           INSERT INTO region_members (region_id, division_id)
           VALUES ($1, $2)
-          ON CONFLICT (region_id, division_id) DO NOTHING
+          ON CONFLICT (region_id, division_id) WHERE custom_geom IS NULL DO NOTHING
         `, [parentRegionId, row.division_id]);
       }
     }

--- a/backend/src/controllers/worldView/regionMemberMutations.ts
+++ b/backend/src/controllers/worldView/regionMemberMutations.ts
@@ -30,14 +30,20 @@ interface AddDivisionsCtx {
 
 /**
  * Find-or-create a region by (worldViewId, parentRegionId, name). Race-safe:
- * serialises concurrent callers on a transaction-scoped advisory lock keyed
- * by the (worldView, parent, name) triple before the SELECT-then-INSERT.
+ * leans on the partial unique index `idx_regions_unique_subregion_name` (added
+ * by migration 004) so concurrent callers either insert a new row or surface
+ * the existing one — Postgres resolves the conflict deterministically, no
+ * application-level lock needed.
  *
- * The advisory lock is an application-level fix. The proper schema-level
- * resolution (partial unique index + `INSERT … ON CONFLICT DO UPDATE`) is
- * tracked in issue #378 — it needs a one-shot data cleanup of legacy dev-DB
- * duplicates (created by this same race before it was fixed), which is out
- * of scope for the lint-guardrail PR.
+ * `(xmax = 0)` distinguishes a freshly inserted row from one returned by the
+ * conflict path (xmax is the deleting transaction id; on a brand-new row it's
+ * always 0, on a row returned because of ON CONFLICT it's set). This lets us
+ * keep the existing `createdEntry` semantics — non-null only on real creates.
+ *
+ * The `DO UPDATE SET name = regions.name` is a no-op write whose only purpose
+ * is to make Postgres return the conflicting row via `RETURNING`. `DO NOTHING`
+ * would leave RETURNING empty in the conflict case, forcing an extra round
+ * trip to fetch the existing id.
  */
 async function ensureSubregion(
   worldViewId: number,
@@ -45,39 +51,19 @@ async function ensureSubregion(
   name: string,
   color: string,
 ): Promise<{ id: number; createdEntry: { id: number; name: string } | null }> {
-  const lockKey = `subregion:${worldViewId}:${parentRegionId}:${name}`;
-  const client = await pool.connect();
-  try {
-    await client.query('BEGIN');
-    // Transaction-scoped advisory lock — released automatically on COMMIT/ROLLBACK.
-    // hashtextextended(text, int8) returns an int8 that pg_advisory_xact_lock accepts.
-    await client.query('SELECT pg_advisory_xact_lock(hashtextextended($1, 0))', [lockKey]);
-
-    const existing = await client.query(
-      'SELECT id FROM regions WHERE world_view_id = $1 AND parent_region_id = $2 AND name = $3',
-      [worldViewId, parentRegionId, name],
-    );
-    if (existing.rows.length > 0) {
-      await client.query('COMMIT');
-      return { id: existing.rows[0].id, createdEntry: null };
-    }
-    const newRegion = await client.query(
-      `INSERT INTO regions (world_view_id, name, parent_region_id, color)
-       VALUES ($1, $2, $3, $4)
-       RETURNING id, name`,
-      [worldViewId, name, parentRegionId, color],
-    );
-    await client.query('COMMIT');
-    return {
-      id: newRegion.rows[0].id,
-      createdEntry: { id: newRegion.rows[0].id, name: newRegion.rows[0].name },
-    };
-  } catch (err) {
-    await client.query('ROLLBACK');
-    throw err;
-  } finally {
-    client.release();
-  }
+  const result = await pool.query(
+    `INSERT INTO regions (world_view_id, name, parent_region_id, color)
+     VALUES ($1, $2, $3, $4)
+     ON CONFLICT (world_view_id, parent_region_id, name) WHERE parent_region_id IS NOT NULL
+     DO UPDATE SET name = regions.name
+     RETURNING id, name, (xmax = 0) AS inserted`,
+    [worldViewId, name, parentRegionId, color],
+  );
+  const row = result.rows[0];
+  return {
+    id: row.id,
+    createdEntry: row.inserted ? { id: row.id, name: row.name } : null,
+  };
 }
 
 async function processGadmChildren(

--- a/db/init/01-schema.sql
+++ b/db/init/01-schema.sql
@@ -165,6 +165,13 @@ CREATE INDEX IF NOT EXISTS idx_regions_anchor_point ON regions USING GIST(anchor
 CREATE INDEX IF NOT EXISTS idx_regions_hull_geom ON regions USING GIST(hull_geom);
 CREATE INDEX IF NOT EXISTS idx_regions_is_leaf ON regions(is_leaf) WHERE is_leaf = true;
 CREATE INDEX IF NOT EXISTS idx_regions_focus_bbox ON regions USING gin(focus_bbox) WHERE focus_bbox IS NOT NULL;
+-- Partial unique index: prevents two sibling subregions with the same name under the
+-- same parent in the same world view. Lets ensureSubregion use ON CONFLICT for race
+-- resolution (see #378 / migration 004). Root regions (parent_region_id IS NULL) are
+-- intentionally excluded — duplicate root names per world view are allowed.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_regions_unique_subregion_name
+  ON regions(world_view_id, parent_region_id, name)
+  WHERE parent_region_id IS NOT NULL;
 
 -- Trigger to maintain is_leaf column
 CREATE OR REPLACE FUNCTION update_is_leaf() RETURNS trigger AS $$

--- a/db/migrations/004-dedupe-subregions.sql
+++ b/db/migrations/004-dedupe-subregions.sql
@@ -1,0 +1,140 @@
+-- Migration 004: Dedupe sibling subregions and add a unique index
+--
+-- One-shot cleanup of duplicate sibling subregions left by a since-fixed
+-- find-or-create race in regionMemberMutations.ts::ensureSubregion (#378).
+-- Idempotent: re-running on a clean DB is a no-op.
+--
+-- Strategy: keep the lowest-id row per (world_view_id, parent_region_id, name)
+-- tuple. Once the duplicates are gone, the partial unique index lets the new
+-- ensureSubregion implementation use INSERT … ON CONFLICT DO UPDATE …
+-- RETURNING id (race-resolved deterministically by Postgres) instead of the
+-- transaction-scoped advisory lock that PR #377 introduced as a stopgap.
+--
+-- SAFETY: the audit on the known dev installation showed every duplicate is
+-- completely orphaned (no region_members, no experience_regions, no children,
+-- no user visits, no match suggestions — only region_import_state references,
+-- which CASCADE intentionally as part of import-metadata cleanup). But this
+-- migration runs on every production DB, where the historical race could have
+-- produced different duplicates with real dependent data. The pre-flight DO
+-- block aborts the entire transaction with a clear error message if any
+-- duplicate has dependents, so an operator can re-point the data manually
+-- (or audit the case) instead of silently losing memberships, visits, etc.
+--
+-- Wrapped in BEGIN/COMMIT so the pre-flight, DELETE, and CREATE INDEX succeed
+-- or fail together. Plain `CREATE INDEX` (not CONCURRENTLY) is transactional
+-- in PostgreSQL.
+--
+-- Deployment order: apply this migration to every running DB BEFORE deploying
+-- the matching code change, since `ON CONFLICT (cols)` inference will fail
+-- without the index.
+
+BEGIN;
+
+-- Block concurrent writers on regions for the duration of the migration so
+-- the pre-flight dependent-data check can't be invalidated before the DELETE.
+-- EXCLUSIVE conflicts with ROW SHARE (which is what FK validation acquires via
+-- `SELECT … FOR KEY SHARE` when inserting into region_members,
+-- experience_regions, etc.), but does NOT conflict with ACCESS SHARE — plain
+-- SELECTs on regions still go through. Lock is released at COMMIT/ROLLBACK.
+LOCK TABLE regions IN EXCLUSIVE MODE;
+
+-- Stage the duplicate ids that the migration would delete.
+CREATE TEMP TABLE _dedupe_candidates ON COMMIT DROP AS
+SELECT id FROM (
+  SELECT id, ROW_NUMBER() OVER (
+    PARTITION BY world_view_id, parent_region_id, name
+    ORDER BY id
+  ) AS rn
+  FROM regions
+  WHERE parent_region_id IS NOT NULL
+) ranked WHERE rn > 1;
+
+-- Pre-flight: refuse to run if any candidate has dependent data in any FK
+-- target other than region_import_state (which is intentionally CASCADE-safe
+-- — it holds per-region import metadata that's expected to die with the row).
+DO $$
+DECLARE
+  bad   text := '';
+  n     bigint;
+  total bigint := (SELECT count(*) FROM _dedupe_candidates);
+BEGIN
+  IF total = 0 THEN
+    -- Already deduped (re-run on a clean DB) — nothing to check.
+    RETURN;
+  END IF;
+
+  -- INTENTIONAL OMISSION: region_import_state.region_id is also FK ON DELETE
+  -- CASCADE to regions(id), but is NOT checked here. Those rows ARE the
+  -- per-duplicate import metadata that produced the dups in the first place;
+  -- their CASCADE deletion is the desired outcome of this migration. Adding a
+  -- check on it would block the migration from ever running on a dev DB,
+  -- since every duplicate has a corresponding region_import_state row.
+  -- Every OTHER FK target IS checked below.
+
+  -- regions.parent_region_id — children would be orphaned via ON DELETE SET NULL
+  SELECT count(*) INTO n FROM regions
+    WHERE parent_region_id IN (SELECT id FROM _dedupe_candidates);
+  IF n > 0 THEN bad := bad || format(E'\n  - regions.parent_region_id: %s child region(s) (ON DELETE SET NULL would orphan them)', n); END IF;
+
+  -- region_members — would CASCADE-delete division memberships
+  SELECT count(*) INTO n FROM region_members
+    WHERE region_id IN (SELECT id FROM _dedupe_candidates);
+  IF n > 0 THEN bad := bad || format(E'\n  - region_members: %s row(s) (CASCADE delete)', n); END IF;
+
+  -- experience_regions
+  SELECT count(*) INTO n FROM experience_regions
+    WHERE region_id IN (SELECT id FROM _dedupe_candidates);
+  IF n > 0 THEN bad := bad || format(E'\n  - experience_regions: %s row(s) (CASCADE delete)', n); END IF;
+
+  -- experience_location_regions
+  SELECT count(*) INTO n FROM experience_location_regions
+    WHERE region_id IN (SELECT id FROM _dedupe_candidates);
+  IF n > 0 THEN bad := bad || format(E'\n  - experience_location_regions: %s row(s) (CASCADE delete)', n); END IF;
+
+  -- experience_rejections
+  SELECT count(*) INTO n FROM experience_rejections
+    WHERE region_id IN (SELECT id FROM _dedupe_candidates);
+  IF n > 0 THEN bad := bad || format(E'\n  - experience_rejections: %s row(s) (CASCADE delete)', n); END IF;
+
+  -- experience_curation_log
+  SELECT count(*) INTO n FROM experience_curation_log
+    WHERE region_id IN (SELECT id FROM _dedupe_candidates);
+  IF n > 0 THEN bad := bad || format(E'\n  - experience_curation_log: %s row(s) (ON DELETE SET NULL would orphan audit entries)', n); END IF;
+
+  -- user_visited_regions
+  SELECT count(*) INTO n FROM user_visited_regions
+    WHERE region_id IN (SELECT id FROM _dedupe_candidates);
+  IF n > 0 THEN bad := bad || format(E'\n  - user_visited_regions: %s row(s) (CASCADE delete — loses user visit history)', n); END IF;
+
+  -- region_match_suggestions (both columns)
+  SELECT count(*) INTO n FROM region_match_suggestions
+    WHERE region_id IN (SELECT id FROM _dedupe_candidates);
+  IF n > 0 THEN bad := bad || format(E'\n  - region_match_suggestions.region_id: %s row(s) (CASCADE delete)', n); END IF;
+  SELECT count(*) INTO n FROM region_match_suggestions
+    WHERE donor_region_id IN (SELECT id FROM _dedupe_candidates);
+  IF n > 0 THEN bad := bad || format(E'\n  - region_match_suggestions.donor_region_id: %s row(s) (ON DELETE SET NULL)', n); END IF;
+
+  -- curator_assignments
+  SELECT count(*) INTO n FROM curator_assignments
+    WHERE region_id IN (SELECT id FROM _dedupe_candidates);
+  IF n > 0 THEN bad := bad || format(E'\n  - curator_assignments: %s row(s) (CASCADE delete)', n); END IF;
+
+  -- region_map_images
+  SELECT count(*) INTO n FROM region_map_images
+    WHERE region_id IN (SELECT id FROM _dedupe_candidates);
+  IF n > 0 THEN bad := bad || format(E'\n  - region_map_images: %s row(s) (CASCADE delete — loses cached images)', n); END IF;
+
+  -- (region_import_state intentionally omitted — see top of block.)
+
+  IF bad <> '' THEN
+    RAISE EXCEPTION E'Migration 004 aborted: % duplicate sibling subregion row(s) have dependent data:%\nManual cleanup required: re-point dependents to the kept (lowest-id) row per (world_view_id, parent_region_id, name) tuple, then re-run.', total, bad;
+  END IF;
+END $$;
+
+DELETE FROM regions WHERE id IN (SELECT id FROM _dedupe_candidates);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_regions_unique_subregion_name
+  ON regions(world_view_id, parent_region_id, name)
+  WHERE parent_region_id IS NOT NULL;
+
+COMMIT;


### PR DESCRIPTION
## Description

PR #377 made `ensureSubregion` race-safe by serialising find-or-create calls on a transaction-scoped advisory lock (`pg_advisory_xact_lock`). That worked but was an application-level workaround; the proper schema-level resolution (partial unique index + `INSERT … ON CONFLICT DO UPDATE`) was deferred because existing dev DBs contained 14 duplicate sibling subregion rows left by the pre-fix race — the index would have failed to create.

This PR completes the migration in four steps:

1. **`db/migrations/004-dedupe-subregions.sql`** dedupes the duplicate sibling subregions then creates the partial unique index. Wrapped in `BEGIN`/`COMMIT` so DELETE and CREATE INDEX succeed or fail together. **Pre-flight DO block** before the DELETE counts dependent rows in every FK target that references `regions` (except `region_import_state`, which is intentionally CASCADE-safe — its rows are per-region import metadata meant to die with the row). If any duplicate has dependents, the migration RAISEs with a clear error naming each table and action so the operator can re-point the data manually. Idempotent on a clean DB.
2. **`db/init/01-schema.sql`** gets the same `CREATE UNIQUE INDEX IF NOT EXISTS …` so fresh installs have it from day one without depending on the migration.
3. **`ensureSubregion`** drops the advisory lock + transaction wrapper and uses:
   ```sql
   INSERT … VALUES …
   ON CONFLICT (world_view_id, parent_region_id, name) WHERE parent_region_id IS NOT NULL
   DO UPDATE SET name = regions.name
   RETURNING id, name, (xmax = 0) AS inserted
   ```
   The `(xmax = 0)` test distinguishes a freshly-inserted row (xmax is the deleting txid; on a brand-new row it's always 0) from one returned via the conflict path, preserving the existing `createdEntry` non-null-on-real-create semantics. The `DO UPDATE SET name = regions.name` is a no-op write whose only purpose is to make Postgres return the existing row via `RETURNING` — `DO NOTHING` would leave it empty, forcing an extra round trip.
4. **`ensureRegionMember`** and the bulk INSERT in `moveDivisionMembershipsForParentChange` tighten their bare `ON CONFLICT DO NOTHING` to an explicit arbiter pinned to the partial index `idx_region_members_unique_no_custom`:
   ```sql
   ON CONFLICT (region_id, division_id) WHERE custom_geom IS NULL DO NOTHING
   ```
   The bare form works today (only one unique constraint on the table), but pinning protects against a future unique constraint silently changing dedupe semantics.

**Open question — case sensitivity.** The new index is exact-name (case + accent sensitive). Every real dup in the live DB is also exact-match. A separate sweep could normalise both callers and the index to `lower(immutable_unaccent(name))` if the codebase moves toward case-insensitive region names overall — out of scope here.

**Out of scope — `deleteRegion` widens partial coverage on `moveChildrenToParent`.** CodeRabbit flagged that `regionCrud.ts:540-555` copies all `region_members` rows without filtering `custom_geom IS NULL`, silently widening partial coverage to full when promoting members to the parent. The same pattern exists in `wvImportTreeOpsController.ts:209`. Pre-existing on main, not introduced here; the fix needs a product call on drop/preserve/refuse/accumulate semantics. Tracked as #384.

## Related Issues
Closes: #378

## How Was This Tested?

- **Migration on clean test-db**: 6207 regions, 6 duplicate-subregion-name tuples (all 14 extras orphaned per the issue body's audit). Migration: `DELETE 14`, `CREATE INDEX`, `COMMIT`. After: 6193 regions, 0 duplicates, index present.
- **Migration on synthetic dirty DB** (extra child region pointing at the to-be-deleted dup): RAISEs with the expected helpful error and rolls back — no rows changed.
   ```
   ERROR:  Migration 004 aborted: 1 duplicate sibling subregion row(s) have dependent data:
     - regions.parent_region_id: 1 child region(s) (ON DELETE SET NULL would orphan them)
   Manual cleanup required: re-point dependents to the kept (lowest-id) row per
   (world_view_id, parent_region_id, name) tuple, then re-run.
   ```
- **Migration idempotent**: re-run on already-migrated DB → `DELETE 0`, `CREATE INDEX` skipped via `IF NOT EXISTS`, `COMMIT`.
- **`ensureSubregion` end-to-end against test-db**: 20 concurrent callers converged to a single id, exactly 1 returned `createdEntry !== null`, DB row count was exactly 2 (Child A + Child B, not 21).
- **`helpers.test.ts`** gains 2 regression tests for `ensureRegionMember`:
  - SQL contains `ON CONFLICT (region_id, division_id) WHERE custom_geom IS NULL DO NOTHING` (and not the bare form).
  - INSERT column list is `(region_id, division_id)` only — `custom_geom` neither in columns nor values.
- `npm run check` — passes (exit 0).
- `TEST_REPORT_LOCAL=1 npm test` — 318/318 (incl. 2 new) pass.
- `npm run test:py` — 1/1 pass.
- `/security-check` — no findings on the changed files.

## Checklist
- [x] Commit messages follow the standard template.
- [x] All commits are signed.
- [x] Related issues are mentioned in the description above.
- [x] Linter checks have been passed.

## Additional Comments

**Deployment order matters.** Apply `db/migrations/004-dedupe-subregions.sql` to every running DB BEFORE deploying the code change. The new `ensureSubregion` uses `ON CONFLICT (world_view_id, parent_region_id, name) WHERE parent_region_id IS NOT NULL` — if the partial unique index doesn't exist yet, Postgres can't infer the arbiter and the INSERT will fail.

If a running prod DB has duplicates with real dependents, the migration aborts cleanly and the error message names every affected FK target. An operator can then re-point the dependents (or audit the case) and re-run; nothing is lost in the meantime.

If staged deploys are an option: migrate first (if any dups have dependents, you have time to act before deploying code), observe one cycle, then deploy the code.