### PR TITLE
Gitignore generated output, trim CLAUDE.md, harden /commit

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -1,20 +1,35 @@
 # Commit Changes
 
-Review uncommitted changes, organize them into atomic commits on an appropriate branch, and push.
+Review uncommitted changes, organize them into atomic commits on an appropriate branch, run the project's mandatory pre-commit gates, and push.
 
 ## Arguments
 
-$ARGUMENTS — optional: branch name or short description of the change. If not provided, infer from the changes.
+`$ARGUMENTS` — optional. Accepts any combination of:
+
+- A branch name or short description of the change (e.g. `fix-auth-token-refresh`). If absent, infer from the diff.
+- `--skip-tests` — skip the test runs for trivial doc-only / comment-only / `.gitignore`-only changes. The lint+typecheck gate (`npm run check`) and the security pass still run.
+
+Examples: `/commit`, `/commit fix-token-refresh`, `/commit docs-cleanup --skip-tests`.
 
 ## Prerequisites
 
 Follow the commit conventions defined in `docs/tech/development-guide.md` — specifically the "Commits and Branches" section (granular commits, title+body format, branch discipline, docs in dedicated commits).
+
+## Why these conventions matter
+
+The conventions exist because each one has burned this repo before:
+
+- **DCO sign-off (`-s`) is a CI gate, not a style preference.** PRs without a `Signed-off-by:` trailer fail the DCO check and cannot merge. This is the most common cause of red CI on dependency PRs.
+- **72-char body wrap** keeps `git log`, `gh pr view`, and review tools readable. Longer lines wrap mid-word and obscure the history.
+- **Pre-commit gates** (`npm run check`, tests, security pass) catch issues locally that would otherwise show up as red CI 5 minutes later. Running them now saves a force-push cycle.
+- **One purpose per branch** keeps PRs reviewable and reversible.
 
 ## Instructions
 
 ### 1. Assess current state
 
 Run in parallel:
+
 ```bash
 git status
 git diff
@@ -24,6 +39,7 @@ git branch --show-current
 ```
 
 Also check if the current branch has unmerged commits (i.e., is not `main`):
+
 ```bash
 git log main..HEAD --oneline
 ```
@@ -31,27 +47,54 @@ git log main..HEAD --oneline
 ### 2. Determine the branch
 
 - **If already on a non-main branch with unmerged commits**: check if the uncommitted changes are related to the branch's purpose. If yes, use this branch. If the changes are unrelated (different feature/fix), stash them, switch to main, and create a new branch.
-- **If on main or on a clean feature branch with no relation to the changes**: create a new branch. Use a descriptive kebab-case name (e.g., `fix-auth-token-refresh`, `add-region-export`). If $ARGUMENTS provides a name or hint, use that.
+- **If on main or on a clean feature branch with no relation to the changes**: create a new branch. Use a descriptive kebab-case name (e.g., `fix-auth-token-refresh`, `add-region-export`). If `$ARGUMENTS` provides a name or hint, use that.
 
 ### 3. Filter out junk
 
 Review every changed file. **Do NOT stage** any of the following:
+
 - `.env`, `.env.*` files or anything with secrets/credentials
 - Files with hardcoded local paths, hostnames, ports specific to your machine
-- IDE/editor config (`.idea/`, `.vscode/settings.json`, etc.) unless they're already tracked
+- IDE/editor config (`.idea/`, `.vscode/settings.json`, etc.) unless already tracked
 - OS files (`.DS_Store`, `Thumbs.db`)
 - Build artifacts, `node_modules/`, `dist/`, `.cache/`
 - Log files, temporary files, debug output
+- Local-only tweaks
 - Any file that contains private data (API keys, tokens, personal info)
 
 If you find suspicious files, **skip them** and mention it in the summary.
 
