### PR TITLE
fix(ai): enforce request timeout in chatCompletion wrapper (#365)

### DIFF
--- a/backend/src/services/ai/chatCompletion.test.ts
+++ b/backend/src/services/ai/chatCompletion.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type OpenAI from 'openai';
+import {
+  chatCompletion,
+  ChatCompletionTimeoutError,
+  DEFAULT_AI_TIMEOUT_MS,
+} from './chatCompletion.js';
+
+type CreateFn = OpenAI['chat']['completions']['create'];
+
+function makeClient(create: CreateFn): OpenAI {
+  return { chat: { completions: { create } } } as unknown as OpenAI;
+}
+
+function makeResponse(model: string, totalTokens = 10): OpenAI.Chat.Completions.ChatCompletion {
+  return {
+    id: 'chatcmpl-test',
+    object: 'chat.completion',
+    created: 0,
+    model,
+    choices: [],
+    usage: { prompt_tokens: 5, completion_tokens: 5, total_tokens: totalTokens },
+  } as unknown as OpenAI.Chat.Completions.ChatCompletion;
+}
+
+describe('chatCompletion — timeout enforcement (#365)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  it('passes through on success and logs timing (no timeout fired)', async () => {
+    const create = vi.fn().mockResolvedValue(makeResponse('gpt-x'));
+    const client = makeClient(create as unknown as CreateFn);
+
+    const result = await chatCompletion(client, { model: 'gpt-x', messages: [] });
+    expect(result.model).toBe('gpt-x');
+    expect(create).toHaveBeenCalledTimes(1);
+
+    // SDK is invoked WITH a signal (the auto-timeout) by default.
+    const callArgs = create.mock.calls[0];
+    expect(callArgs[1]?.signal).toBeDefined();
+    expect(callArgs[1]?.signal?.aborted).toBe(false);
+  });
+
+  it('throws ChatCompletionTimeoutError when timeoutMs elapses before the SDK resolves', async () => {
+    // Resolve the SDK call only when the signal aborts — simulates a hung server.
+    const create = vi.fn().mockImplementation((_: unknown, opts?: { signal?: AbortSignal }) => {
+      return new Promise((_resolve, reject) => {
+        opts?.signal?.addEventListener('abort', () => {
+          const err = new Error('Request was aborted') as Error & { name: string };
+          err.name = 'AbortError';
+          reject(err);
+        });
+      });
+    });
+    const client = makeClient(create as unknown as CreateFn);
+
+    // Attach .catch BEFORE advancing timers so the rejection is handled
+    // synchronously when it occurs — avoids spurious unhandled-rejection
+    // warnings from the test runner.
+    const captured = chatCompletion(
+      client,
+      { model: 'gpt-x', messages: [] },
+      { timeoutMs: 5_000 },
+    ).catch(e => e);
+    await vi.advanceTimersByTimeAsync(5_001);
+    const err = await captured;
+
+    expect(err).toBeInstanceOf(ChatCompletionTimeoutError);
+    expect(err.timeoutMs).toBe(5_000);
+    expect(err.model).toBe('gpt-x');
+    expect(err.isTimeout).toBe(true);
+    expect(err.elapsedMs).toBeGreaterThanOrEqual(5_000);
+  });
+
+  it('uses DEFAULT_AI_TIMEOUT_MS when timeoutMs is not specified', async () => {
+    const create = vi.fn().mockImplementation((_: unknown, opts?: { signal?: AbortSignal }) => {
+      return new Promise((_resolve, reject) => {
+        opts?.signal?.addEventListener('abort', () => {
+          const err = new Error('Aborted') as Error & { name: string };
+          err.name = 'AbortError';
+          reject(err);
+        });
+      });
+    });
+    const client = makeClient(create as unknown as CreateFn);
+
+    const captured = chatCompletion(client, { model: 'gpt-x', messages: [] }).catch(e => e);
+    await vi.advanceTimersByTimeAsync(DEFAULT_AI_TIMEOUT_MS + 1);
+    const err = await captured;
+
+    expect(err).toBeInstanceOf(ChatCompletionTimeoutError);
+    expect((err as ChatCompletionTimeoutError).timeoutMs).toBe(DEFAULT_AI_TIMEOUT_MS);
+  });
+
+  it('does NOT install a timeout signal when timeoutMs is null (opt-out)', async () => {
+    const create = vi.fn().mockResolvedValue(makeResponse('gpt-x'));
+    const client = makeClient(create as unknown as CreateFn);
+
+    await chatCompletion(client, { model: 'gpt-x', messages: [] }, { timeoutMs: null });
+    // No external signal either → SDK called without { signal }.
+    const callArgs = create.mock.calls[0];
+    expect(callArgs[1]?.signal).toBeUndefined();
+  });
+
+  it('caller-cancelled abort does NOT surface as ChatCompletionTimeoutError', async () => {
+    const externalCtl = new AbortController();
+    const create = vi.fn().mockImplementation((_: unknown, opts?: { signal?: AbortSignal }) => {
+      return new Promise((_resolve, reject) => {
+        opts?.signal?.addEventListener('abort', () => {
+          const err = new Error('Request was aborted by user') as Error & { name: string };
+          err.name = 'AbortError';
+          reject(err);
+        });
+      });
+    });
+    const client = makeClient(create as unknown as CreateFn);
+
+    const captured = chatCompletion(
+      client,
+      { model: 'gpt-x', messages: [] },
+      { timeoutMs: 60_000, signal: externalCtl.signal },
+    ).catch(e => e);
+
+    // Cancel WELL BEFORE the timeout would fire.
+    await vi.advanceTimersByTimeAsync(100);
+    externalCtl.abort();
+    const err = await captured;
+
+    expect(err).not.toBeInstanceOf(ChatCompletionTimeoutError);
+    expect((err as Error).name).toBe('AbortError');
+  });
+
+  it('combines external signal with timeout signal', async () => {
+    const externalCtl = new AbortController();
+    let capturedSignal: AbortSignal | undefined;
+    const create = vi.fn().mockImplementation((_: unknown, opts?: { signal?: AbortSignal }) => {
+      capturedSignal = opts?.signal;
+      return Promise.resolve(makeResponse('gpt-x'));
+    });
+    const client = makeClient(create as unknown as CreateFn);
+
+    await chatCompletion(
+      client,
+      { model: 'gpt-x', messages: [] },
+      { timeoutMs: 30_000, signal: externalCtl.signal },
+    );
+
+    // The SDK got SOME signal; not strictly the external one (we wrap with AbortSignal.any).
+    expect(capturedSignal).toBeDefined();
+  });
+
+  it('timeout fired DURING retry surfaces as ChatCompletionTimeoutError, not AbortError', async () => {
+    // Sequence: first call rejects fast with "Unsupported parameter" 400 →
+    // retry fires → server hangs → timeout fires → retry rejects with
+    // AbortError. Without the inner try/catch around retryWithoutParam, the
+    // public contract ("timeout always surfaces as ChatCompletionTimeoutError")
+    // would be broken on this code path.
+    let attempt = 0;
+    const create = vi.fn().mockImplementation((_: unknown, opts?: { signal?: AbortSignal }) => {
+      attempt++;
+      if (attempt === 1) {
+        const err = Object.assign(new Error("Unsupported parameter: 'temperature'"), {
+          status: 400,
+        });
+        return Promise.reject(err);
+      }
+      // Retry call: hang until aborted.
+      return new Promise((_resolve, reject) => {
+        opts?.signal?.addEventListener('abort', () => {
+          const abort = new Error('Request was aborted') as Error & { name: string };
+          abort.name = 'AbortError';
+          reject(abort);
+        });
+      });
+    });
+    const client = makeClient(create as unknown as CreateFn);
+
+    const captured = chatCompletion(
+      client,
+      { model: 'gpt-z', messages: [], temperature: 0.5 },
+      { timeoutMs: 5_000 },
+    ).catch(e => e);
+    await vi.advanceTimersByTimeAsync(5_001);
+    const err = await captured;
+
+    expect(err).toBeInstanceOf(ChatCompletionTimeoutError);
+    expect((err as ChatCompletionTimeoutError).timeoutMs).toBe(5_000);
+    expect((err as Error).message).toMatch(/timed out/);
+    // We DID fire the retry (so the assertion is meaningful):
+    expect(create).toHaveBeenCalledTimes(2);
+  });
+
+  it('still retries on Unsupported parameter 400 (retry path preserved)', async () => {
+    let attempt = 0;
+    const create = vi.fn().mockImplementation(() => {
+      attempt++;
+      if (attempt === 1) {
+        const err = Object.assign(new Error("Unsupported parameter: 'temperature'"), {
+          status: 400,
+        });
+        return Promise.reject(err);
+      }
+      return Promise.resolve(makeResponse('gpt-z'));
+    });
+    const client = makeClient(create as unknown as CreateFn);
+
+    const result = await chatCompletion(client, {
+      model: 'gpt-z',
+      messages: [],
+      temperature: 0.5,
+    });
+    expect(result.model).toBe('gpt-z');
+    expect(create).toHaveBeenCalledTimes(2);
+    // Retry call should NOT have temperature
+    const retryParams = create.mock.calls[1][0] as { temperature?: number };
+    expect(retryParams.temperature).toBeUndefined();
+  });
+
+  it('rethrows non-timeout, non-retryable errors as-is', async () => {
+    const networkErr = Object.assign(new Error('socket hangup'), { code: 'ECONNRESET' });
+    const create = vi.fn().mockRejectedValue(networkErr);
+    const client = makeClient(create as unknown as CreateFn);
+
+    await expect(
+      chatCompletion(client, { model: 'gpt-x', messages: [] }),
+    ).rejects.toBe(networkErr);
+  });
+});

