### PR TITLE
fix(wv-import): send ?onlyId for single-ancestor children-coverage (#385)

### DIFF
--- a/frontend/src/api/admin/wvImportCoverage.ts
+++ b/frontend/src/api/admin/wvImportCoverage.ts
@@ -210,6 +210,13 @@ export interface ChildrenCoverageResult {
  * - getChildrenCoverage(worldViewId)                   → all regions
  * - getChildrenCoverage(worldViewId, regionId)         → ancestors of regionId
  * - getChildrenCoverage(worldViewId, undefined, ancestorId) → single ancestor only
+ *
+ * Wire-format note: the third shape sends `?onlyId=<id>`, which matches the
+ * backend's Zod schema (childrenCoverageQuerySchema accepts `regionId` and
+ * `onlyId` only). The JS argument is named `ancestorId` because that's the
+ * caller's intent — a specific ancestor's row to refresh after a mutation —
+ * but it maps to the backend's `onlyId` filter that short-circuits to
+ * `targetAncestorIds = new Set([onlyId])` (fast single-ancestor path).
  */
 export async function getChildrenCoverage(
   worldViewId: number,
@@ -218,7 +225,7 @@ export async function getChildrenCoverage(
 ): Promise<ChildrenCoverageResult> {
   const params = new URLSearchParams();
   if (regionId != null) params.set('regionId', String(regionId));
-  if (ancestorId != null) params.set('ancestorId', String(ancestorId));
+  if (ancestorId != null) params.set('onlyId', String(ancestorId));
   const query = params.toString();
   const url = `${API_URL}/api/admin/wv-import/matches/${worldViewId}/children-coverage${query ? '?' + query : ''}`;
   return authFetchJson(url);


### PR DESCRIPTION
## Description

The frontend's `getChildrenCoverage(worldViewId, undefined, ancestorId)` wrapper (third call shape — "single ancestor only") sent `?ancestorId=<id>` as the wire param. But the backend's `childrenCoverageQuerySchema` only declares `regionId` and `onlyId`:

```ts
// backend/src/types/index.ts
export const childrenCoverageQuerySchema = z.object({
  regionId: z.coerce.number().int().positive().optional(),
  onlyId:   z.coerce.number().int().positive().optional(),
});
```

The `validate()` middleware silently strips undeclared fields, so the controller saw no filter and fell into the "compute for ALL container nodes (initial load)" path — recomputing 622 containers per call instead of the intended single ancestor.

`useTreeMutations.ts:150` fires one of these calls per ancestor on every mutation in the import tree (accept, reject, etc.). With `CONCURRENCY = 10` parallel `ST_Union` queries per call and a `pool.max` of 20, the backend connection pool got hammered after a few rapid clicks. Live evidence taken just before the fix: 7+ identical 30–40-second PostGIS queries in `pg_stat_activity`, all from `computeMultiDivisionCoverage`'s batch:

```
=== Active DB queries (longer than 1s) ===
334  00:00:40  active  WITH parent_union AS (SELECT ST_ForcePolygonCCW...)
132  00:00:38  active  ...
331  00:00:38  active  ...
336  00:00:37  active  ...
337  00:00:37  active  ...
329  00:00:33  active  ...
100  00:00:33  active  ...
```

**Fix.** Smallest correct change: rename the wire-format param from `ancestorId` to `onlyId`. The backend already implements `onlyId` as the fast single-ancestor short-circuit (`computeTargetAncestors` returns `new Set([onlyId])` when it's set), so this just activates the existing path. No backend code, schema, or handler changes.

**TypeScript arg name unchanged.** The JS argument is still named `ancestorId` because that's the caller's semantic intent (a specific ancestor's row to refresh after a mutation). The single positional callsite (`useTreeMutations.ts:150`) doesn't care about parameter names. JSDoc has a wire-format note explaining the JS↔HTTP name divergence so the next reader sees why they differ.

**Alternative considered.** Add `ancestorId` to `childrenCoverageQuerySchema` and read it in the controller. Rejected: more wiring, introduces two synonyms for the same filter, no semantic gain.

## Related Issues
Closes: #385

## How Was This Tested?

- **Behavior trace before fix** (live dev backend with PostGIS): every `children-coverage?ancestorId=X` request logged `[WV Import] Children coverage: 622 containers computed, 598 zero-coverage`. `pg_stat_activity` showed 7+ concurrent 30–40 s PostGIS queries from `computeMultiDivisionCoverage` while the user clicked accept-batch.
- **After fix, expected backend log line** for these calls: `[WV Import] Children coverage: 1 containers computed (onlyId=X)`. Response time should drop from 30 s+ to milliseconds. (To be verified end-to-end on dev by reproducing the accept-batch flow against the patched frontend.)
- `npm run check` — passes (exit 0).
- `TEST_REPORT_LOCAL=1 npm test` — 316/316 pass.
- `npm run test:py` — 1/1 pass.
- `/security-check` — no findings on the single changed file.

## Checklist
- [x] Commit messages follow the standard template.
- [x] All commits are signed.
- [x] Related issues are mentioned in the description above.
- [x] Linter checks have been passed.

## Additional Comments

Found while investigating a "pending forever" `accept-batch` + `children-coverage` pair in the Network panel during normal admin usage. The root cause wasn't `accept-batch` itself (a fast transactional INSERT/DELETE/UPDATE) — it was the cascade of full-recompute `children-coverage` calls that pinned the backend connection pool, making `accept-batch` queue behind them.

The "validate() middleware strips undeclared fields" gotcha is documented in the project memory as a recurring source of this kind of silent contract drift between FE wrappers and BE Zod schemas. Worth a separate sweep audit if there are other places where the FE and BE param names diverge.