-### 4. Group changes into atomic commits
+### 4. Run the mandatory pre-commit gates
+
+Run these **before** creating any commit, so a failure aborts the workflow before history is touched.
+
+**a. Lint + typecheck + fast security (always):**
+
+```bash
+npm run check
+```
+
+If this fails, stop. Report the specific failure to the user with the relevant output (the failing lint rule, type error, audit advisory, etc.). Don't try to commit "anyway" — the same failure will appear in CI and block the PR. Either fix the underlying issue or ask the user how to proceed (e.g. if the failure is unrelated infra noise, the user may want to aggregate a separate fix into this PR — that's what we did for PR #396).
+
+**b. Tests (unless `--skip-tests` was passed):**
+
+```bash
+TEST_REPORT_LOCAL=1 npm test
+npm run test:py
+```
+
+`--skip-tests` is only appropriate for changes that touch zero executable code: `*.md` doc edits, comment-only edits, `.gitignore` / `.editorconfig` tweaks. Any `.ts`, `.tsx`, `.js`, `.py`, `.sql`, `.yaml` (config) change — run the tests.
+
+**c. Security pass on changed files:**
+
+Invoke the `security-check` skill via the Skill tool to scan the diff for secrets, missing auth, IDOR, injection patterns, and the language-specific gotchas listed in `.claude/commands/security-check.md`. If the skill flags anything CRITICAL or HIGH, stop and surface it — fix before committing.
+
+### 5. Group changes into atomic commits
 
 Analyze the staged-worthy changes and group them by purpose. Each commit should contain **only** changes that belong together:
 
 - A bug fix is one commit — don't mix in unrelated refactoring
-- A new feature should be split into **multiple granular commits** when it has distinct layers (e.g., backend endpoint, frontend hook, frontend wiring — each gets its own commit)
+- A new feature should be split into multiple granular commits when it has distinct layers (e.g., backend endpoint, frontend hook, frontend wiring — each gets its own commit)
 - **Documentation updates always get their own dedicated commit** — never mix docs with code changes
 - Config changes get their own commit unless directly tied to a feature
 - Each commit must compile and pass lint on its own
@@ -59,45 +102,89 @@ Analyze the staged-worthy changes and group them by purpose. Each commit should 
 
 **Do NOT create a commit that mixes unrelated changes.** If changes span multiple unrelated topics, they need separate commits (and potentially separate branches — see step 2).
 
-**CRITICAL: Each branch/PR must be single-purpose.** A branch exists to deliver ONE feature, fix, or improvement. Do not sneak in unrelated changes — no matter how small — into a branch that serves a different purpose. Inbox notes, unrelated doc edits, minor refactors, or "while I'm here" fixes must go on their own branch or be left uncommitted. A PR reviewer should never see a diff that makes them ask "why is this here?"
+**Each branch/PR must be single-purpose.** A branch exists to deliver ONE feature, fix, or improvement. Don't sneak in unrelated changes — no matter how small — into a branch that serves a different purpose. Inbox notes, unrelated doc edits, minor refactors, or "while I'm here" fixes must go on their own branch or be left uncommitted. A PR reviewer should never see a diff that makes them ask "why is this here?"
 
-### 5. Create commits
+### 6. Create commits
 
-For each atomic group, stage the specific files and commit:
+For each atomic group, stage the specific files and commit. Always pass `-s` and always use a HEREDOC so the body keeps its line breaks:
 
 ```bash
 git add <file1> <file2> ...
 git commit -s -m "$(cat <<'EOF'
-<title: imperative, under 72 chars>
+<Type>: <Topic>.
 
-<body: explain what changed and why, wrap at 72 chars>
+<body: explain what changed and why, wrap every line at 72 chars>
 
-Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+Closes #<N>
+
+Co-Authored-By: <model name> <noreply@anthropic.com>
 EOF
 )"
 ```
 
-Rules for commit messages:
-- **Title**: imperative mood ("Add X", "Fix Y", "Update Z"), max 72 characters
-- **Body**: explain _what_ changed and _why_ (not just _how_). Provide enough context that someone reading `git log` understands the motivation
-- **Related issues**: if the change addresses or relates to a GitHub issue, include `Closes #N` or `Relates to #N` in the commit body (before the trailers). Search open issues with `gh issue list` if unsure whether a relevant issue exists
-- **Always** use `-s` (sign-off: Developer Certificate of Origin)
-- **Always** include the `Co-Authored-By` trailer
+The heredoc delimiter is quoted (`<<'EOF'`), so **everything between the
+markers is literal** — no expansion, and no shell comments. Never annotate
+a line inline; the annotation lands in the commit message verbatim. The
+last two lines above are conditional: drop `Closes #<N>` when no issue
+applies, and drop the `Co-Authored-By` trailer entirely for commits a
+human wrote (see **Trailers** below).
 
