### PR TITLE
Make the review bots look outside the diff and run on Opus 5

### DIFF
--- a/.github/workflows/claude-dependabot.yml
+++ b/.github/workflows/claude-dependabot.yml
@@ -102,7 +102,11 @@ jobs:
             Be terse. No narration of what the PR does — Dependabot
             already says it in the PR body.
 
+          # Turn budget sized off observed runs: 6-16 turns for minor bumps.
+          # A major bump with a wide usage surface costs more, and running
+          # out mid-analysis posts a truncated verdict rather than failing
+          # loudly — so leave headroom. Unused turns cost nothing.
           claude_args: |
-            --model claude-sonnet-4-6
-            --max-turns 30
+            --model claude-opus-5
+            --max-turns 40
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(grep:*),Bash(rg:*)"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -73,16 +73,21 @@ jobs:
             You are reviewing this PR. Project conventions live in CLAUDE.md
             (already in your context). The structure below mirrors
             anthropics/claude-code-security-review's prompt design — phased
-            methodology, generic categories, confidence-based filter.
+            methodology, generic categories, confidence-based publish bar.
 
             ## CRITICAL INSTRUCTIONS
 
-            1. **Confidence-based filter.** Only flag findings you'd defend
-               in a real PR review. Skip speculative ("could be"),
-               theoretical, or low-impact findings. If you can't name the
-               specific control-flow path that's broken or the specific
-               contract that's violated, you're guessing — trace harder or
-               skip.
+            1. **Find first, filter second — separate steps.** While
+               analysing, note EVERY candidate with a severity and a
+               confidence, including ones you suspect are weak. Do not
+               suppress candidates while you are still looking. Only once
+               analysis is complete, apply the publish bar: post a finding
+               if you can name the specific control-flow path that's
+               broken, the specific contract that's violated, or the
+               specific other file that now contradicts this change. Drop
+               the rest silently, without narrating what you dropped. A bar
+               applied during discovery costs you real findings; the same
+               bar applied at publish time costs you nothing.
             2. **Avoid noise.** Skip stylistic preferences, defensive-code
                wishes where internal guarantees exist, reformatting wishes.
             3. **Verify before flagging.** When tempted to flag "X is
@@ -248,7 +253,7 @@ jobs:
           # grep/rg shell entries mirror claude-qa.yml + claude-dependabot.yml
           # so the Phase 4 repo search has a path either way.
           claude_args: |
-            --model claude-sonnet-4-6
+            --model claude-opus-5
             --effort xhigh
             --max-turns 50
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(grep:*),Bash(rg:*)"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -136,7 +136,11 @@ jobs:
             project's patterns and conventions for this domain.
 
             **Phase 2 — Diff.** Get the diff with `gh pr diff`. Identify
-            what changed: pure move vs new behavior vs deletion.
+            what changed: pure move vs new behavior vs deletion. For each
+            hunk also name the *claim* it changes — a rule, a threshold, a
+            command, a flag, a signature, a schema field, a documented
+            behaviour. Phase 4 checks those claims against the rest of the
+            repo.
 
             **Phase 3 — Trace.** For each non-trivial change, MENTALLY
             EXECUTE the code paths — happy path, early returns, error
@@ -146,7 +150,38 @@ jobs:
             must satisfy the required contract (commit/rollback, release,
             close, unlock, cleanup). Verify, don't pattern-match.
 
-            **Phase 4 — Verify.** For each candidate finding, run the
+            **Phase 4 — Ripple.** The diff is not the blast radius. For
+            each claim from Phase 2, `Grep` the repo for OTHER places that
+            state the same claim, and check they still agree. A PR that
+            changes a rule in one file and leaves the contradicting
+            statement standing in another is a defect even though the
+            second file never appears in the diff — that file is now
+            wrong, and nothing else will catch it. This phase is not
+            optional and cannot be done from the diff alone: if you have
+            not run a search this phase did not happen.
+
+            Places this repo states the same thing twice — check the ones
+            the diff actually touches, not all of them:
+              - `CLAUDE.md` ⇄ `docs/tech/development-guide.md` — both
+                state process rules (commit format, pre-commit gates,
+                file-size limits, refactoring hygiene)
+              - `CLAUDE.md` command table ⇄ `package.json` scripts
+              - any user-visible change ⇄ `docs/vision/vision.md`
+              - auth / endpoint / role / input-surface changes ⇄
+                `docs/security/SECURITY.md` and
+                `docs/security/asvs-checklist.yaml`
+              - architectural choices ⇄ accepted ADRs in `docs/decisions/`
+              - backend response shape ⇄ its frontend consumer
+              - `.env.example` ⇄ `docker-compose.yml` ⇄ any doc naming
+                the variable
+              - `db/init/*.sql` ⇄ Drizzle schema ⇄ the domain model
+                described in CLAUDE.md
+
+            An inline comment must land on a line that exists in the diff,
+            so anchor a ripple finding on the line the PR *changed* and
+            name the other `file:line` that now disagrees.
+
+            **Phase 5 — Verify.** For each candidate finding, run the
             CRITICAL INSTRUCTION #3 check (upstream/downstream) before
             posting. Drop verified-handled candidates.
 
@@ -167,6 +202,11 @@ jobs:
               a genuine linter false positive). The latter is the more common
               and more dangerous failure mode — verify each new suppression's
               reason actually justifies the suppression.
+            - **Cross-file consistency** — a rule, command, constant, env
+              var, schema, or documented behaviour changed in one file
+              while another file still states the old version (Phase 4).
+              Docs count: a stale rule in CLAUDE.md is as real a defect as
+              a stale constant in code, because both are read as truth.
             - **Convention adherence** — code reuse (shared components/utils),
               file-size limits, dev-guide patterns, commit hygiene
 
