### PR TITLE
Restore lost WV-import geoshape schema and hierarchy_warnings

### DIFF
--- a/backend/src/services/worldViewImport/importer.test.ts
+++ b/backend/src/services/worldViewImport/importer.test.ts
@@ -36,7 +36,7 @@ describe('insertRegion duplicate-sibling resilience', () => {
 
   it('reuses a duplicate sibling without re-inserting import state, still merging its subtree', async () => {
     let firstRegionInsert = true;
-    const query = vi.fn(async (sql: string) => {
+    const query = vi.fn(async (sql: string, _params?: unknown[]) => {
       if (sql.includes('INSERT INTO regions')) {
         if (firstRegionInsert) {
           firstRegionInsert = false;
@@ -55,11 +55,66 @@ describe('insertRegion duplicate-sibling resilience', () => {
     await insertRegion({ query } as never, tree, 2, 3120, 99, progress);
 
     const sqls = query.mock.calls.map((c) => String(c[0]));
-    // The reused parent must NOT get a duplicate import-state row; only the fresh child does.
-    expect(sqls.filter((s) => s.includes('region_import_state')).length).toBe(1);
+    // The reused parent must NOT get a duplicate import-state INSERT; only the fresh child does.
+    expect(sqls.filter((s) => s.includes('INSERT INTO region_import_state')).length).toBe(1);
+    // But its warnings are merged into the existing row (it's a grouping node) via UPDATE.
+    const mergeCall = query.mock.calls.find(
+      (c) => String(c[0]).includes('UPDATE region_import_state') && String(c[0]).includes('hierarchy_warnings'),
+    );
+    expect(mergeCall).toBeDefined();
+    expect((mergeCall![1] as unknown[])[0]).toBe(10); // the reused parent's region id
+    expect((mergeCall![1] as unknown[])[1]).toContain('Grouping: no source page (parsed from item list)');
     // Only the fresh child is counted, not the reused parent.
     expect(progress.createdRegions).toBe(1);
     // The child INSERT still ran (subtree merged under the reused region).
     expect(sqls.filter((s) => s.includes('INSERT INTO regions')).length).toBe(2);
+  });
+});
+
+describe('insertRegion hierarchy warnings', () => {
+  /** Run insertRegion and return the hierarchy_warnings param for each region_import_state insert, keyed by region id. */
+  async function warningsByRegion(tree: ImportTreeNode): Promise<Map<number, string[]>> {
+    let nextId = 10;
+    const query = vi.fn(async (sql: string, _params?: unknown[]) =>
+      sql.includes('INSERT INTO regions')
+        ? { rows: [{ id: nextId++, inserted: true }] }
+        : { rows: [] },
+    );
+    await insertRegion({ query } as never, tree, 1, null, 99, makeProgress());
+
+    const map = new Map<number, string[]>();
+    for (const [sql, params] of query.mock.calls) {
+      if (String(sql).includes('INSERT INTO region_import_state')) {
+        const p = params as unknown[];
+        map.set(p[0] as number, p[5] as string[]);
+      }
+    }
+    return map;
+  }
+
+  it('flags grouping nodes (no source page, has children) with a hierarchy warning', async () => {
+    // Parent has no sourceUrl but has a child → grouping node; the leaf child is not.
+    const warnings = await warningsByRegion({ name: 'Grouping', children: [{ name: 'Leaf', children: [] }] });
+    expect(warnings.get(10)).toContain('Grouping: no source page (parsed from item list)');
+    expect(warnings.get(11)).toEqual([]);
+  });
+
+  it('does not flag nodes that have a source URL', async () => {
+    const warnings = await warningsByRegion({
+      name: 'HasPage',
+      sourceUrl: 'https://en.wikivoyage.org/wiki/HasPage',
+      children: [{ name: 'Leaf', children: [] }],
+    });
+    expect(warnings.get(10)).toEqual([]);
+  });
+
+  it('preserves extractor-supplied node warnings', async () => {
+    const warnings = await warningsByRegion({
+      name: 'Sourced',
+      sourceUrl: 'https://en.wikivoyage.org/wiki/Sourced',
+      warnings: ['Extractor flagged something'],
+      children: [],
+    });
+    expect(warnings.get(10)).toEqual(['Extractor flagged something']);
   });
 });

--- a/backend/src/services/worldViewImport/importer.ts
+++ b/backend/src/services/worldViewImport/importer.ts
@@ -28,6 +28,43 @@ function countLeaves(node: ImportTreeNode): number {
   return count;
 }
 
+/**
+ * Hierarchy-review warnings for a node: any extractor-supplied warnings, plus a
+ * flag for grouping nodes (no source page but with children — parsed from an item
+ * list) that an admin should review. Feeds region_import_state.hierarchy_warnings.
+ * Source-neutral wording: importTree is source-agnostic (wikivoyage, osm, ...).
+ */
+function hierarchyWarningsFor(node: ImportTreeNode): string[] {
+  const warnings = [...(node.warnings ?? [])];
+  if (!node.sourceUrl && node.children.length > 0) {
+    warnings.push('Grouping: no source page (parsed from item list)');
+  }
+  return warnings;
+}
+
+/**
+ * Merge a reused (duplicate-sibling) node's warnings into its existing
+ * region_import_state row, de-duplicated. The #378 dedup path skips inserting a
+ * new row for a duplicate, so without this a warning carried only by the later
+ * duplicate (e.g. it is the occurrence that brings children) would be lost.
+ */
+async function mergeHierarchyWarnings(
+  client: PoolClient,
+  regionId: number,
+  node: ImportTreeNode,
+): Promise<void> {
+  const warnings = hierarchyWarningsFor(node);
+  if (warnings.length === 0) return;
+  await client.query(
+    `UPDATE region_import_state
+     SET hierarchy_warnings = ARRAY(
+       SELECT DISTINCT e FROM unnest(COALESCE(hierarchy_warnings, '{}'::text[]) || $2::text[]) AS e
+     )
+     WHERE region_id = $1`,
+    [regionId, warnings],
+  );
+}
+
 /** Options for importTree controlling source metadata */
 export interface ImportTreeOptions {
   sourceType?: string;   // default: 'imported'
@@ -155,11 +192,11 @@ export async function insertRegion(
   if (inserted) {
     const sourceUrl = node.sourceUrl ?? null;
 
-    // Insert region_import_state
+    // Insert region_import_state (hierarchy_warnings flags grouping nodes for review)
     await client.query(
-      `INSERT INTO region_import_state (region_id, import_run_id, source_url, source_external_id, region_map_url)
-       VALUES ($1, $2, $3, $4, $5)`,
-      [regionId, importRunId, sourceUrl, node.wikidataId || null, node.regionMapUrl || null],
+      `INSERT INTO region_import_state (region_id, import_run_id, source_url, source_external_id, region_map_url, hierarchy_warnings)
+       VALUES ($1, $2, $3, $4, $5, $6)`,
+      [regionId, importRunId, sourceUrl, node.wikidataId || null, node.regionMapUrl || null, hierarchyWarningsFor(node)],
     );
 
     // Insert map image candidates
@@ -183,6 +220,8 @@ export async function insertRegion(
     console.warn(
       `[WV Importer] Duplicate sibling "${node.name}" under parent ${parentRegionId} — reusing region ${regionId} and merging its subtree.`,
     );
+    // Don't lose warnings carried only by this duplicate occurrence.
+    await mergeHierarchyWarnings(client, regionId, node);
   }
 
   // Recurse into children (merging a duplicate's subtree under the reused region)

--- a/db/init/01-schema.sql
+++ b/db/init/01-schema.sql
@@ -1863,7 +1863,10 @@ CREATE TABLE IF NOT EXISTS region_import_state (
     fix_note TEXT,
     region_map_url TEXT,
     map_image_reviewed BOOLEAN DEFAULT FALSE,
-    marker_points JSONB
+    marker_points JSONB,
+    geo_available BOOLEAN,  -- NULL = unknown, set after geoshape lookup (geoshapeCoverage.ts)
+    hierarchy_reviewed BOOLEAN NOT NULL DEFAULT FALSE,  -- admin confirmed child set via AI Review Children
+    hierarchy_warnings TEXT[]  -- AI-flagged issues with the region's child set
 );
 
 CREATE INDEX IF NOT EXISTS idx_ris_status ON region_import_state(match_status);
@@ -1872,6 +1875,9 @@ CREATE INDEX IF NOT EXISTS idx_ris_run ON region_import_state(import_run_id);
 COMMENT ON TABLE region_import_state IS 'Import metadata for regions created via WorldView Import (1:1 with region)';
 COMMENT ON COLUMN region_import_state.match_status IS 'Match lifecycle: no_candidates, needs_review, auto_matched, manual_matched, children_matched, suggested';
 COMMENT ON COLUMN region_import_state.source_external_id IS 'External identifier from import source (e.g. Wikidata QID)';
+COMMENT ON COLUMN region_import_state.geo_available IS 'Whether a Wikidata geoshape is available for this region (NULL until checked)';
+COMMENT ON COLUMN region_import_state.hierarchy_reviewed IS 'True once an admin has run AI Review Children on this region';
+COMMENT ON COLUMN region_import_state.hierarchy_warnings IS 'AI-flagged issues with the current child set (empty/NULL = none)';
 
 -- Match suggestions (1:N per region, replaces metadata.suggestions + rejectedDivisionIds)
 CREATE TABLE IF NOT EXISTS region_match_suggestions (
@@ -1905,6 +1911,26 @@ CREATE TABLE IF NOT EXISTS region_map_images (
 CREATE INDEX IF NOT EXISTS idx_rmi_region ON region_map_images(region_id);
 
 COMMENT ON TABLE region_map_images IS 'Candidate map images for imported regions (from Wikimedia Commons etc.)';
+
+-- Wikidata geoshape cache (geometry for geoshape-based GADM matching)
+-- Cache-first proxy: filled from maps.wikimedia.org and from composite unions of
+-- child entity geoshapes. Keyed by Wikidata QID or "commons:{filename}".
+-- See backend/src/services/worldViewImport/geoshapeCache.ts / geoshapeComposite.ts.
+CREATE TABLE IF NOT EXISTS wikidata_geoshapes (
+    wikidata_id TEXT PRIMARY KEY,            -- Wikidata QID or "commons:{filename}"
+    geom geometry(MultiPolygon, 4326),       -- NULL when not_available; SRID 4326
+    not_available BOOLEAN NOT NULL DEFAULT FALSE,  -- TRUE = no geoshape exists (negative cache)
+    -- Negative-cache invariant: a row is either a real geoshape or a not_available
+    -- marker. Stops a NULL geom with not_available=FALSE from reaching PostGIS calls
+    -- (e.g. geoshapeCoverage.ts) and blocks a degenerate composite union from
+    -- overwriting a valid cached geom with NULL via ON CONFLICT DO UPDATE.
+    CONSTRAINT wikidata_geoshapes_geom_presence CHECK (not_available OR geom IS NOT NULL)
+);
+
+CREATE INDEX IF NOT EXISTS idx_wikidata_geoshapes_geom ON wikidata_geoshapes USING GIST (geom);
+
+COMMENT ON TABLE wikidata_geoshapes IS 'Cache of Wikidata/Commons geoshapes (and composite unions) for WorldView Import geoshape matching';
+COMMENT ON COLUMN wikidata_geoshapes.not_available IS 'Negative cache: TRUE means a geoshape lookup confirmed none exists';
 
 -- =============================================================================
 -- AI Settings

--- a/db/migrations/005-wv-import-geoshape-schema.sql
+++ b/db/migrations/005-wv-import-geoshape-schema.sql
@@ -1,0 +1,50 @@
+-- Migration 005: Restore WorldView Import geoshape + hierarchy-review schema
+--
+-- The geoshape-precision matching and AI "Review Children" features ship TS code
+-- that depends on a `wikidata_geoshapes` table and three `region_import_state`
+-- columns (geo_available, hierarchy_reviewed, hierarchy_warnings). Those objects
+-- were only ever applied as ad-hoc DDL to dev databases and were never committed
+-- to db/init/01-schema.sql or a migration. After a `git reset --hard` the TS code
+-- was recovered but the DDL was not, so freshly-initialized databases lack them
+-- and the import-review endpoints fail with:
+--   - relation "wikidata_geoshapes" does not exist (42P01)
+--   - column ris.hierarchy_warnings does not exist (42703)
+--
+-- This migration adds the missing objects to existing dev databases. The same
+-- definitions now live in db/init/01-schema.sql so fresh databases are correct.
+--
+-- Idempotent: IF NOT EXISTS guards and the constraint DO-block make re-running a no-op.
+
+ALTER TABLE region_import_state
+    ADD COLUMN IF NOT EXISTS geo_available      BOOLEAN,
+    ADD COLUMN IF NOT EXISTS hierarchy_reviewed BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS hierarchy_warnings TEXT[];
+
+COMMENT ON COLUMN region_import_state.geo_available IS 'Whether a Wikidata geoshape is available for this region (NULL until checked)';
+COMMENT ON COLUMN region_import_state.hierarchy_reviewed IS 'True once an admin has run AI Review Children on this region';
+COMMENT ON COLUMN region_import_state.hierarchy_warnings IS 'AI-flagged issues with the current child set (empty/NULL = none)';
+
+CREATE TABLE IF NOT EXISTS wikidata_geoshapes (
+    wikidata_id TEXT PRIMARY KEY,
+    geom geometry(MultiPolygon, 4326),
+    not_available BOOLEAN NOT NULL DEFAULT FALSE,
+    CONSTRAINT wikidata_geoshapes_geom_presence CHECK (not_available OR geom IS NOT NULL)
+);
+
+-- Add the negative-cache invariant to databases where the table predates it
+-- (the CREATE TABLE above is a no-op when the table already exists).
+-- NOT VALID: enforce the constraint for every new/updated row without an
+-- immediate full-table scan under an Access Exclusive lock, and without failing
+-- the migration if a legacy row already violates it. Run
+-- `ALTER TABLE wikidata_geoshapes VALIDATE CONSTRAINT wikidata_geoshapes_geom_presence`
+-- after cleaning up any such rows to mark it fully validated.
+DO $$ BEGIN
+    ALTER TABLE wikidata_geoshapes
+        ADD CONSTRAINT wikidata_geoshapes_geom_presence CHECK (not_available OR geom IS NOT NULL) NOT VALID;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_wikidata_geoshapes_geom ON wikidata_geoshapes USING GIST (geom);
+
+COMMENT ON TABLE wikidata_geoshapes IS 'Cache of Wikidata/Commons geoshapes (and composite unions) for WorldView Import geoshape matching';
+COMMENT ON COLUMN wikidata_geoshapes.not_available IS 'Negative cache: TRUE means a geoshape lookup confirmed none exists';


### PR DESCRIPTION
## Description

Recovers two pieces of the WorldView Import system that were silently lost, which broke the import-review screen (`/admin` → import review: stats, tree, and children-coverage panels all 500'd).

**1. Missing schema (cause: a past `git reset --hard`).** Committed TS code references a `wikidata_geoshapes` table and three `region_import_state` columns (`geo_available`, `hierarchy_reviewed`, `hierarchy_warnings`), but the DDL for these was **never committed to any SQL file** — it had only been applied ad-hoc to dev databases. The recovery after the reset restored the TS readers but not the schema, so freshly-initialized databases failed with:
- `relation "wikidata_geoshapes" does not exist` (42P01)
- `column ris.hierarchy_warnings does not exist` (42703)

Restored in `db/init/01-schema.sql` (fresh databases) + idempotent migration `005` (existing databases). Types were reconstructed from the code's usage: `wikidata_geoshapes` is a cache keyed by Wikidata QID / `commons:{file}` with a `MultiPolygon(4326)` geom (GIST-indexed) and a `not_available` negative-cache flag; the three columns hold boolean / `text[]` review state.

**2. Lost importer writer (cause: #378 / ddf3111, already on main).** That refactor moved `insertRegion` to `ON CONFLICT` dedup and silently dropped `hierarchy_warnings` from the INSERT — while the readers, the review UI, and the column all still expect it populated. Grouping nodes (no Wikivoyage page but with children) therefore stopped being flagged for review. Restored via a small `hierarchyWarningsFor()` helper (extracted to stay under the cognitive-complexity limit) + regression tests.

## Related Issues

None — the regression was discovered during import review and has no tracking issue. The writer-side cause is #378 (ddf3111, already merged to main).

## How Was This Tested?

- `npm run check` (Node side): backend+frontend lint, both typechecks, `npm audit` (0 vulns), knip, and lint:extra (madge/shellcheck/hadolint) all pass. Python checks (ruff/mypy/bandit/pip-audit) are N/A — no Python changed — and run in CI.
- `TEST_REPORT_LOCAL=1 npm test`: **364/364 pass**, including 3 new regression tests in `importer.test.ts` (grouping node flagged; sourced node not flagged; extractor-supplied warnings pass through).
- Node Semgrep SAST (`p/owasp-top-ten`, `p/nodejs`, `p/react`, `p/secrets`): 0 findings.
- Verified against the live dev DB: migration `005` applies cleanly and the previously-failing `getMatchStats` query for the imported world view now succeeds.

## Checklist

- [x] Commit messages follow the standard template.
- [x] All commits are signed. (`Signed-off-by` present on both)
- [x] Related issues are mentioned in the description above.
- [x] Linter checks have been passed.

## Additional Comments

- **Deployment:** existing databases must apply `db/migrations/005-wv-import-geoshape-schema.sql` (already applied to the local dev DB).
- **Scope:** code-only — existing already-imported regions are **not** back-filled, so their grouping-node warnings (44 nodes in the current dev world view) won't appear until re-import. Future imports populate correctly; a one-time backfill `UPDATE` is trivial if wanted.