### PR TITLE
build(deps): bump starlette, python-multipart, and nodemailer (clear the security audit gate)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -20,7 +20,7 @@
         "express-rate-limit": "^8.5.1",
         "helmet": "^8.0.0",
         "jsonwebtoken": "^9.0.3",
-        "nodemailer": "^8.0.5",
+        "nodemailer": "^8.0.9",
         "openai": "^6.17.0",
         "passport": "^0.7.0",
         "passport-apple": "^2.0.2",
@@ -7011,9 +7011,9 @@
       }
     },
     "node_modules/nodemailer": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.5.tgz",
-      "integrity": "sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w==",
+      "version": "8.0.9",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.9.tgz",
+      "integrity": "sha512-5ofa7BUN8+C+Hckh5V2GjeeOGRQBx0CJQA6KxrvuZfC8iU4/q7sLn8XrtEEhJkjV6HdyIiQs7Bba6bTao8JhkA==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"

--- a/backend/package.json
+++ b/backend/package.json
@@ -30,7 +30,7 @@
     "express-rate-limit": "^8.5.1",
     "helmet": "^8.0.0",
     "jsonwebtoken": "^9.0.3",
-    "nodemailer": "^8.0.5",
+    "nodemailer": "^8.0.9",
     "openai": "^6.17.0",
     "passport": "^0.7.0",
     "passport-apple": "^2.0.2",

--- a/cv-python/requirements.txt
+++ b/cv-python/requirements.txt
@@ -1,11 +1,12 @@
-# fastapi >=0.134.0 is the minimum that allows starlette>=1.0.1, which closes
-# GHSA-86qp-5c8j-p5mr / PYSEC-2026-161 (Host header validation bypass) on top
-# of the earlier GHSA-2c2j-9gv5-cj73 and GHSA-7f5h-v6xp-fcq8 fixes.
-# Upgrade if newer GHSAs land via pip-audit.
+# fastapi >=0.134.0 permits starlette 1.3.1, which closes GHSA-86qp-5c8j-p5mr /
+# PYSEC-2026-161 (Host header validation bypass) plus the 1.1.0/1.3.x advisories
+# GHSA-wqp7-x3pw-xc5r, GHSA-x746-7m8f-x49c, GHSA-82w8-qh3p-5jfq,
+# GHSA-jp82-jpqv-5vv3, on top of the earlier GHSA-2c2j-9gv5-cj73 /
+# GHSA-7f5h-v6xp-fcq8 fixes. Upgrade if newer GHSAs land via pip-audit.
 # Stay on 0.136.1 — 0.136.3 was flagged MAL-2026-4750 (typosquat `fastar`
 # injected into the [standard] extras group); 0.136.2 was never published.
 fastapi==0.136.1
-starlette==1.0.1
+starlette==1.3.1
 # uvicorn[standard] >=0.46.0 transitively pulls h11>=0.16.0 (closes the
 # malformed-chunked-encoding CVE in older h11).
 uvicorn[standard]==0.46.0
@@ -13,9 +14,11 @@ numpy==2.2.4
 opencv-python-headless==4.11.0.86
 scikit-image==0.25.2
 scipy==1.14.1
-# python-multipart >=0.0.27 closes DoS-via-large-preamble, unbounded headers
-# DoS, and arbitrary file write CVEs from the 0.0.20 series.
-python-multipart==0.0.27
+# python-multipart 0.0.31 closes the 0.0.20-series CVEs (DoS-via-large-preamble,
+# unbounded-headers DoS, arbitrary file write) plus GHSA-v9pg-7xvm-68hf,
+# GHSA-5rvq-cxj2-64vf, GHSA-6jv3-5f52-599m. >=0.0.31 also adds stricter input
+# validation (rejects negative Content-Length, bounds header-name size).
+python-multipart==0.0.31
 # easyocr transitively pulls torch, currently flagged by GHSA-rrmf-rvhw-rf47
 # (low, torch.jit.script memory corruption, no fixed release). Ignored in the
 # security:py:deps npm script — see docs/security/SECURITY.md "Known Gaps".


### PR DESCRIPTION
Bumps the three production dependencies whose advisories were jointly blocking the check gate. The Lint and Type Check job runs the bandit -> pip-audit -> npm audit chain, which fails at the first vulnerable package, so the failures were layered and only became visible one at a time.

main was red due to a layered audit debt:
- pip-audit (cv-python): starlette 1.0.1 (4 advisories) + python-multipart 0.0.27 (3)
- npm audit (backend, prod): nodemailer 8.0.5 (3 advisories)
- npm audit (frontend, prod): clean (0 found)

Each Dependabot PR alone could not pass the gate (it stopped at whichever package it did not fix), so this combines all three fixes:
- starlette to 1.3.1: GHSA-wqp7-x3pw-xc5r, GHSA-x746-7m8f-x49c, GHSA-82w8-qh3p-5jfq, GHSA-jp82-jpqv-5vv3
- python-multipart to 0.0.31: GHSA-v9pg-7xvm-68hf, GHSA-5rvq-cxj2-64vf, GHSA-6jv3-5f52-599m
- nodemailer to 8.0.9: GHSA-268h-hp4c-crq3, GHSA-wqvq-jvpq-h66f, GHSA-r7g4-qg5f-qqm2

Supersedes #409, #407, and #410 (will close them on merge). The remaining open Dependabot PRs (#406 vite, #408 js-yaml, #411 babel) are dev-deps that the prod audit omits; they just need a rebase once this lands.

The accepted torch advisory (GHSA-rrmf-rvhw-rf47, no fixed release, tracked by #403) is untouched and stays suppressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)