### PR TITLE
fix(wv-parser): find balanced Regionlist close before scanning trailing bullets (#369)

### DIFF
--- a/backend/src/services/wikivoyageExtract/__tests__/parser.test.ts
+++ b/backend/src/services/wikivoyageExtract/__tests__/parser.test.ts
@@ -10,6 +10,7 @@ import {
   classifyMultiLink,
   parseRegionlist,
   parseBulletLinks,
+  findBalancedTemplateEnd,
 } from '../parser.js';
 
 const FIXTURES = path.join(__dirname, 'fixtures');
@@ -370,6 +371,111 @@ describe('parseBulletLinks', () => {
   it('ignores links after dash separator', () => {
     const wt = `* [[Target]] — see also [[Other]]`;
     expect(parseBulletLinks(wt)).toEqual(['Target']);
+  });
+});
+
+// ─── findBalancedTemplateEnd ────────────────────────────────────────────────
+
+describe('findBalancedTemplateEnd', () => {
+  it('finds the close of a simple template', () => {
+    const t = 'before {{Foo}} after';
+    const open = t.indexOf('{{');
+    const end = findBalancedTemplateEnd(t, open);
+    expect(end).toBe(t.indexOf('}}'));
+    expect(t.slice(open, end + 2)).toBe('{{Foo}}');
+  });
+
+  it('returns the OUTER close when a parameter contains a nested template', () => {
+    const t = 'X {{Outer|p={{Inner}}}} Y';
+    const open = t.indexOf('{{Outer');
+    const end = findBalancedTemplateEnd(t, open);
+    expect(t.slice(open, end + 2)).toBe('{{Outer|p={{Inner}}}}');
+    // Specifically NOT the first }} (which closes Inner):
+    expect(end).not.toBe(t.indexOf('}}'));
+  });
+
+  it('handles deep nesting', () => {
+    const t = '{{A|{{B|{{C}}}}}}';
+    const end = findBalancedTemplateEnd(t, 0);
+    expect(t.slice(0, end + 2)).toBe(t); // whole string is the template
+  });
+
+  it('handles multiple sibling nested templates', () => {
+    const t = 'pre {{Foo|a={{X}}|b={{Y}}|c={{Z}}}} post';
+    const open = t.indexOf('{{Foo');
+    const end = findBalancedTemplateEnd(t, open);
+    expect(t.slice(open, end + 2)).toBe('{{Foo|a={{X}}|b={{Y}}|c={{Z}}}}');
+  });
+
+  it('returns -1 when openIdx does not point at a {{ open', () => {
+    expect(findBalancedTemplateEnd('hello {{Foo}}', 0)).toBe(-1);
+    expect(findBalancedTemplateEnd('hello {{Foo}}', 5)).toBe(-1);
+  });
+
+  it('returns -1 for an unbalanced template', () => {
+    expect(findBalancedTemplateEnd('{{Foo|{{Bar}}', 0)).toBe(-1);
+    expect(findBalancedTemplateEnd('{{Foo', 0)).toBe(-1);
+  });
+
+  it('does not treat a single } as a close', () => {
+    // Curly inside a string literal-ish parameter — must not decrement depth.
+    const t = '{{Tpl|p=val}with{single}braces}}';
+    const end = findBalancedTemplateEnd(t, 0);
+    expect(end).toBe(t.length - 2);
+  });
+});
+
+// ─── parseRegionlist trailing-bullets regression (#369) ─────────────────────
+
+describe('parseRegionlist — trailing bullets with nested template in description', () => {
+  it('finds the balanced Regionlist close even when a description value contains a nested template', () => {
+    // The buggy implementation scanned for the FIRST }} after the last
+    // regionN<param>=, which here closes the {{convert}} inside
+    // region1description= — making bullet-link parsing start INSIDE the
+    // Regionlist body and promote description content to extraLinks.
+    const wt = `
+{{Regionlist
+| region1name=[[Region One]]
+| region1description=Coast stretches over {{convert|10|km}} along the bay.
+| region2name=[[Region Two]]
+| region2description=Inland plateau, around {{convert|800|m}} above sea level.
+}}
+
+* [[Trailing One]] — extra link below the template
+* [[Trailing Two]]
+`;
+    const { regions, extraLinks } = parseRegionlist(wt);
+    expect(regions.map(r => r.name)).toEqual(['Region One', 'Region Two']);
+    expect(extraLinks).toEqual(['Trailing One', 'Trailing Two']);
+    // Description-internal wikilinks must NOT leak into extraLinks
+    // (none in this fixture — but the bug used to pull whatever wikitext
+    // happened to live between the inner }} and the outer }}.)
+    expect(extraLinks).not.toContain('Region One');
+    expect(extraLinks).not.toContain('Region Two');
+  });
+
+  it('still works for a plain Regionlist without nested templates', () => {
+    const wt = `
+{{Regionlist
+| region1name=[[A]]
+| region2name=[[B]]
+}}
+
+* [[Tail]]
+`;
+    const { regions, extraLinks } = parseRegionlist(wt);
+    expect(regions.map(r => r.name)).toEqual(['A', 'B']);
+    expect(extraLinks).toEqual(['Tail']);
+  });
+
+  it('returns no extraLinks when there is no trailing content', () => {
+    const wt = `
+{{Regionlist
+| region1name=[[Only One]]
+}}
+`;
+    const { extraLinks } = parseRegionlist(wt);
+    expect(extraLinks).toEqual([]);
   });
 });
 

--- a/backend/src/services/wikivoyageExtract/parser.ts
+++ b/backend/src/services/wikivoyageExtract/parser.ts
@@ -266,27 +266,6 @@ const STD_COLORS: Record<string, string> = {
   t9: '#a4b8d1', t10: '#c4c78c',
 };
 
-/**
- * Find the closing `}}` that balances the `{{mapshape|` starting at `startIdx`.
- * Returns the index of the first `}` of the balanced `}}`, or -1 if not found.
- */
-function findBalancedMapshapeEnd(text: string, startIdx: number): number {
-  let depth = 0;
-  for (let i = startIdx; i < text.length - 1; i++) {
-
-    if (text[i] === '{' && text[i + 1] === '{') {
-      depth++;
-      i++;
-
-    } else if (text[i] === '}' && text[i + 1] === '}') {
-      depth--;
-      if (depth === 0) return i;
-      i++;
-    }
-  }
-  return -1;
-}
-
 /** Resolve `{{StdColor|code}}` templates inside mapshape body to hex placeholders. */
 function resolveStdColors(inner: string): string {
   return inner.replace(
@@ -363,7 +342,7 @@ export function parseMapshapes(wikitext: string): MapshapeEntry[] {
   while (true) {
     const startIdx = lower.indexOf(MAPSHAPE_OPEN, searchFrom);
     if (startIdx === -1) break;
-    const endIdx = findBalancedMapshapeEnd(cleanText, startIdx);
+    const endIdx = findBalancedTemplateEnd(cleanText, startIdx);
     if (endIdx === -1) break;
 
     const inner = cleanText.substring(startIdx + MAPSHAPE_OPEN.length, endIdx);
@@ -522,17 +501,58 @@ function buildRegionEntry(
 }
 
 /**
+ * Find the index of the matching `}}` for the template opened at `openIdx`
+ * (which must point at the `{{` of the template). Tracks `{{`/`}}` depth so
+ * nested templates inside parameter values don't terminate the scan early.
+ *
+ * Returns the index of the closing `}}`, or -1 if not at a template open or
+ * the template is unbalanced.
+ *
+ * Exported for unit tests; also a small reusable helper for any other call
+ * site that needs to find a balanced template close in MediaWiki wikitext.
+ */
+const OPEN_BRACE_CC = 0x7B;
+const CLOSE_BRACE_CC = 0x7D;
+
+export function findBalancedTemplateEnd(text: string, openIdx: number): number {
+  if (text.charCodeAt(openIdx) !== OPEN_BRACE_CC || text.charCodeAt(openIdx + 1) !== OPEN_BRACE_CC) {
+    return -1;
+  }
+  let depth = 1;
+  let i = openIdx + 2;
+  while (i < text.length - 1) {
+    const c = text.charCodeAt(i);
+    const next = text.charCodeAt(i + 1);
+    if (c === OPEN_BRACE_CC && next === OPEN_BRACE_CC) {
+      depth++;
+      i += 2;
+    } else if (c === CLOSE_BRACE_CC && next === CLOSE_BRACE_CC) {
+      depth--;
+      if (depth === 0) return i;
+      i += 2;
+    } else {
+      i++;
+    }
+  }
+  return -1;
+}
+
+/**
  * Capture bullet links appearing after the Regionlist template's closing `}}`.
- * Locates the last `regionN<param>=` in the text, then scans for the next `}}`.
+ *
+ * Earlier this scanned for the first `}}` after the last `regionN<param>=`
+ * value, but `regionNdescription=` values can contain nested templates
+ * (e.g. `{{convert|10|km}}`); the first `}}` then closes the inner template,
+ * not the outer Regionlist, and bullet parsing started from inside the body
+ * — promoting description links into `extraLinks`. (#369)
+ *
+ * Now: locate `{{Regionlist` (case-insensitive), use findBalancedTemplateEnd
+ * to find the matching outer `}}`, parse bullets from after that.
  */
 function extractTrailingBulletLinks(cleanText: string): string[] {
-  let lastRegionParam: number | undefined;
-  // `\w{1,50}` caps the trailing parameter-name segment length.
-  for (const m of cleanText.matchAll(/region\d{1,4}\w{1,50}\s*=/g)) {
-    lastRegionParam = m.index! + m[0].length;
-  }
-  if (lastRegionParam === undefined) return [];
-  const rlEnd = cleanText.indexOf('}}', lastRegionParam);
+  const openMatch = cleanText.match(/\{\{regionlist/i);
+  if (!openMatch || openMatch.index === undefined) return [];
+  const rlEnd = findBalancedTemplateEnd(cleanText, openMatch.index);
   if (rlEnd < 0) return [];
   return parseBulletLinks(cleanText.slice(rlEnd + 2));
 }


### PR DESCRIPTION
## Description

`extractTrailingBulletLinks` in `backend/src/services/wikivoyageExtract/parser.ts:530` scanned for the first `}}` after the last `regionN<param>=` match:

```ts
const rlEnd = cleanText.indexOf('}}', lastRegionParam);
```

When a `regionNdescription=` value contains a nested template (e.g. `{{convert|10|km}}`), the first `}}` closes the inner template, not the outer `{{Regionlist}}` — so bullet parsing started from inside the Regionlist body and could promote description-internal wikilinks into `extraLinks`.

**Fix.** Locate `{{Regionlist` (case-insensitive) and use a new shared helper `findBalancedTemplateEnd(text, openIdx)` to find the matching outer `}}`, then parse bullets from after that. The helper tracks `{{`/`}}` depth so any number of nested templates inside parameter values is handled correctly. Exported for reuse — other parser code that scans MediaWiki wikitext can use the same primitive.

**Defensive scope.** The issue body marked this "low impact in practice" — most `{{Regionlist}}` usages in real Wikivoyage pages don't put nested templates in description values. Shipping anyway because the change is small (~50 LOC incl. tests), the helper is reusable, and the regression test locks in correctness for the case when it does occur.

## Related Issues
Closes: #369

## How Was This Tested?

- New tests in `backend/src/services/wikivoyageExtract/__tests__/parser.test.ts`:
  - **7 for `findBalancedTemplateEnd`** — simple template, nested parameter (the regression case in isolation), deep nesting, multiple sibling nested templates, `openIdx` not at `{{` returns -1, unbalanced returns -1, single `}` not treated as close.
  - **3 for `parseRegionlist` end-to-end** — the regression scenario (`region1description={{convert|10|km}}` with trailing bullets after the outer `}}`), the plain no-nested-template path (preserves existing behaviour), and the "no trailing content" path returns empty.
- `npm run check` — passes (exit 0). Initial run failed on `sonarjs/no-commented-code` for the inline `/* { */` annotations on `0x7B`/`0x7D` charcode literals; replaced with named constants `OPEN_BRACE_CC` / `CLOSE_BRACE_CC` which is clearer anyway.
- `TEST_REPORT_LOCAL=1 npm test` — 328/328 (incl. 10 new) pass.
- `npm run test:py` — 1/1 pass.
- `/security-check` — no findings on the two changed files.

## Checklist
- [x] Commit messages follow the standard template.
- [x] All commits are signed.
- [x] Related issues are mentioned in the description above.
- [x] Linter checks have been passed.

## Additional Comments

Pure parser-internal change — no API surface modified, no DB schema, no migration. The exported `findBalancedTemplateEnd` is the only addition to the public API; it's small (~20 lines) and broadly useful for any future MediaWiki-wikitext work.

If a future caller needs to skip nested templates in non-Regionlist contexts (e.g. extracting markers from regions with templated coords), the same helper can drop in.