-### 6. Push
+**Title:**
 
-After all commits are created:
+- Imperative mood: "Add X", "Fix Y", "Update Z" (not "Added"/"Fixes")
+- Max 72 characters (including the type)
+- Specific: "Fix hover state not clearing on region change" not "Fix bug"
+- Format `<Type>: <Topic>.` where `<Type>` is one of `front` (frontend), `back` (backend), `deploy` (deployment), or **left blank** if the change isn't specific to one of those. Do NOT use Conventional-Commit prefixes (`feat(scope):`, `fix(scope):`, …). Check `git log --oneline -20` for examples.
+
+**Body:**
+
+- Explain *what* changed and *why* — not just *how*. The diff already shows *how*.
+- Wrap every line at 72 characters. If you're unsure, after writing the message run:
+  ```bash
+  git log -1 --format=%B | awk '{ if (length > 72) print NR": "length" chars: "$0 }'
+  ```
+  Empty output = all lines ≤ 72. Anything printed = re-wrap and amend.
+- Reference issues with `Closes #N` (for fixes that close the issue) or `Relates to #N` (for partial progress). Place these before the trailers. Run `gh issue list --search "<keyword>"` if unsure whether a relevant issue exists.
+
+**Trailers:**
+
+- `-s` produces the `Signed-off-by:` line — this is the DCO trailer (a CI gate). Never skip it.
+- `Co-Authored-By: <model name> <noreply@anthropic.com>` — **only for commits written with AI assistance**, never by default. Use the human-readable model name from your current environment's system prompt (e.g. "Claude Opus 4.8"); don't hardcode an older version. Omit this trailer entirely for commits a human wrote.
+
+### 7. Verify the commit landed correctly
+
+Immediately after each commit:
+
+```bash
+git log -1 --format=%B
+```
+
+Check by eye:
+
+- Title is imperative and ≤72 chars
+- Every body line is ≤72 chars (run the `awk` check above if uncertain)
+- `Signed-off-by: <real name> <email>` trailer is present
+- `Co-Authored-By: ...` trailer is present **only if** the commit was AI-assisted
+
+If anything's off and the commit hasn't been pushed yet, undo with `git reset --soft HEAD~1`, fix, and recommit fresh — don't `--amend` silently (per repo policy, prefer new commits to amends). If the commit was already pushed, ask the user before rewriting.
+
+### 8. Push
+
+After all commits are created and verified:
+
 ```bash
 git push -u origin <branch-name>
 ```
 
-If the branch is new, this sets up tracking. If pushing to an existing branch, a regular `git push` suffices.
+If the branch is new, this sets up tracking. If pushing to an existing branch, a regular `git push` suffices. If the branch was rebased, use `git push --force-with-lease` (never bare `--force`) and confirm with the user first if the branch already has a PR with reviewers.
 
-### 7. Summary
+### 9. Summary
 
-Report:
+Report to the user:
+
 - Branch name
 - Number of commits created (with short titles)
+- Pre-commit gate results (which gates ran, anything noteworthy)
 - Any files that were **skipped** (junk, secrets, host-specific) and why
 - Any uncommitted changes that remain (files you chose not to commit)
-- Remind the user if there are leftover changes that might need a separate branch
+- Remind the user if leftover changes suggest a separate branch

--- a/.gitignore
+++ b/.gitignore
@@ -98,5 +98,18 @@ repomix-output.*
 data/cache/
 data/cv-python-tests/
 