@@ -194,17 +234,21 @@ jobs:
 
             Workflow:
             1. Get the diff: `gh pr diff`
-            2. For each specific line-level concern → inline comment
-            3. Once all inline comments are posted → ONE top-level summary via `gh pr comment`
-            4. **Re-run only**: if there are existing UNRESOLVED claude[bot] inline review threads on this PR (use `gh api graphql` with the `reviewThreads` query), check whether the diff at the thread's path/line still contains the issue you previously flagged. For each thread whose concern is now addressed, resolve it via the GraphQL `resolveReviewThread` mutation. Skip threads where the original concern still applies — leave those open. Skip threads from other authors (CodeQL, CodeRabbit, humans) — only resolve your own.
+            2. Run the Phase 4 repo search for every claim the diff changes
+            3. For each specific line-level concern → inline comment
+            4. Once all inline comments are posted → ONE top-level summary via `gh pr comment`
+            5. **Re-run only**: if there are existing UNRESOLVED claude[bot] inline review threads on this PR (use `gh api graphql` with the `reviewThreads` query), check whether the diff at the thread's path/line still contains the issue you previously flagged. For each thread whose concern is now addressed, resolve it via the GraphQL `resolveReviewThread` mutation. Skip threads where the original concern still applies — leave those open. Skip threads from other authors (CodeQL, CodeRabbit, humans) — only resolve your own.
 
             Other rules:
             - Only post GitHub comments — don't submit review text as chat messages.
             - Be terse. Actionable findings only, no narration of what the PR does.
             - On a clean re-review (everything resolved + no new findings), the top-level summary should explicitly mention how many threads you resolved (e.g. "Resolved 3 prior findings; no new issues.").
 
+          # Grep/Glob/Read come from the action's own base tool set; the
+          # grep/rg shell entries mirror claude-qa.yml + claude-dependabot.yml
+          # so the Phase 4 repo search has a path either way.
           claude_args: |
             --model claude-sonnet-4-6
             --effort xhigh
             --max-turns 50
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(grep:*),Bash(rg:*)"


### PR DESCRIPTION
## Description

The PR reviewer only ever saw `gh pr diff` output, so a change that made
another file wrong was invisible to it: the second file was never in its
input. That is how a rule relaxed in `docs/tech/development-guide.md`
shipped while `CLAUDE.md` still stated the stricter version — CodeRabbit
caught the contradiction, our bot reported "Clean. No issues."

The run log for that review rules out the obvious explanations:
`permission_denials_count: 0`, six turns of a fifty-turn cap, and
`Glob,Grep,LS,Read` already in the action's base tool set. It had the
search tool and no instruction to reach for it.

Two changes, one per commit:

- **Phase 4 (Ripple)** in `claude-review.yml`, between the trace and the
  verify pass. Name the claim each hunk changes, then search the repo
  for other statements of that claim and check they still agree. The
  listed pairs are the places this repo says the same thing twice:
  `CLAUDE.md` against the development guide, the command table against
  `package.json`, user-visible behaviour against the vision doc, auth
  changes against the security profile and ASVS checklist. A finding
  anchors on a changed line, since that is the only place an inline
  comment can attach, and names the stale file in the comment body.

- **Opus 5** for `claude-review.yml` and `claude-dependabot.yml`. The
  model bump on its own would likely have made the reviewer flag less,
  not more: Opus 5 follows conservative-reporting instructions more
  literally, a documented effect for review harnesses where measured
  recall drops even as bug-finding improves. CRITICAL INSTRUCTION #1 was
  exactly that shape, applied while the model is still looking. It now
  separates discovery from filtering — enumerate every candidate with a
  severity and a confidence, apply the bar only at publish time.

`claude-qa.yml` stays on Sonnet: it fires only on an explicit `@claude`
mention and carries no prompt of its own, so its workload is whatever
the comment asks for.

## Related Issues

None.

## How Was This Tested?

N/A — CI configuration change, no test suite covers it. What was done
instead:

- All three workflow files parsed with a YAML loader after each edit.
- Turn budgets sized off real runs pulled from `gh run view --log`: the
  reviewer used 6 of its 50-turn cap, the Dependabot reviewer 6/10/16
  of 30. The latter goes to 40 — running out mid-analysis posts a
  truncated verdict rather than failing loudly.
- `npm run check` not run: nothing in it covers `.github/workflows/`.

This PR gets no Claude review at all, and that is by design:
`claude-code-action` validates that the workflow file matches the
version on the default branch and skips itself when it does not — a
guard against a PR rewriting the review prompt and tool allowlist and
then having them run under the app token. Confirmed in the run log for
this PR: `Skipping action due to workflow validation`.

Worth knowing beyond this PR: the `review` check still reports green
when that happens, so the skip is silent. Any PR touching these three
files goes unreviewed by the bot without saying so.

The first live exercise of Phase 4 is therefore the next PR opened
after this one lands.

## Checklist

- [x] Commit messages follow the standard template.
- [x] All commits are signed.
- [x] Related issues are mentioned in the description above.
- [x] Linter checks have been passed — YAML validated by parser; no
      linter in `npm run check` covers workflow files.

## Additional Comments

Both jobs authenticate with the Pro/Max OAuth token, so this spends
subscription allowance rather than billed API credit. The last reviewer
run cost \$0.26-equivalent over six turns; expect a few times that with
Opus 5 plus the added repo search.

One loose end, deliberately not addressed here: a Dependabot review run
on the postcss bump reported `permission_denials_count: 2`. Which tool
was denied is not in the job log — only the count is — so there is
nothing actionable to fix blind. That review completed successfully.
