### PR TITLE
back: Reuse duplicate sibling regions on Wikivoyage import.

### DIFF
--- a/backend/src/services/worldViewImport/importer.test.ts
+++ b/backend/src/services/worldViewImport/importer.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest';
+import { insertRegion } from './importer.js';
+import type { ImportProgress, ImportTreeNode } from './types.js';
+
+/** Minimal ImportProgress for exercising insertRegion in isolation. */
+function makeProgress(): ImportProgress {
+  return { createdRegions: 0, totalRegions: 0, cancel: false } as unknown as ImportProgress;
+}
+
+describe('insertRegion duplicate-sibling resilience', () => {
+  it('uses ON CONFLICT find-or-reuse and records import state for fresh regions', async () => {
+    const query = vi.fn(async (sql: string) =>
+      sql.includes('INSERT INTO regions')
+        ? { rows: [{ id: 10, inserted: true }] }
+        : { rows: [] },
+    );
+    const progress = makeProgress();
+    const tree: ImportTreeNode = { name: 'A', children: [{ name: 'B', children: [] }] };
+
+    await insertRegion({ query } as never, tree, 1, null, 99, progress);
+
+    const sqls = query.mock.calls.map((c) => String(c[0]));
+    // The region INSERT must be a find-or-reuse against the partial unique index.
+    expect(
+      sqls.some(
+        (s) =>
+          s.includes('INSERT INTO regions') &&
+          s.includes('ON CONFLICT') &&
+          s.includes('parent_region_id IS NOT NULL'),
+      ),
+    ).toBe(true);
+    // Fresh regions get an import-state row and are counted.
+    expect(sqls.filter((s) => s.includes('region_import_state')).length).toBe(2);
+    expect(progress.createdRegions).toBe(2);
+  });
+
+  it('reuses a duplicate sibling without re-inserting import state, still merging its subtree', async () => {
+    let firstRegionInsert = true;
+    const query = vi.fn(async (sql: string) => {
+      if (sql.includes('INSERT INTO regions')) {
+        if (firstRegionInsert) {
+          firstRegionInsert = false;
+          return { rows: [{ id: 10, inserted: false }] }; // duplicate sibling → reused
+        }
+        return { rows: [{ id: 11, inserted: true }] }; // its child → fresh
+      }
+      return { rows: [] };
+    });
+    const progress = makeProgress();
+    const tree: ImportTreeNode = {
+      name: 'Eastern Andino',
+      children: [{ name: 'Child', children: [] }],
+    };
+
+    await insertRegion({ query } as never, tree, 2, 3120, 99, progress);
+
+    const sqls = query.mock.calls.map((c) => String(c[0]));
+    // The reused parent must NOT get a duplicate import-state row; only the fresh child does.
+    expect(sqls.filter((s) => s.includes('region_import_state')).length).toBe(1);
+    // Only the fresh child is counted, not the reused parent.
+    expect(progress.createdRegions).toBe(1);
+    // The child INSERT still ran (subtree merged under the reused region).
+    expect(sqls.filter((s) => s.includes('INSERT INTO regions')).length).toBe(2);
+  });
+});

--- a/backend/src/services/worldViewImport/importer.ts
+++ b/backend/src/services/worldViewImport/importer.ts
@@ -118,7 +118,19 @@ export async function importTree(
   }
 }
 
