### PR TITLE
Record that plans stay local and gitignore them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,12 @@ deployment/
 # Inbox (local scratchpad, not for version control)
 docs/inbox/
 
+# Plans and design specs are local working documents. What gets committed is
+# documentation of what exists, under docs/tech/ — a committed plan drifts from
+# reality and becomes a second, wrong source of truth.
+# Note: this hides new plans only. Docs already tracked here stay tracked.
+docs/tech/planning/
+
 # Debug screenshots
 *.png
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,8 +133,8 @@ See `docs/README.md` for the full index.
 
 When working on this codebase, keep docs in sync:
 
-- **Planning a feature** → create or update a doc in `docs/tech/planning/`
-- **Implementing a feature** → update relevant `docs/tech/` doc (or create one)
+- **Planning a feature** → create or update a doc in `docs/tech/planning/`. **Plans are never committed** — they stay untracked local working documents (the directory is gitignored). Do not stage one, and never open a PR for one
+- **Implementing a feature** → update relevant `docs/tech/` doc (or create one). This is the committed artefact: docs describe **what exists**, never what is planned. A committed plan starts drifting from reality the moment it lands and becomes a second, wrong source of truth
 - **Any user-facing change** → **always** update `docs/vision/vision.md`. This applies to any change that affects what visitors, users, curators, or admins can see or do — new UI, changed workflows, new input methods, etc. Vision docs describe the product from the user's perspective
 - **Security-relevant change** → update `docs/security/SECURITY.md` (profile, known gaps) and/or `docs/security/asvs-checklist.yaml` (requirement status). This applies to new auth flows, new API endpoints, new input surfaces, file handling changes, new roles/permissions, or changes to token/session handling
 - **Completing a plan** → trim the planning doc to only unimplemented ideas/improvements. Remove fully implemented sections
@@ -190,6 +190,6 @@ When executing **any** skill workflow (brainstorming, writing-plans, debugging, 
 4. **ADRs for architecture** — check `docs/decisions/` before proposing architectural choices; create a new ADR if one is needed
 5. **Security standards** — follow OWASP ASVS 5.0 Level 2 rules (see Security Standards section above)
 6. **Pre-commit checks** — before every commit, run `npm run check` (comprehensive gate; includes knip + lint:extra), `TEST_REPORT_LOCAL=1 npm test` + `npm run test:py`, and `/security-check`. Run `npm run security:all` before pushing (it adds the slow Semgrep + Trivy scans on top of `check`).
-7. **Design docs path** — save design documents and plans to `docs/tech/planning/` (not `docs/plans/`)
+7. **Design docs path** — save design documents and plans to `docs/tech/planning/` (not `docs/plans/`), and leave them **uncommitted**: plans are local working documents. What gets committed when the work lands is documentation of what exists, in `docs/tech/`. Guideline edits a plan calls for (this file, `.claude/commands/*`) ship with the implementation, never ahead of it
 8. **Development guide** — follow all conventions in `docs/tech/development-guide.md` (file size limits, commit format, refactoring hygiene)
 9. **Refactoring cleanup** — after any code change, remove unused imports, dead variables, and now-redundant checks


### PR DESCRIPTION
## Description

The rule was unwritten, so `CLAUDE.md` read as if planning docs should be
committed — it said *where* to put them and nothing about their lifecycle.
Acting on that reading produced a PR for a design document, which was not
wanted (#426, closed).

Two changes:

**`CLAUDE.md`** — Documentation Workflow and Skill Integration Rules #7 now say
it outright: plans are untracked local working documents; what gets committed
when work lands is documentation of **what exists**, under `docs/tech/`.
Guideline edits a plan calls for ship with the implementation, never ahead of
it.

**`.gitignore`** — `docs/tech/planning/` joins `docs/inbox/`, which already had
the same "local scratchpad, not for version control" treatment.

The reason is recorded next to the rule, because it is the part that makes it
stick: a committed plan starts drifting from reality the moment it lands and
becomes a second, wrong source of truth. This repo has already been bitten —
`e2e-fresh-db-strategy.md` promises a fresh database with GADM loaded while
`scripts/test-stack.sh` seeds nothing at all, and the contradiction went
unnoticed because nothing ran the tests it described.

## Related Issues

None.

## How Was This Tested?

N/A — documentation and ignore-rule change, no executable code.

Behaviour of the ignore rule was verified rather than assumed:

- 13 untracked plan docs disappear from `git status` (they were noise on every
  status call)
- `git check-ignore -v docs/tech/planning/<new>.md` resolves to the new rule
- `git ls-files docs/tech/planning/ | wc -l` is unchanged — already-tracked
  docs stay tracked, since `.gitignore` does not untrack anything
- `npm run lint` and `npm run typecheck` clean

## Checklist

- [x] Commit messages follow the standard template.
- [x] All commits are signed.
- [x] Related issues are mentioned in the description above.
- [x] Linter checks have been passed.

## Additional Comments (if any):

**This hides new plans only.** The 12 docs already tracked under
`docs/tech/planning/` are unaffected and need a separate decision. Worth noting
that several of them are not plans at all by the rule this PR writes down —
`deployment.md` (351 lines), `ci-cd.md`, `groupings.md` and `testing-strategy.md`
describe what exists. Those belong in `docs/tech/` rather than being dropped, so
sorting them is a deliberate piece of work rather than a `git rm --cached`
sweep. Left out of this PR on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LTGqzxWFStMcpuR8J6tQ8A