### PR TITLE
fix(a11y): make "Try wider" a focusable interactive control (#348)

### DIFF
--- a/frontend/src/components/admin/TreeNodeActions.tsx
+++ b/frontend/src/components/admin/TreeNodeActions.tsx
@@ -2,6 +2,7 @@ import {
   Box,
   Chip,
   IconButton,
+  Link,
   Typography,
   CircularProgress,
 } from '@mui/material';
@@ -186,9 +187,14 @@ function SearchActionButtons({ nodeId, wikidataId, nodeGeocodeMsg, nodeGeocodeNe
             {nodeGeocodeMsg}
           </Typography>
           {nodeGeocodeNextScope && (
-            <Typography
+            // component="button" → real <button> in the tab order, native
+            // focus ring + Enter/Space activation. sx resets the button
+            // defaults (background/border/padding/font) so the inline-link
+            // look (underlined caption, primary colour, hover) is preserved.
+            <Link
+              component="button"
+              type="button"
               variant="caption"
-              component="span"
               onClick={() => {
                 const retry = nodeGeocodeRetryType === 'point' ? onPointMatch : onGeoshapeMatch;
                 retry(nodeId, nodeGeocodeNextScope.ancestorId);
@@ -198,11 +204,16 @@ function SearchActionButtons({ nodeId, wikidataId, nodeGeocodeMsg, nodeGeocodeNe
                 color: 'primary.main',
                 cursor: 'pointer',
                 textDecoration: 'underline',
+                background: 'none',
+                border: 0,
+                padding: 0,
+                font: 'inherit',
+                lineHeight: 'inherit',
                 '&:hover': { color: 'primary.dark' },
               }}
             >
               Try wider: {nodeGeocodeNextScope.ancestorName}
-            </Typography>
+            </Link>
           )}
         </Box>
       )}


### PR DESCRIPTION
## Description

The fallback "Try wider: <ancestor>" link in the WorldView import review tree (`frontend/src/components/admin/TreeNodeActions.tsx`, now line 189 after refactor — was line 123 when the issue was filed) was rendered as a clickable `Typography component="span"`:

```tsx
<Typography
  variant="caption"
  component="span"
  onClick={() => { … }}
  sx={{ … cursor: 'pointer', textDecoration: 'underline' … }}
>
  Try wider: {nodeGeocodeNextScope.ancestorName}
</Typography>
```

No `tabIndex`, no `role`, no `onKeyDown` — mouse-clickable only. Keyboard users (including screen-reader users) were blocked from the fallback re-scope path entirely.

**Fix.** Switched to MUI `Link component="button" type="button"`. That renders a real `<button>` element, which:

- sits in the tab order natively (no manual `tabIndex={0}`),
- gets the default focus ring,
- activates on Enter and Space without needing a custom `onKeyDown` handler,
- carries the right ARIA role.

The `sx` block preserves the existing visual treatment (0.65 rem caption, `primary.main` underlined text, `primary.dark` hover) and resets the button-default styles that would otherwise conflict with the inline-link look (`background`, `border`, `padding`, `font`, `line-height`).

## Related Issues
Closes: #348

## How Was This Tested?

- **Validation against current code first** (per project rule): confirmed the bug is still live in `TreeNodeActions.tsx:189`. The issue body cited line 123, but the file got refactored in the meantime; the same Typography-with-onClick pattern just moved.
- `npm run check` — passes (exit 0).
- `TEST_REPORT_LOCAL=1 npm test` — 337/337 pass (no new tests added; this is a structural swap with no logic change. The component-level test infra exists but adding a focused a11y test for one MUI element would be more ceremony than signal; manual keyboard validation in the running app is the right check).
- `npm run test:py` — 1/1 pass.
- `/security-check` — no findings on the single changed file.
- Manual a11y verification still pending: in the admin import review tree, after a geocode/geoshape mismatch surfaces the "Try wider" suggestion, tab to the link, press Enter (and separately Space) — both should fire the re-scoped retry. Focus ring should be visible.

## Checklist
- [x] Commit messages follow the standard template.
- [x] All commits are signed.
- [x] Related issues are mentioned in the description above.
- [x] Linter checks have been passed.

## Additional Comments

**Same anti-pattern still exists at a handful of other call sites in this file** (e.g. lines 361, 364, 660 — Typography spans with `onClick` for status messages). Out of scope for this PR per the issue body's note: "broader a11y story for the admin import UI deserves a focused pass rather than a one-off swap here". Worth a separate sweep that walks every `Typography` + `onClick` in `frontend/src/components/admin/` and converts each per the same pattern.