### PR TITLE
fix(deps): bump starlette + qs/express to close active CVEs

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,7 +15,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "drizzle-orm": "^0.45.2",
-        "express": "^4.21.0",
+        "express": "^4.22.2",
         "express-async-errors": "^3.1.1",
         "express-rate-limit": "^8.5.1",
         "helmet": "^8.0.0",
@@ -4365,9 +4365,9 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -4378,7 +4378,7 @@
         "http-errors": "~2.0.1",
         "iconv-lite": "~0.4.24",
         "on-finished": "~2.4.1",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
         "unpipe": "~1.0.0"
@@ -4970,9 +4970,9 @@
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -5336,14 +5336,14 @@
       }
     },
     "node_modules/express": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
+        "body-parser": "~1.20.5",
         "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
         "cookie": "~0.7.1",
@@ -5362,7 +5362,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "~0.19.0",
@@ -5826,9 +5826,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -6984,9 +6984,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -7411,13 +7411,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"

--- a/backend/package.json
+++ b/backend/package.json
@@ -25,7 +25,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "drizzle-orm": "^0.45.2",
-    "express": "^4.21.0",
+    "express": "^4.22.2",
     "express-async-errors": "^3.1.1",
     "express-rate-limit": "^8.5.1",
     "helmet": "^8.0.0",

--- a/cv-python/requirements.txt
+++ b/cv-python/requirements.txt
@@ -1,8 +1,11 @@
-# fastapi >=0.124.0 is the minimum that allows starlette>=0.49.1, which closes
-# GHSA-2c2j-9gv5-cj73 (fixed in starlette 0.47.2) and GHSA-7f5h-v6xp-fcq8
-# (fixed in starlette 0.49.1). Upgrade if newer GHSAs land via pip-audit.
-fastapi==0.124.0
-starlette==0.49.1
+# fastapi >=0.134.0 is the minimum that allows starlette>=1.0.1, which closes
+# GHSA-86qp-5c8j-p5mr / PYSEC-2026-161 (Host header validation bypass) on top
+# of the earlier GHSA-2c2j-9gv5-cj73 and GHSA-7f5h-v6xp-fcq8 fixes.
+# Upgrade if newer GHSAs land via pip-audit.
+# Stay on 0.136.1 — 0.136.3 was flagged MAL-2026-4750 (typosquat `fastar`
+# injected into the [standard] extras group); 0.136.2 was never published.
+fastapi==0.136.1
+starlette==1.0.1
 # uvicorn[standard] >=0.46.0 transitively pulls h11>=0.16.0 (closes the
 # malformed-chunked-encoding CVE in older h11).
 uvicorn[standard]==0.46.0


### PR DESCRIPTION
## Summary
Aggregate two security dependency bumps so CI goes green in a single PR.

**cv-python (`starlette` 0.49.1 → 1.0.1, `fastapi` 0.124.0 → 0.136.1)**
- Closes **PYSEC-2026-161 / GHSA-86qp-5c8j-p5mr** — Starlette reconstructs `request.url.path` from an unvalidated `Host` header, so a crafted `Host` can inject path segments that bypass path-based auth/security checks while routing still uses the real path.
- `fastapi` 0.124.0 caps starlette at `<0.51.0`; 0.134.0 is the first release that allows starlette 1.0+. Pinned to `0.136.1` because **0.136.3 is flagged MAL-2026-4750** (typosquat `fastar` injected into the `[standard]` extras group) and **0.136.2 was never published**.

**backend (`qs` 6.14.2 → 6.15.2, `express` 4.22.1 → 4.22.2)**
- Closes **GHSA-q8mj-m7cp-5q26** — `qs.stringify` crashes with `TypeError` on null/undefined entries in `arrayFormat: 'comma'` + `encodeValuesOnly` (remotely triggerable DoS).
- Cherry-picked from Dependabot PR #395 (which can be closed once this lands). Express 4.22.2 also restores `>20` array parsing for `req.query` repeated keys.

## Test plan
- [x] cv-python: `pip-audit -r requirements.txt` → no known vulnerabilities
- [x] cv-python: `pytest` → 1 passed (FastAPI app imports/starts on new pins)
- [x] cv-python: `ruff check`, `ruff format --check`, `mypy app` → clean
- [x] backend: no direct `qs` import; `express` is a patch bump (no API changes)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)