-# Python CV model artifacts (downloaded at runtime)
-backend/data/models/
+# Experience images downloaded at runtime, and CV/matching debug dumps
+data/images/
+data/cv-debug/
+data/matching-dumps/
+
+# Canon sync cache and CV model artifacts, both downloaded/written at runtime.
+# Also catches the cache landing here when the backend runs with cwd=backend/.
+backend/data/
+
+# Design-system sync: local converter staging area and its generated bundle
+.ds-sync/
+ds-bundle/
+
+# Superpowers skill working directory
+.superpowers/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,29 +7,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ```bash
 npm run check              # Comprehensive gate: lint + typecheck (Node + Python) + fast security + knip + lint:extra. Same script CI runs. (~90s, run before committing)
 TEST_REPORT_LOCAL=1 npm test  # Unit tests without Docker (run before committing)
-npm run test:py            # cv-python pytest with coverage
-npm run knip               # Find unused files + dependencies (already part of check; standalone for ad-hoc use)
-npm run security:all       # check + slow Semgrep (Node+Python) + Trivy image scan (run before pushing)
 npm run dev                # Start all services via Docker Compose
-npm run dev:backend        # Start backend only (local, no Docker)
-npm run dev:frontend       # Start frontend only (local, no Docker)
 npm run db:shell           # Open psql shell to active database
-npm run db:status          # Show current DB info and row counts
-npm run check:py           # Ruff lint + format check + mypy on cv-python
-npm run lint:py:fix        # Ruff auto-fix on cv-python
-npm run format:py:fix      # Ruff format apply on cv-python
-npm run security:scan      # Semgrep SAST scan, Node configs (via Docker)
-npm run security:py:semgrep  # Semgrep SAST scan, Python configs (via Docker)
-npm run security:py:bandit # Bandit SAST on cv-python/app
-npm run security:py:deps   # pip-audit on cv-python/requirements.txt
-npm run security:py:all    # All Python security scans
-npm run security:image     # Build cv-python image and Trivy CVE scan
-npm run security:deps      # npm audit for backend + frontend
-npm run lint:circular      # madge: find circular ts/tsx imports
-npm run lint:shell         # shellcheck on scripts/*.sh (Docker)
-npm run lint:docker        # hadolint on every Dockerfile (Docker)
-npm run lint:extra         # composite: lint:circular + lint:shell + lint:docker (already part of check)
-npm run help               # Full command reference
+npm run help               # Full command reference (all other scripts: package.json)
 ```
 
 Backend runs on port 3001, frontend on port 5173, Martin tile server on port 3000, cv-python on port 8000.
@@ -69,19 +49,10 @@ Express backend + React/MUI frontend + PostgreSQL/PostGIS + Martin vector tile s
 - **treasures** — Independently trackable items inside venues (artworks, artifacts). Globally unique by `external_id`. Linked to experiences via `experience_treasures` junction table (many-to-many)
 - **is_iconic** — Boolean flag on both `experiences` and `treasures` for highlighting must-see items
 
-### Backend Structure
-- **Routes** (`backend/src/routes/`): authRoutes, divisionRoutes, worldViewRoutes, experienceRoutes, adminRoutes, userRoutes, aiRoutes, viewRoutes
-- **Controllers** (`backend/src/controllers/`): Organized by domain — division*, worldView/region*, experience*, sync*, ai*
-- **Services** (`backend/src/services/`): Sync services (UNESCO, museum, landmark), hull calculation, image downloading, region assignment, OpenAI integration
-- **Middleware**: `requireAuth`, `requireAdmin`, `optionalAuth` in `middleware/auth.ts`
-- Startup cleanup in `index.ts` marks orphaned `running` sync logs as `failed`
-
-### Frontend Structure
-- **Routing** (`App.tsx`): `/` (main map), `/discover` (experience browsing), `/auth/callback`, `/admin/*`
-- **State**: TanStack Query for server state, Context API for UI state (`useNavigation`, `useAuth`, `useExperienceContext`)
-- **API layer** (`frontend/src/api/`): All calls use `authFetchJson()` from `fetchUtils.ts` with in-memory JWT. Refresh token stored as httpOnly cookie
-- **Map**: MapLibre GL via react-map-gl. `RegionMapVT.tsx` renders vector tiles from Martin. `ExperienceMarkers.tsx` uses declarative `<Source>`/`<Layer>` with native GeoJSON clustering
-- **Hooks** (`frontend/src/hooks/`): `useNavigation` (world views, divisions, breadcrumbs, tile version), `useExperienceContext` (experiences, hover sync, selection), `useAuth`, `useVisitedRegions`, `useVisitedExperiences`
+### Structure notes (non-obvious contracts; layout itself — see `ls backend/src`, `ls frontend/src`)
+- Startup cleanup in backend `index.ts` marks orphaned `running` sync logs as `failed`
+- All frontend API calls go through `authFetchJson()` (`frontend/src/api/fetchUtils.ts`) with in-memory JWT; refresh token lives in an httpOnly cookie
+- Map: MapLibre GL via react-map-gl; `RegionMapVT.tsx` renders Martin vector tiles; `ExperienceMarkers.tsx` uses declarative `<Source>`/`<Layer>` with native GeoJSON clustering
 
 ### Martin Vector Tiles
 - Config: `martin/config.yaml` (auto-discovers PostGIS tables/functions)


