### PR TITLE
refactor(ai): migrate learnedRulesService CRUD to Drizzle (#364)

### DIFF
--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, serial, varchar, integer, boolean, timestamp, jsonb, index, unique } from 'drizzle-orm/pg-core';
+import { pgTable, serial, varchar, integer, boolean, timestamp, jsonb, index, unique, text } from 'drizzle-orm/pg-core';
 import { relations } from 'drizzle-orm';
 
 /**
@@ -465,6 +465,23 @@ export const aiSettings = pgTable('ai_settings', {
   value: varchar('value', { length: 1000 }).notNull(),
   updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow(),
 });
+
+/**
+ * AI Learned Rules
+ *
+ * User-provided rules injected into AI prompts to improve future extractions.
+ * When the AI makes a mistake and the admin corrects it with a note, the note
+ * becomes a learned rule. Read by buildLearnedRulesPrompt() at AI-call time.
+ */
+export const aiLearnedRules = pgTable('ai_learned_rules', {
+  id: serial('id').primaryKey(),
+  feature: varchar('feature', { length: 100 }).notNull(),
+  ruleText: text('rule_text').notNull(),
+  context: text('context'),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+}, (table) => ({
+  featureIdx: index('idx_ai_learned_rules_feature').on(table.feature),
+}));
 
 /**
  * Experience rejections (per region)

--- a/backend/src/services/ai/learnedRulesService.ts
+++ b/backend/src/services/ai/learnedRulesService.ts
@@ -9,7 +9,10 @@
  * the admin sees the full rule set in one unified view.
  */
 
