### PR TITLE
fix(deps): bump react-router-dom to 6.30.4 (patch open redirect GHSA-2j2x-hqr9-3h42)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1414,9 +1414,9 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
-      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
+      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -9197,12 +9197,12 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
-      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
+      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2"
+        "@remix-run/router": "1.23.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -9212,13 +9212,13 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
-      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
+      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2",
-        "react-router": "6.30.3"
+        "@remix-run/router": "1.23.3",
+        "react-router": "6.30.4"
       },
       "engines": {
         "node": ">=14.0.0"


### PR DESCRIPTION
## Description

`react-router` ≤ 6.30.3 is affected by **GHSA-2j2x-hqr9-3h42** (moderate): a same-origin redirect to a path starting with `//` is reinterpreted as a protocol-relative URL, producing an **open redirect**.

`npm audit --audit-level=moderate` flags it, which fails the **`security:deps`** step of `npm run check` — and therefore the **"Lint & Type Check"** CI job — on every branch, `main` included.

### Change
Lockfile-only bump in `frontend/`:
- `react-router` 6.30.3 → **6.30.4**
- `react-router-dom` 6.30.3 → **6.30.4**
- `@remix-run/router` (shared dep) 1.23.2 → **1.23.3**

The existing `^6.28.0` range in `frontend/package.json` already permits 6.30.4, so **no manifest change** is needed — only `package-lock.json` changes (12 lines).

## Related Issues
None. Repo-wide dependency advisory surfaced while triaging CI on #397.

## How Was This Tested?
- `npm audit --audit-level=moderate --omit=dev` (the exact CI gate) → **found 0 vulnerabilities**, exit 0.
- npm resolver re-resolve keeps the bumped entries (integrity hashes are the official registry values from `npm view`), so the lock is installable.

## Checklist
- [x] Commit messages follow the standard template (conventional prefix + body, wrapped at 72).
- [x] All commits are signed (DCO `Signed-off-by`).
- [x] Related issues mentioned above.
- [x] Linter checks passed (the `security:deps` audit this PR fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)