### PR DESCRIPTION
## Description

Repo hygiene, no behaviour change. Two independent commits.

**Gitignore the remaining generated and local-tooling output.** ~221 MB sat
untracked but unignored, so it showed up in every `git status` and was one
stray `git add -A` away from being committed:

| Path | What it is |
|---|---|
| `data/images`, `data/cv-debug`, `data/matching-dumps` | runtime image downloads and CV/matching debug dumps |
| `backend/data` | canon sync cache and runtime-downloaded CV model artifacts |
| `.ds-sync`, `ds-bundle` | design-system sync converter staging area (carries its own `node_modules`) and the bundle it generates |
| `.superpowers` | skill working directory |

Nothing under these paths is tracked, so no history is affected. The
`backend/data` rule is byte-identical (comment included) to the one already on
`feat/design-system-claude-sync` from a7f7f43, so the two branches converge on
the same line rather than drifting into a near-miss duplicate. It subsumes the
old `backend/data/models/` entry, which is removed rather than left redundant.

**Trim CLAUDE.md, harden the /commit command.** CLAUDE.md was restating what the
repo already answers for itself, which costs context every session and goes
stale without anyone noticing:

- the command block listed all 24 npm scripts → keeps the four used daily and
  points at `package.json` for the rest
- `Backend Structure` / `Frontend Structure` enumerated directory layouts that
  `ls backend/src` and `ls frontend/src` report accurately and for free →
  collapsed into `Structure notes`, holding only what is *not* visible from the
  tree (orphaned-sync-log cleanup at startup, the `authFetchJson` /
  httpOnly-cookie split, the MapLibre/Martin setup)

`.claude/commands/commit.md` picks up what had been tribal knowledge: a
mandatory pre-commit gate step placed *before* any commit is created,
`--skip-tests` scoped to changes touching zero executable code, a "why these
conventions matter" section (DCO sign-off is a CI gate, not a style
preference), the `<Type>: <Topic>.` title format, the rule that
`Co-Authored-By` belongs only on AI-assisted commits, a post-commit
verification step, and `--force-with-lease` guidance for rebased branches.

## Related Issues

None.

## How Was This Tested?

N/A — configuration/documentation change. The diff is `.gitignore` plus two
markdown files, which is exactly the case `commit.md` scopes `--skip-tests` to.

Verified by inspection instead:

- `git status` now shows only the untracked planning docs that are meant to
  stay untracked; all 221 MB is covered
- `git check-ignore -v backend/data/cache backend/data/models` — both resolve to
  the single `backend/data/` rule, confirming the removed entry was redundant
- `npm run lint` and `npm run typecheck` clean

## Checklist

- [x] Commit messages follow the standard template.
- [x] All commits are signed.
- [x] Related issues are mentioned in the description above.
- [x] Linter checks have been passed.

## Additional Comments (if any):

The `docs` commit carries only `Signed-off-by`, with no `Co-Authored-By` — those
two files were authored by hand, and the rule being documented in this very diff
says the trailer is for AI-assisted commits only.

Both review findings from the first round are folded into the commits they
belong to rather than added as follow-ups, per the clean-history gate in
`CLAUDE.md`: the redundant `backend/data/models/` entry, and the heredoc
annotations in `commit.md` that would have been emitted into commit messages
verbatim (the delimiter is quoted, so there are no shell comments inside).