-import { pool } from '../../db/index.js';
+// ADR-0004: Drizzle ORM over raw SQL for non-PostGIS queries.
+import { eq, asc, inArray } from 'drizzle-orm';
+import { db } from '../../db/index.js';
+import { aiLearnedRules } from '../../db/schema.js';
 
 export interface LearnedRule {
   id: number;
@@ -41,65 +44,55 @@ export const PREDEFINED_RULES: PredefinedRule[] = [
   { code: 'interview.coverage', feature: 'extraction_interview', ruleText: 'If <50% of subregions have pages, recommend not splitting.' },
 ];
 
+/**
+ * Drizzle returns `created_at` as `Date | null`. The public LearnedRule shape
+ * uses `string` (ISO) so JSON-serializing the response keeps a stable format.
+ */
+function toLearnedRule(row: typeof aiLearnedRules.$inferSelect): LearnedRule {
+  return {
+    id: row.id,
+    feature: row.feature,
+    ruleText: row.ruleText,
+    context: row.context,
+    createdAt: (row.createdAt ?? new Date()).toISOString(),
+  };
+}
+
 /** Get all rules for a given feature (e.g., 'extraction'). */
 export async function getRules(feature: string): Promise<LearnedRule[]> {
-  const result = await pool.query(
-    `SELECT id, feature, rule_text, context, created_at
-     FROM ai_learned_rules
-     WHERE feature = $1
-     ORDER BY created_at ASC`,
-    [feature],
-  );
-  return result.rows.map(r => ({
-    id: r.id as number,
-    feature: r.feature as string,
-    ruleText: r.rule_text as string,
-    context: r.context as string | null,
-    createdAt: r.created_at instanceof Date ? r.created_at.toISOString() : String(r.created_at),
-  }));
+  const rows = await db
+    .select()
+    .from(aiLearnedRules)
+    .where(eq(aiLearnedRules.feature, feature))
+    .orderBy(asc(aiLearnedRules.createdAt));
+  return rows.map(toLearnedRule);
 }
 
 /** Get all rules across all features. */
 export async function getAllRules(): Promise<LearnedRule[]> {
-  const result = await pool.query(
-    `SELECT id, feature, rule_text, context, created_at
-     FROM ai_learned_rules
-     ORDER BY feature, created_at ASC`,
-  );
-  return result.rows.map(r => ({
-    id: r.id as number,
-    feature: r.feature as string,
-    ruleText: r.rule_text as string,
-    context: r.context as string | null,
-    createdAt: r.created_at instanceof Date ? r.created_at.toISOString() : String(r.created_at),
-  }));
+  const rows = await db
+    .select()
+    .from(aiLearnedRules)
+    .orderBy(asc(aiLearnedRules.feature), asc(aiLearnedRules.createdAt));
+  return rows.map(toLearnedRule);
 }
 
 /** Add a new learned rule. Returns the new rule. */
 export async function addRule(feature: string, ruleText: string, context?: string): Promise<LearnedRule> {
-  const result = await pool.query(
-    `INSERT INTO ai_learned_rules (feature, rule_text, context)
-     VALUES ($1, $2, $3)
-     RETURNING id, feature, rule_text, context, created_at`,
-    [feature, ruleText, context ?? null],
-  );
-  const r = result.rows[0];
-  return {
-    id: r.id as number,
-    feature: r.feature as string,
-    ruleText: r.rule_text as string,
-    context: r.context as string | null,
-    createdAt: r.created_at instanceof Date ? r.created_at.toISOString() : String(r.created_at),
-  };
+  const [row] = await db
+    .insert(aiLearnedRules)
+    .values({ feature, ruleText, context: context ?? null })
+    .returning();
+  return toLearnedRule(row);
 }
 
-/** Delete a learned rule by ID. */
+/** Delete a learned rule by ID. Returns true if a row was removed. */
 export async function deleteRule(id: number): Promise<boolean> {
-  const result = await pool.query(
-    'DELETE FROM ai_learned_rules WHERE id = $1',
-    [id],
-  );
-  return (result.rowCount ?? 0) > 0;
+  const deleted = await db
+    .delete(aiLearnedRules)
+    .where(eq(aiLearnedRules.id, id))
+    .returning({ id: aiLearnedRules.id });
+  return deleted.length > 0;
 }
 
 /**
@@ -124,21 +117,22 @@ ${rulesText}
 When multiple rules apply, later rules (higher numbers) take precedence over earlier ones.`;
 }
 
-/** Bulk-replace a rule's text by ID. */
+/** Bulk-replace a rule's text by ID. Returns true if a row was updated. */
 export async function updateRuleText(id: number, ruleText: string): Promise<boolean> {
-  const result = await pool.query(
-    'UPDATE ai_learned_rules SET rule_text = $2 WHERE id = $1',
-    [id, ruleText],
-  );
-  return (result.rowCount ?? 0) > 0;
+  const updated = await db
+    .update(aiLearnedRules)
+    .set({ ruleText })
+    .where(eq(aiLearnedRules.id, id))
+    .returning({ id: aiLearnedRules.id });
+  return updated.length > 0;
 }
 
 /** Bulk-delete multiple rules by IDs. Returns number of rows deleted. */
 export async function deleteRules(ids: number[]): Promise<number> {
   if (ids.length === 0) return 0;
-  const result = await pool.query(
-    'DELETE FROM ai_learned_rules WHERE id = ANY($1::int[])',
-    [ids],
-  );
-  return result.rowCount ?? 0;
+  const deleted = await db
+    .delete(aiLearnedRules)
+    .where(inArray(aiLearnedRules.id, ids))
+    .returning({ id: aiLearnedRules.id });
+  return deleted.length;
 }


### PR DESCRIPTION
## Description

Per [ADR-0004](https://github.com/uncovering-world/track-your-regions/blob/main/docs/decisions/0004-drizzle-orm-over-raw-sql.md) (Drizzle ORM over raw SQL for non-PostGIS queries), `backend/src/services/ai/learnedRulesService.ts` used raw `pool.query()` for plain CRUD on `ai_learned_rules`. This PR moves the 6 read/write call sites (`getRules`, `getAllRules`, `addRule`, `deleteRule`, `updateRuleText`, `deleteRules`) to Drizzle.

**Schema addition.** The issue body claimed an existing `aiLearnedRules` schema definition in `backend/src/db/schema.ts`, but it wasn't there — the prior service was talking to raw SQL only. Added the table to the schema, matching `db/init/01-schema.sql` exactly:

- `serial` id PK
- `varchar(100)` feature notnull
- `text` rule_text notnull
- `text` context nullable
- `timestamptz` created_at default NOW()
- `btree` index on feature (`idx_ai_learned_rules_feature`)

Followed the same `pgTable(name, columns, (table) => ({ ... }))` callback signature the rest of `schema.ts` uses (TypeScript flags this signature as deprecated repo-wide; migrating all 30+ tables to the new array form is a separate sweep — keeping local consistency was the right call here).

**Date handling.** A shared `toLearnedRule(row)` helper centralises row → public `LearnedRule` mapping so the `createdAt`-as-ISO-string contract stays consistent across every CRUD function. Drizzle returns `Date | null`; we coerce `null → new Date()` defensively (in practice the column has a default of NOW(), so it shouldn't be null on a freshly inserted row — but the guard protects against future schema relaxation).

**No call site changes.** Every public signature (`getRules`, `getAllRules`, `addRule`, `updateRuleText`, `deleteRule`, `deleteRules`, `buildLearnedRulesPrompt`, `PREDEFINED_RULES`) keeps the same shape and return contract. Callers in `aiController.ts`, `wikivoyageExtractController.ts`, `ruleReviewService.ts`, `aiRegionParser.ts`, and `aiInterviewer.ts` see no behavior change.

## Related Issues
Closes: #364

## How Was This Tested?

- **End-to-end against test-db** (temporary script, now cleaned up). 13 scenarios all pass with the new Drizzle code path:
  - empty `getRules`
  - `addRule` with context, `addRule` without context (→ `null`)
  - `getRules` returns insertion order
  - `getAllRules` contains the test rules
  - `updateRuleText` persists, `updateRuleText` on missing id → `false`
  - `deleteRule` returns `true`/`false` correctly
  - `deleteRules` empty short-circuit, bulk delete with one valid + one missing → count 1
  - `buildLearnedRulesPrompt` empty path → empty string
  - `buildLearnedRulesPrompt` with content includes header + rule text

- `npm run check` — passes (exit 0).
- `TEST_REPORT_LOCAL=1 npm test` — 337/337 pass (no new tests added; the existing suite covers callers indirectly, and the e2e script above directly verified CRUD parity).
- `npm run test:py` — 1/1 pass.
- `/security-check` — no findings.

## Checklist
- [x] Commit messages follow the standard template.
- [x] All commits are signed.
- [x] Related issues are mentioned in the description above.
- [x] Linter checks have been passed.

## Additional Comments

No DB migration needed — this PR only changes how the service queries an existing table. The SQL schema for `ai_learned_rules` is unchanged in `db/init/01-schema.sql`; the Drizzle definition in `db/schema.ts` is a faithful mirror.

The TypeScript "deprecated `pgTable` signature" warnings on the new table are pre-existing across the repo (every table in `schema.ts` uses the old callback form). Following the local convention; the project-wide migration to the new array form is out of scope.