### PR TITLE
fix(cv-python): apply Debian security patches at image build time

### DIFF
--- a/cv-python/Dockerfile
+++ b/cv-python/Dockerfile
@@ -1,4 +1,8 @@
 FROM python:3.12-slim
+# Pull Debian security patches at build time so the image isn't pinned to
+# whatever package set Docker Hub last baked into python:3.12-slim. See #393.
+RUN apt-get update && apt-get upgrade -y \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt


### PR DESCRIPTION
## Description

`cv-python/Dockerfile` bases on `python:3.12-slim`, an unpinned tag. Docker Hub does not rebuild it on every Debian security advisory, so there are regular windows where the published image contains Debian packages with known upstream fixes that aren't yet baked in. During those windows the `Trivy Image Scan (cv-python)` job fails on every PR, regardless of whether the PR touched the Dockerfile.

Today's exhibit: PR #391 (a Python-only change in `match.py`) was blocked by `CVE-2026-4878` (libcap2 TOCTOU privilege escalation, HIGH) and `CVE-2026-29111` (libsystemd0 RCE/DoS). Both have Debian fixes (`1:2.75-10+deb13u1`, `257.13-1~deb13u1`) in the trixie security stream, but Docker Hub's `python:3.12-slim` was last pushed 2026-05-13 and predates the advisories.

This PR adds an `apt-get update && apt-get upgrade -y` layer (with cleanup in the same `RUN` so the apt cache doesn't bloat the image) right after `FROM`, so Debian security patches are applied at build time independently of the base tag's freshness. `ignore-unfixed: true` is already set on the Trivy action, so the scan goes green once the upgrade applies the fix.

The two alternatives considered and rejected:
- **`.trivyignore` for the two CVEs** — defers the same class of failure to the next Debian advisory; suppresses real, fixed-upstream CVEs. Was attempted on #391 and reverted; the tracking ticket (#392) is closed as superseded.
- **Pin the base by digest** — no current `python:3.12-slim*` digest contains the patches (newest pushed 2026-05-13), so pinning today gives the same vulnerable image. A digest-pin + renovate-bot strategy is complementary and worth a separate ADR if anyone wants reproducibility on top of this; tracked as a future improvement, not in scope here.

## Related Issues

Closes: #393

## How Was This Tested?

- **Static review of the Dockerfile change** — single 4-line edit; standard OWASP Docker hardening pattern (combined `update && upgrade && clean && rm -rf /var/lib/apt/lists/*` in one `RUN` layer).
- **Local `npm run security:image` skipped** — Docker daemon isn't accessible from the authoring shell (user not in `docker` group) and podman couldn't pull from docker.io without re-auth in this environment.
- **Local `npm run lint:docker` (hadolint) skipped** — same reason; same image-pull restriction.
- **CI `Trivy Image Scan (cv-python)` on this PR is the meaningful validator** — both `CVE-2026-4878` and `CVE-2026-29111` should be absent from the report once the upgrade step pulls patched packages. The `Build` and `Python Tests (cv-python)` jobs verify no behavioural regression.

## Checklist

- [x] Commit messages follow the standard template.
- [x] All commits are signed.
- [x] Related issues are mentioned in the description above.
- [ ] Linter checks have been passed. — `lint:docker` (hadolint) couldn't be run locally; CI's `Lint & Type Check` job covers it.

## Additional Comments

Trade-offs:
- **+** Closes the "base-tag-staleness" CI-failure class going forward — any future Debian advisory with an upstream fix will be picked up at the next build instead of red-flagging unrelated PRs.
- **+** More deterministic security posture (image is always patched at build time vs. "whenever Docker Hub last rebuilt").
- **−** +30–60s on cold-cache builds; slightly larger image (handful of MB).

Follow-up after this merges: rebase #391 onto main so its `Trivy Image Scan` picks up the fix.