-async function insertRegion(
+/**
+ * Insert a region node and recurse into its subtree under `parentRegionId`.
+ *
+ * Find-or-create: a duplicate sibling name reuses the existing region and merges
+ * this node's subtree under it, rather than violating the
+ * `idx_regions_unique_subregion_name` unique index and rolling back the whole
+ * import (the extractor can emit the same sibling twice — see #378, which moved
+ * the find-or-create path to ON CONFLICT but missed this one). Only freshly
+ * created regions get a `region_import_state` row and advance the progress
+ * counter; root rows (NULL parent) are exempt from the partial index, so
+ * duplicate root names still insert.
+ */
+export async function insertRegion(
   client: PoolClient,
   node: ImportTreeNode,
   worldViewId: number,
@@ -128,42 +140,52 @@ async function insertRegion(
 ): Promise<void> {
   if (progress.cancel) return;
 
-  // Insert region (no metadata JSONB needed)
+  // `inserted` (xmax = 0) is true only for a freshly created row.
   const result = await client.query(
     `INSERT INTO regions (world_view_id, name, parent_region_id)
-     VALUES ($1, $2, $3) RETURNING id`,
+     VALUES ($1, $2, $3)
+     ON CONFLICT (world_view_id, parent_region_id, name) WHERE parent_region_id IS NOT NULL
+     DO UPDATE SET name = regions.name
+     RETURNING id, (xmax = 0) AS inserted`,
     [worldViewId, node.name, parentRegionId],
   );
   const regionId = result.rows[0].id as number;
+  const inserted = result.rows[0].inserted as boolean;
 
-  const sourceUrl = node.sourceUrl ?? null;
+  if (inserted) {
+    const sourceUrl = node.sourceUrl ?? null;
 
-  // Insert region_import_state
-  await client.query(
-    `INSERT INTO region_import_state (region_id, import_run_id, source_url, source_external_id, region_map_url)
-     VALUES ($1, $2, $3, $4, $5)`,
-    [regionId, importRunId, sourceUrl, node.wikidataId || null, node.regionMapUrl || null],
-  );
+    // Insert region_import_state
+    await client.query(
+      `INSERT INTO region_import_state (region_id, import_run_id, source_url, source_external_id, region_map_url)
+       VALUES ($1, $2, $3, $4, $5)`,
+      [regionId, importRunId, sourceUrl, node.wikidataId || null, node.regionMapUrl || null],
+    );
 
-  // Insert map image candidates
-  if (node.mapImageCandidates?.length) {
-    for (const imageUrl of node.mapImageCandidates) {
-      await client.query(
-        `INSERT INTO region_map_images (region_id, image_url) VALUES ($1, $2)`,
-        [regionId, imageUrl],
-      );
+    // Insert map image candidates
+    if (node.mapImageCandidates?.length) {
+      for (const imageUrl of node.mapImageCandidates) {
+        await client.query(
+          `INSERT INTO region_map_images (region_id, image_url) VALUES ($1, $2)`,
+          [regionId, imageUrl],
+        );
+      }
     }
+
+    progress.createdRegions++;
+    if (progress.createdRegions % 500 === 0) {
+      console.log(`[WV Importer] Progress: ${progress.createdRegions}/${progress.totalRegions} regions created`);
+    }
+    if (progress.createdRegions % 100 === 0) {
+      progress.statusMessage = `Creating regions... ${progress.createdRegions}/${progress.totalRegions}`;
+    }
+  } else {
+    console.warn(
+      `[WV Importer] Duplicate sibling "${node.name}" under parent ${parentRegionId} — reusing region ${regionId} and merging its subtree.`,
+    );
   }
 
-  progress.createdRegions++;
-  if (progress.createdRegions % 500 === 0) {
-    console.log(`[WV Importer] Progress: ${progress.createdRegions}/${progress.totalRegions} regions created`);
-  }
-  if (progress.createdRegions % 100 === 0) {
-    progress.statusMessage = `Creating regions... ${progress.createdRegions}/${progress.totalRegions}`;
-  }
-
-  // Recurse into children
+  // Recurse into children (merging a duplicate's subtree under the reused region)
   for (const child of node.children) {
     if (progress.cancel) return;
     await insertRegion(client, child, worldViewId, regionId, importRunId, progress);


### PR DESCRIPTION
## Description
The WorldView importer (`insertRegion`) inserted every tree node with a raw `INSERT`, so when the Wikivoyage extractor emits two sibling regions with the same name under one parent, the second violates the `idx_regions_unique_subregion_name` unique index and the **entire import transaction rolls back** — discarding the whole extraction (one run lost ~3,200 regions after hours of AI + Wikidata work to a single `Eastern Andino` duplicate).

This is a **regression from #378**, which replaced the `ensureSubregion` advisory lock with a unique index + `ON CONFLICT` find-or-create but did not update `insertRegion`. Before #378 the advisory-lock path merged duplicate siblings; after it, the importer's raw insert violates the new constraint.

The fix brings `insertRegion` in line with the #378 pattern: `INSERT … ON CONFLICT (world_view_id, parent_region_id, name) WHERE parent_region_id IS NOT NULL DO UPDATE SET name = regions.name RETURNING id, (xmax = 0) AS inserted`. A duplicate sibling **reuses** the existing region and merges its subtree under it; `region_import_state` rows and the progress counter are written only for freshly-created regions. Root regions (NULL parent) are exempt from the partial index, so duplicate root names still insert as before.

## Related Issues
None (regression introduced by #378).

## How Was This Tested?
- New `importer.test.ts` (2 tests): the fresh-insert path (uses `ON CONFLICT`, writes import-state, counts progress) and the duplicate-sibling path (reuses the region, no duplicate import-state, still inserts the child subtree). TDD — red before the fix, green after.
- Validated the exact SQL against the live schema in a rolled-back transaction: duplicate root names both insert; a duplicate non-root sibling reuses the existing id.
- Full backend suite: **219/219 pass**; `tsc --noEmit` clean.

## Checklist
- [x] Commit messages follow the standard template (`<Type>: <Topic>` + body wrapped at 72, `-s` sign-off).
- [x] All commits are signed.
- [x] Related issues are mentioned in the description above.
- [x] Linter checks have been passed (`tsc`, backend tests; backend-only TypeScript change).

## Additional Comments (if any):
Follow-up worth considering (not in this PR): the import is still all-or-nothing, so an unrelated error would still discard a long run, and re-running re-incurs the Wikidata-enrichment phase unless fully cached. Making the import resumable / validating the tree up front would harden it further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