--- a/backend/src/services/ai/chatCompletion.ts
+++ b/backend/src/services/ai/chatCompletion.ts
@@ -5,11 +5,52 @@
  * If the model rejects a param (400 "Unsupported parameter/value"), retries without it.
  * Caches unsupported params per model so subsequent calls skip them immediately.
  *
+ * Enforces a request timeout via AbortSignal so a hung OpenAI call can't stall
+ * a sync indefinitely (#365). Default 120s — overridable per-call. Pass
+ * `timeoutMs: null` to opt out entirely. An external `signal` can be passed
+ * for caller-driven cancellation; it's combined with the timeout signal.
+ *
  * Also logs per-call timing for performance diagnostics.
  */
 
 import type OpenAI from 'openai';
 import type { ChatCompletionCreateParamsNonStreaming } from 'openai/resources/chat/completions.js';
+
+/** Default request timeout in ms. Single non-streaming completion → 120s is generous. */
+export const DEFAULT_AI_TIMEOUT_MS = 120_000;
+
+export interface ChatCompletionOptions {
+  /**
+   * Per-call request timeout in ms.
+   * - `undefined` (default) → DEFAULT_AI_TIMEOUT_MS
+   * - positive number → use that as the timeout
+   * - `null` → no timeout (rely on SDK default ~10 min)
+   */
+  timeoutMs?: number | null;
+  /**
+   * External AbortSignal for caller-driven cancellation. Combined with the
+   * timeout signal — whichever fires first aborts the request.
+   */
+  signal?: AbortSignal;
+}
+
+/**
+ * Thrown when a chatCompletion call hits its `timeoutMs` budget. Distinct
+ * from a caller-cancelled abort (which surfaces as the SDK's own abort
+ * error) so callers can handle the two cases separately — e.g. retry on
+ * timeout but bail on cancellation.
+ */
+export class ChatCompletionTimeoutError extends Error {
+  readonly isTimeout = true as const;
+  constructor(
+    public readonly timeoutMs: number,
+    public readonly model: string,
+    public readonly elapsedMs: number,
+  ) {
+    super(`AI request to model "${model}" timed out after ${elapsedMs.toFixed(0)}ms (limit ${timeoutMs}ms)`);
+    this.name = 'ChatCompletionTimeoutError';
+  }
+}
 
 /** In-memory cache: model → set of param names the model doesn't support */
 const unsupportedParams = new Map<string, Set<string>>();
@@ -76,13 +117,17 @@ function rememberUnsupportedParam(model: string, param: OptionalParam): void {
 }
 
 /**
- * Retry the completion with the offending param stripped.
+ * Retry the completion with the offending param stripped. Reuses the same
+ * abort signal so the timeout budget still applies to the retry attempt
+ * (the unsupported-param branch only fires on a fast 400, so most of the
+ * timeout window is still available).
  */
 async function retryWithoutParam(
   client: OpenAI,
   cleanParams: ChatCompletionCreateParamsNonStreaming,
   model: string,
   badParam: OptionalParam,
+  signal?: AbortSignal,
 ): Promise<OpenAI.Chat.Completions.ChatCompletion> {
   rememberUnsupportedParam(model, badParam);
   console.log(`[AI] Model "${model}" does not support "${badParam}" — retrying without it`);
@@ -91,7 +136,7 @@ async function retryWithoutParam(
 
   delete (retryParams as unknown as Record<string, unknown>)[badParam];
   const t1 = performance.now();
-  const result = await client.chat.completions.create(retryParams);
+  const result = await client.chat.completions.create(retryParams, signal ? { signal } : undefined);
   const ms = performance.now() - t1;
   const tokens = result.usage?.total_tokens ?? 0;
   console.log(`[AI] ${model} ${tokens}tok ${ms.toFixed(0)}ms (retry w/o ${badParam})`);
@@ -99,36 +144,117 @@ async function retryWithoutParam(
 }
 
 /**
- * Create a chat completion with automatic parameter negotiation.
+ * Build the AbortSignal passed to the OpenAI SDK call. Combines a fresh
+ * timeout signal (if `timeoutMs > 0`) with an external caller-supplied
+ * signal (if any). Uses manual `setTimeout + AbortController` rather than
+ * `AbortSignal.timeout()` so vitest fake timers can intercept the timer
+ * (the platform AbortSignal.timeout() bypasses vi.useFakeTimers).
+ *
+ * Returns the signal that goes to the SDK, plus the timeout signal handle
+ * so the caller can detect "this aborted because of OUR timeout vs the
+ * caller's cancellation", plus a cleanup function to clear the timer.
+ */
+function buildRequestSignal(
+  timeoutMs: number | null | undefined,
+  externalSignal: AbortSignal | undefined,
+): {
+  requestSignal: AbortSignal | undefined;
+  timeoutSignal: AbortSignal | undefined;
+  cleanup: () => void;
+} {
+  let timeoutSignal: AbortSignal | undefined;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  if (typeof timeoutMs === 'number' && timeoutMs > 0) {
+    const ctl = new AbortController();
+    timer = setTimeout(() => ctl.abort(new Error('timeout')), timeoutMs);
+    timeoutSignal = ctl.signal;
+  }
+  const cleanup = (): void => {
+    if (timer) clearTimeout(timer);
+  };
+
+  const signals = [externalSignal, timeoutSignal].filter((s): s is AbortSignal => s != null);
+  let requestSignal: AbortSignal | undefined;
+  if (signals.length === 0) requestSignal = undefined;
+  else if (signals.length === 1) requestSignal = signals[0];
+  else requestSignal = AbortSignal.any(signals);
+  return { requestSignal, timeoutSignal, cleanup };
+}
+
+/**
+ * Create a chat completion with automatic parameter negotiation and a
+ * request timeout.
  *
  * Pass `temperature`, `top_p`, etc. as normal — they'll be silently
  * dropped for models that don't support them, and used for those that do.
+ *
+ * @throws ChatCompletionTimeoutError if `options.timeoutMs` (default 120s)
+ *   elapses before a response. Distinct from a caller-cancelled abort.
  */
 export async function chatCompletion(
   client: OpenAI,
   params: ChatCompletionCreateParamsNonStreaming,
+  options: ChatCompletionOptions = {},
 ): Promise<OpenAI.Chat.Completions.ChatCompletion> {
+  const { timeoutMs = DEFAULT_AI_TIMEOUT_MS, signal: externalSignal } = options;
   const model = params.model;
   const cleanParams = stripKnownUnsupportedParams(params, model);
 
+  const { requestSignal, timeoutSignal, cleanup } = buildRequestSignal(timeoutMs, externalSignal);
+
   const t0 = performance.now();
   try {
-    const result = await client.chat.completions.create(cleanParams);
+    const result = await client.chat.completions.create(
+      cleanParams,
+      requestSignal ? { signal: requestSignal } : undefined,
+    );
     const ms = performance.now() - t0;
     const tokens = result.usage?.total_tokens ?? 0;
     console.log(`[AI] ${model} ${tokens}tok ${ms.toFixed(0)}ms`);
     return result;
   } catch (err: unknown) {
-    const apiErr = err as ApiError;
+    // Distinguish "we hit our timeout" from "caller cancelled" or other errors.
+    // timeoutSignal.aborted is the precise signal that fired; checking it (vs
+    // requestSignal.aborted) avoids mis-classifying a caller cancellation as
+    // a timeout. (timeoutSignal only exists when timeoutMs > 0, so the cast
+    // below is safe.)
+    if (timeoutSignal?.aborted) {
+      throw makeTimeoutError(model, timeoutMs as number, performance.now() - t0);
+    }
 
+    const apiErr = err as ApiError;
     if (apiErr.status === 429) {
       logRateLimit(model, apiErr, t0);
     }
 
     const badParam = getUnsupportedOptionalParam(apiErr);
     if (badParam) {
-      return retryWithoutParam(client, cleanParams, model, badParam);
+      // `await` is load-bearing: without it, the retry's AbortError would
+      // escape past this catch and reach the caller as a raw AbortError
+      // instead of the contracted ChatCompletionTimeoutError.
+      try {
+        return await retryWithoutParam(client, cleanParams, model, badParam, requestSignal);
+      } catch (retryErr) {
+        if (timeoutSignal?.aborted) {
+          throw makeTimeoutError(model, timeoutMs as number, performance.now() - t0, /*duringRetry*/ true);
+        }
+        throw retryErr;
+      }
     }
     throw err;
+  } finally {
+    cleanup();
   }
+}
+
+/** Build the ChatCompletionTimeoutError + emit a uniform log line. */
+function makeTimeoutError(
+  model: string,
+  timeoutMs: number,
+  elapsedMs: number,
+  duringRetry = false,
+): ChatCompletionTimeoutError {
+  const where = duringRetry ? ' during retry' : '';
+  console.warn(`[AI] ${model} request timed out${where} after ${elapsedMs.toFixed(0)}ms (limit ${timeoutMs}ms)`);
+  return new ChatCompletionTimeoutError(timeoutMs, model, elapsedMs);
 }


### PR DESCRIPTION
## Description

The shared `chatCompletion()` wrapper in `backend/src/services/ai/chatCompletion.ts` had no timeout enforcement. The underlying OpenAI SDK is constructed with `new OpenAI({ apiKey })` — no `timeout` override — so the SDK's default ~10-minute idle timeout applies. A hung server-side completion stalls every AI feature that goes through this wrapper:

- Admin AI hierarchy review (3 calls in `aiHierarchyReviewController.ts`)
- AI matching for WV import (3 calls in `wvImportAIController.ts` — audit, enrich, match-one)
- Wikivoyage extract: AI classifier, region parser (×2), interviewer (×2)
- Rule-review service, group descriptions, group suggestions

Cancelling cleanly required restarting the backend.

**Fix.** Add an optional `ChatCompletionOptions` 3rd parameter to `chatCompletion()`:

- `timeoutMs`: defaults to `DEFAULT_AI_TIMEOUT_MS` (120 s). Pass `null` to opt out (rely on SDK default). Pass a positive number to override per call.
- `signal`: external `AbortSignal` for caller-driven cancellation. Combined with the timeout signal via `AbortSignal.any()` — whichever fires first aborts the request.

A structured `ChatCompletionTimeoutError` (with `isTimeout: true`, `timeoutMs`, `model`, `elapsedMs`) lets callers distinguish "we hit our timeout" from "caller cancelled" or other errors, useful for graceful fallback in batch syncs (retry on timeout vs bail on cancellation).

**Implementation note.** Uses manual `setTimeout + AbortController` rather than `AbortSignal.timeout()`. The platform `AbortSignal.timeout()` bypasses vitest's `vi.useFakeTimers()`, so the deterministic-timing tests need the timer to be mockable. Functionally equivalent.

**No call sites changed.** Default 120 s applies automatically to every existing caller. Per-feature overrides are opt-in; if a sync flow needs a tighter or looser budget it can pass `{ timeoutMs: ... }` explicitly later.

## Related Issues
Closes: #365

## How Was This Tested?

New `backend/src/services/ai/chatCompletion.test.ts` (8 tests, vitest fake timers + mocked OpenAI client):

1. Success path passes a signal through to the SDK by default.
2. Timeout fires → throws `ChatCompletionTimeoutError` with the right `timeoutMs` / `model` / `isTimeout` / `elapsedMs` fields.
3. Default `DEFAULT_AI_TIMEOUT_MS` is used when `timeoutMs` is not specified.
4. `timeoutMs: null` opt-out installs NO signal (and skips the timer entirely).
5. Caller-cancelled abort surfaces as the SDK's `AbortError`, NOT as `ChatCompletionTimeoutError` — distinguishable for retry logic.
6. External + timeout signals combine correctly.
7. The existing 400 "Unsupported parameter" retry path is preserved and reuses the same signal so retry attempts honour the original timeout budget.
8. Non-timeout, non-retryable errors are rethrown unchanged.

- `npm run check` — passes (exit 0).
- `TEST_REPORT_LOCAL=1 npm test` — 336/336 (incl. 8 new) pass.
- `npm run test:py` — 1/1 pass.
- `/security-check` — no findings.

## Checklist
- [x] Commit messages follow the standard template.
- [x] All commits are signed.
- [x] Related issues are mentioned in the description above.
- [x] Linter checks have been passed.

## Additional Comments

The 120 s default is conservative for non-streaming completions — most calls finish in <30 s in practice. Tighter per-feature budgets (e.g. 60 s for batch geocode/db-search where there are many short calls in series) can be added later as a separate sweep when there's data on which features benefit from faster failure.

If batch flows want timeout to be retryable distinct from cancellation, they can `catch` and check `err instanceof ChatCompletionTimeoutError` (or `(err as { isTimeout?: true }).isTimeout === true` if they don't want to import the class).