### PR TITLE
Make the reviewer's tool budget answerable from its own logs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -251,9 +251,50 @@ jobs:
 
           # Grep/Glob/Read come from the action's own base tool set; the
           # grep/rg shell entries mirror claude-qa.yml + claude-dependabot.yml
-          # so the Phase 4 repo search has a path either way.
+          # so the Phase 4 repo search has a path either way. `gh api repos`
+          # closes the one concrete asymmetry with claude-qa.yml, which has it.
+          #
+          # --max-turns is headroom, not a fix: across seven review rounds on
+          # PR #430 the reported num_turns ran 29-59 against a cap of 50 and
+          # every run still ended `subtype: success`, so the two do not count
+          # the same unit and the cap was never observed to bite. 80 costs
+          # nothing when unused and keeps a genuinely large PR off the limit.
           claude_args: |
             --model claude-opus-5
             --effort xhigh
-            --max-turns 50
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(grep:*),Bash(rg:*)"
+            --max-turns 80
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos:*),Bash(grep:*),Bash(rg:*)"
+
+      # Every review round on PR #430 reported 1-6 permission_denials_count
+      # with no way to tell which tool was refused: the action prints only the
+      # count, and the detail lives in an execution log it does not surface.
+      # This lists the tools the run actually reached for, so the allowlist can
+      # be tuned against evidence instead of guesswork — anything here that is
+      # absent from --allowedTools above is a denial.
+      #
+      # Names only, never the transcript: this repo is public, and the log
+      # holds full tool results including file contents the review read.
+      - name: List tools the review reached for
+        if: always()
+        run: |
+          log="${RUNNER_TEMP}/claude-execution-output.json"
+          if [ ! -f "$log" ]; then
+            echo "No execution log at $log — the action skipped or died early."
+            exit 0
+          fi
+          # The result record carries a `permission_denials` array alongside the
+          # count the action already prints, with the tool and the exact input
+          # that was refused. That is the direct answer when it is present.
+          echo "Denied tool calls:"
+          jq -r '[.. | objects | select(has("permission_denials")) | .permission_denials[]?]
+                 | if length == 0 then "  (none recorded under permission_denials)"
+                   else (.[] | "  \(.tool_name): \(.tool_input | tostring | .[0:200])") end' \
+            "$log" 2>/dev/null || echo "  (could not parse the log)"
+          echo
+          # Fallback, and a cross-check: anything listed here that is absent
+          # from --allowedTools was refused, whatever the log's own shape.
+          # Recursive descent keeps both queries shape-agnostic, so an upstream
+          # change to the envelope fails loudly rather than printing nothing.
+          echo "Tools attempted this run:"
+          jq -r '[.. | objects | select(.type? == "tool_use") | .name] | unique[]?' \
+            "$log" | sed 's/^/  /' || echo "  (could not parse the log)"


### PR DESCRIPTION
## Description

Across seven review rounds on #430 the Claude reviewer reported
`permission_denials_count` between 1 and 6 every round, and never once said
which tool was refused — the action prints the count and leaves the detail in
an execution log it does not surface. Tuning `--allowedTools` against that is
guesswork, and guesswork is exactly how the reviewer ended up shipping without
a repo-search instruction in the first place.

- **A step after the run lists the tools the review reached for.** Anything in
  that list absent from `--allowedTools` is a denial, so the next allowlist
  change can be made against evidence. Names only, never the log itself: this
  repo is public and the log carries full tool results, including the contents
  of every file the review read. The `jq` uses recursive descent, so an
  upstream change to the event envelope fails loudly instead of quietly
  printing an empty list.
- **`Bash(gh api repos:*)` added** — the one concrete asymmetry with
  `claude-qa.yml`, which already allows it.
- **`--max-turns` 50 → 80, as headroom rather than a fix.** Worth stating
  plainly because an earlier read of mine was wrong: across those seven rounds
  the reported `num_turns` ran 29–59 against a cap of 50, and every run still
  ended `subtype: success`. The two do not count the same unit and the cap was
  never observed to bite. Unused turns cost nothing, and a large PR hitting a
  real limit would fail the way this repo keeps getting bitten — silently.

## Related Issues

None.

## How Was This Tested?

N/A — CI configuration change, no test suite covers it. What was done instead:

- The workflow file parses, and the rendered `claude_args` were checked for
  the intended `--max-turns` and allowlist values.
- The `jq` expression was run against a sample event envelope of the shape the
  execution log uses, and returns the distinct `tool_use` names.
- Turn and denial figures come from `gh run view --log` on all seven review
  runs of #430, not from recollection.

**This PR gets no Claude review**, by design: `claude-code-action` refuses to
run when the workflow file differs from the version on the default branch — a
guard against a PR rewriting the review prompt and tool allowlist and then
having them run under the app token. The `review` check still reports green
when that happens, so the skip is silent. The first run that exercises the new
step will be the next PR opened after this lands.

## Checklist

- [x] Commit messages follow the standard template.
- [x] All commits are signed.
- [x] Related issues are mentioned in the description above.
- [x] Linter checks have been passed — YAML validated by parser; no linter in
      `npm run check` covers workflow files.

## Additional Comments

`jq` is preinstalled on GitHub-hosted Ubuntu runners, so the step adds no
setup. It runs `if: always()` and exits cleanly when the log is missing, so a
skipped or early-dying action does not turn into a red job.

`claude-dependabot.yml` is left alone: its runs used 6–16 turns of a 40 cap and
it has no denial history worth chasing.