### PR TITLE
Drop restart policy from dev martin and cv-python

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,7 +92,9 @@ services:
       db:
         condition: service_healthy
     command: ["--config", "/config.yaml"]
-    restart: unless-stopped
+    # No restart policy on purpose: with `unless-stopped`, a docker daemon
+    # restart resurrects Martin without the db (which has no policy), causing
+    # an endless crash-loop whose log backlog floods the next `compose up`.
 
   cv-python:
     build:
@@ -111,7 +113,7 @@ services:
       - ./data:/app/data:z
     environment:
       - PYTHONUNBUFFERED=1
-    restart: unless-stopped
+    # No restart policy on purpose — see the note on the martin service.
 
   # One-off GADM loader (GDAL + psycopg2 + dotenv + shapely). Not started by
   # `docker compose up` (tools profile); invoked by `npm run db:load-gadm` via


### PR DESCRIPTION
## Description
With `restart: unless-stopped` on `martin` and `cv-python` — while `db`, `backend`, and `frontend` have no restart policy — a docker daemon restart (e.g. a host reboot) resurrects Martin without its database. Martin then exits every ~60s failing to resolve the `db` host, and Docker restarts it indefinitely.

This actually happened: the dev Martin container accumulated **7,822 restarts over about a week**, and since `docker compose up` replays the full log history of reused containers on attach, the next `npm run dev` flooded the terminal with a week of stale crash-loop errors — making a perfectly healthy startup look broken.

The dev stack is meant to live and die with the interactive `compose up` session, so this drops the restart policies (with an explanatory comment in the compose file) rather than adding one to every service. The production deployment plan (`docs/tech/planning/deployment.md`) applies `unless-stopped` uniformly to all services and is unaffected. `scripts/db-cli.sh` restarts Martin via `docker compose restart`, which works regardless of restart policy.

## Related Issues
None

## How Was This Tested?
- `docker compose config` validates; no `restart:` keys remain in the rendered config.
- Live smoke test: full stack up from `docker compose up`, all services healthy in ~16s (backend `/health`, Martin `/catalog`, Vite on :5173 all responding), then a clean shutdown with nothing left running or restarting.
- Full pre-commit gates: lint, typecheck, knip, lint:extra, npm audit, 364/364 Node tests, and the Python gates (ruff, mypy, bandit, pip-audit, pytest) on Python 3.12.

## Checklist
Before submitting your PR, please review the following:
- [x] Commit messages follow the standard template.
- [x] All commits are signed.
- [x] Related issues are mentioned in the description above.
- [x] Linter checks have been passed.

## Additional Comments (if any):
Rebased on main after #402 so the `check` job runs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)