### PR TITLE
Enforce a single default world view

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,9 +76,8 @@ Express backend + React/MUI frontend + PostgreSQL/PostGIS + Martin vector tile s
 - **Name**: `track_regions` (not `track_your_regions`)
 - **Container**: `tyr-ng-db` (access via `docker exec -i tyr-ng-db psql -U postgres -d track_regions`)
 - **Schema**:
-  - `db/init/01-schema.sql` (tables, triggers, auth)
-  - `db/init/02-martin-functions.sql` (tile functions)
-  - `db/init/03-geom-3857-columns.sql` (SRID 3857 for Martin)
+  - `db/init/01-schema.sql` — the only init file: tables, triggers, auth, Martin tile functions, SRID 3857 columns
+  - `db/migrations/` — one-shot changes for databases that already hold data (see its README)
 - **Extensions**: PostGIS, pg_trgm, unaccent
 
 ### Domain Model

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ Express backend + React/MUI frontend + PostgreSQL/PostGIS + Martin vector tile s
 ### Database
 - **Name**: `track_regions` (NOT `track_your_regions`)
 - **Container**: `tyr-ng-db` — access via `docker exec -i tyr-ng-db psql -U postgres -d track_regions`
-- **Schema**: `db/init/01-schema.sql` (tables, triggers, auth), `02-martin-functions.sql` (tile functions), `03-geom-3857-columns.sql` (SRID 3857 for Martin)
+- **Schema**: `db/init/01-schema.sql` — the only init file: tables, triggers, auth, Martin tile functions and the SRID 3857 columns. One-shot changes for databases that already hold data live in `db/migrations/` (see its README)
 - **Extensions**: PostGIS, pg_trgm, unaccent
 
 ### Domain Model

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -1,5 +1,5 @@
-import { pgTable, serial, varchar, integer, boolean, timestamp, jsonb, index, unique, text } from 'drizzle-orm/pg-core';
-import { relations } from 'drizzle-orm';
+import { pgTable, serial, varchar, integer, boolean, timestamp, jsonb, index, unique, uniqueIndex, text } from 'drizzle-orm/pg-core';
+import { relations, sql } from 'drizzle-orm';
 
 /**
  * Database Schema for Track Your Regions
@@ -51,7 +51,13 @@ export const worldViews = pgTable('world_views', {
   lastAssignmentAt: timestamp('last_assignment_at', { withTimezone: true }),
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
   updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow(),
-});
+}, (table) => ({
+  // At most one default world view (GADM). Also the ON CONFLICT arbiter that
+  // keeps the GADM seed in db/init/01-schema.sql idempotent on re-application.
+  singleDefaultIdx: uniqueIndex('idx_world_views_single_default')
+    .on(table.isDefault)
+    .where(sql`${table.isDefault}`),
+}));
 
 // =============================================================================
 // Regions (user-defined groupings within a WorldView)

--- a/backend/src/db/schemaSeeds.test.ts
+++ b/backend/src/db/schemaSeeds.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+// db/init/01-schema.sql is applied by docker-entrypoint-initdb.d on a fresh
+// database, but it is also re-applied by hand to existing databases whenever
+// the schema grows new tables or columns (db/migrations/README.md). Every seed
+// in it must therefore be idempotent.
+const SCHEMA_PATH = fileURLToPath(new URL('../../../db/init/01-schema.sql', import.meta.url));
+// eslint-disable-next-line security/detect-non-literal-fs-filename -- path is a literal resolved against this module's own URL
+const schema = readFileSync(SCHEMA_PATH, 'utf8');
+
+/** Tables the schema file is expected to seed. A new entry here is a signal to
+ *  check that the new seed carries an arbiter of its own. */
+const SEEDED_TABLES = ['experience_categories', 'world_views'];
+
+/**
+ * Blank out the contents of every `$$ … $$` block, preserving length so offsets
+ * into the result still address the original file. Trigger and function bodies
+ * are not seeds — their semicolons are not statement terminators, and an
+ * `INSERT INTO` inside one (an audit-log write, say) would otherwise be
+ * reported as an unguarded seed.
+ */
+function blankDollarQuotedBodies(sql: string): string {
+  return sql
+    .split('$$')
+    .map((part, i) => (i % 2 === 1 ? ' '.repeat(part.length) : part))
+    .join('$$');
+}
+
+/** Each `INSERT INTO ...` seed statement, up to its terminating semicolon. */
+function seedStatements(): { table: string; sql: string; offset: number }[] {
+  // Split on the statement terminator first, then match the table name inside
+  // each chunk — a single regex spanning the statement body would need chained
+  // quantifiers over overlapping character classes.
+  const statements: { table: string; sql: string; offset: number }[] = [];
+  const scannable = blankDollarQuotedBodies(schema);
+  let offset = 0;
+
+  for (const chunk of scannable.split(';')) {
+    // Tolerant of case and of any whitespace run, including a line break: a
+    // seed the scanner fails to see would pass the arbiter assertion below by
+    // never being collected, which is the one way this guard can go quiet.
+    const match = /\bINSERT\s+INTO\s+(\w+)/i.exec(chunk);
+    if (match) {
+      statements.push({
+        table: match[1],
+        sql: `${chunk.slice(match.index)};`,
+        offset: offset + match.index,
+      });
+    }
+    offset += chunk.length + 1;
+  }
+
+  return statements;
+}
+
+describe('db/init/01-schema.sql seeds', () => {
+  it('finds the seeds it is supposed to guard', () => {
+    // Guards the guard: a scanner that silently collects nothing would make
+    // every assertion below vacuously true.
+    const tables = [...new Set(seedStatements().map((s) => s.table))].sort();
+
+    expect(tables).toEqual(SEEDED_TABLES);
+  });
+
+  it('pins every seed to an explicit ON CONFLICT arbiter', () => {
+    // A bare `ON CONFLICT DO NOTHING` is not a guard: it only fires on a real
+    // unique/exclusion violation, so on a table whose sole unique constraint is
+    // a serial primary key it never fires at all. That is how re-applying this
+    // file used to add a second "GADM (Default)" world view on every run.
+    // Naming the arbiter forces the guard to be backed by an actual index.
+    for (const { table, sql } of seedStatements()) {
+      expect(sql, `seed into ${table} must name an ON CONFLICT arbiter`).toMatch(
+        /ON CONFLICT \([^)]+\)/,
+      );
+    }
+  });
+
+  it('creates the single-default index before seeding GADM', () => {
+    const indexOffset = schema.indexOf('CREATE UNIQUE INDEX IF NOT EXISTS idx_world_views_single_default');
+    const seed = seedStatements().find((s) => s.table === 'world_views');
+
+    expect(indexOffset).toBeGreaterThan(-1);
+    expect(seed).toBeDefined();
+    // The arbiter index has to exist before the INSERT that names it, or the
+    // seed raises "no unique or exclusion constraint matching the ON CONFLICT".
+    expect(indexOffset).toBeLessThan(seed!.offset);
+    expect(seed!.sql).toMatch(/ON CONFLICT \(is_default\)\s+WHERE is_default\s+DO NOTHING/);
+  });
+});

--- a/db/init/01-schema.sql
+++ b/db/init/01-schema.sql
@@ -119,10 +119,24 @@ CREATE TABLE IF NOT EXISTS world_views (
     updated_at TIMESTAMPTZ DEFAULT NOW()
 );
 
+-- At most one world view carries is_default (GADM's). That is all an index can
+-- state — zero defaults satisfies it too, which is why deleteWorldView refuses
+-- to delete the default one (backend/src/controllers/worldView/worldViewCrud.ts);
+-- the two together keep it at exactly one.
+--
+-- The index also doubles as the arbiter for the seed below, which is what makes
+-- re-applying this file to an existing database idempotent. Without it the
+-- seed's ON CONFLICT had nothing to fire on — world_views has no unique
+-- constraint besides the serial primary key, so every re-application inserted
+-- another "GADM (Default)" row. Databases that predate the index get it from
+-- db/migrations/006-single-default-world-view.sql, which clears the duplicates
+-- the index would otherwise reject.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_world_views_single_default ON world_views(is_default) WHERE is_default;
+
 -- Insert GADM as the default hierarchy
 INSERT INTO world_views (name, description, is_default, is_active)
 VALUES ('GADM', 'Global Administrative Areas - Default hierarchy from GADM database', true, true)
-ON CONFLICT DO NOTHING;
+ON CONFLICT (is_default) WHERE is_default DO NOTHING;
 
 -- =============================================================================
 -- Regions (user-defined groupings within a WorldView)

--- a/db/migrations/006-single-default-world-view.sql
+++ b/db/migrations/006-single-default-world-view.sql
@@ -1,0 +1,87 @@
+-- Migration 006: Remove duplicate default world views and add the unique index
+--
+-- One-shot cleanup for databases that already carry more than one row with
+-- is_default = true, produced by a since-fixed non-idempotent seed in
+-- db/init/01-schema.sql (#434). That seed was guarded by a bare
+-- `ON CONFLICT DO NOTHING`, but world_views had no unique constraint besides
+-- its serial primary key, so the guard had nothing to fire on and every
+-- re-application of the schema file inserted another "GADM (Default)" row.
+-- Idempotent: re-running on a clean DB is a no-op.
+--
+-- Strategy: keep the lowest-id default row — the one the database has used
+-- since it was created — and delete the later copies. The partial unique index
+-- then makes the duplicate state unreachable, and is what the repaired seed's
+-- `ON CONFLICT (is_default) WHERE is_default` infers as its arbiter.
+--
+-- SAFETY: on the known dev installation the duplicate was completely orphaned
+-- (no regions, no import runs). On another database the duplicate could have
+-- been picked in the World View selector and had regions created under it, and
+-- both FKs are ON DELETE CASCADE, so the pre-flight DO block aborts the whole
+-- transaction instead of cascading real data away. The operator then decides
+-- per row — re-point the regions to the kept world view, or clear is_default on
+-- the row worth keeping as a custom world view — and re-runs. region_render_geom
+-- needs no check: it is a VIEW over regions, not a table.
+--
+-- Wrapped in BEGIN/COMMIT so the pre-flight, DELETE and CREATE INDEX succeed or
+-- fail together. Plain `CREATE INDEX` (not CONCURRENTLY) is transactional in
+-- PostgreSQL.
+--
+-- Order: apply this to an existing database BEFORE re-applying 01-schema.sql to
+-- it. Both statements in that file depend on this one having run: the index
+-- creation fails while duplicates remain, and the seed's ON CONFLICT inference
+-- fails while the index is missing.
+
+-- psql exits 0 on a failed statement unless this is set, which would report the
+-- pre-flight abort below as a success to whatever ran the file. Set here rather
+-- than left to the caller: the safety design of this migration is worth nothing
+-- if the abort is silent.
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+-- Block concurrent writers on world_views for the duration of the migration so
+-- the pre-flight check can't be invalidated before the DELETE. EXCLUSIVE does
+-- not conflict with ACCESS SHARE, so plain SELECTs still go through. Lock is
+-- released at COMMIT/ROLLBACK.
+LOCK TABLE world_views IN EXCLUSIVE MODE;
+
+-- Stage the default rows the migration would delete: every one but the oldest.
+CREATE TEMP TABLE _duplicate_defaults ON COMMIT DROP AS
+SELECT id FROM (
+  SELECT id, ROW_NUMBER() OVER (ORDER BY id) AS rn
+  FROM world_views
+  WHERE is_default
+) ranked WHERE rn > 1;
+
+DO $$
+DECLARE
+  bad   text := '';
+  n     bigint;
+  total bigint := (SELECT count(*) FROM _duplicate_defaults);
+BEGIN
+  IF total = 0 THEN
+    -- Fresh database, or already cleaned up — nothing to check.
+    RETURN;
+  END IF;
+
+  -- regions.world_view_id — CASCADE would delete every region under the copy
+  SELECT count(*) INTO n FROM regions
+    WHERE world_view_id IN (SELECT id FROM _duplicate_defaults);
+  IF n > 0 THEN bad := bad || format(E'\n  - regions: %s row(s) (CASCADE delete)', n); END IF;
+
+  -- import_runs.world_view_id — CASCADE would delete the import history
+  SELECT count(*) INTO n FROM import_runs
+    WHERE world_view_id IN (SELECT id FROM _duplicate_defaults);
+  IF n > 0 THEN bad := bad || format(E'\n  - import_runs: %s row(s) (CASCADE delete)', n); END IF;
+
+  IF bad <> '' THEN
+    RAISE EXCEPTION E'Migration 006 aborted: % duplicate default world view(s) have dependent data:%\nManual cleanup required: re-point the dependents to the kept (lowest-id) default world view, or clear is_default on the row you want to keep as a custom world view, then re-run.', total, bad;
+  END IF;
+END $$;
+
+DELETE FROM world_views WHERE id IN (SELECT id FROM _duplicate_defaults);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_world_views_single_default
+  ON world_views(is_default) WHERE is_default;
+
+COMMIT;

--- a/db/migrations/README.md
+++ b/db/migrations/README.md
@@ -1,10 +1,38 @@
 # Database Migrations
 
-This directory is empty because no production release exists yet.
+`db/init/01-schema.sql` is the canonical schema — tables, indexes, triggers,
+tile functions and the auth system. It is the only file in `db/init/`, and
+Postgres applies it automatically when a database is created empty
+(`docker-entrypoint-initdb.d`, see `docker-compose.yml`).
 
-All schema changes have been consolidated into the init scripts:
-- `db/init/01-schema.sql` - Tables, indexes, triggers, and auth system
-- `db/init/02-martin-functions.sql` - Martin vector tile functions
-- `db/init/03-geom-3857-columns.sql` - SRID 3857 columns and simplification
+The numbered files in this directory carry what a database holding data cannot
+get from that file: one-shot cleanups, backfills, and DDL that fails while the
+old rows are still there. Apply them by hand, in filename order:
 
-For new databases, run the init scripts in order. Migration files will be added here after the first production release when backwards compatibility becomes necessary.
+```bash
+npm run db:run-sql -- -v ON_ERROR_STOP=1 < db/migrations/006-single-default-world-view.sql
+```
+
+The flag is not optional. `db:run-sql` is plain `psql`, and psql exits 0 when a
+statement in a piped script fails, so without it a migration that aborts on
+purpose — 006 refuses to run when a row it would delete still has dependents —
+reports success to the shell. `006` also sets `\set ON_ERROR_STOP on` in the
+file itself so it cannot be defeated by the way it is invoked; `001`-`005`
+predate that habit.
+
+Nothing records which of these files a given database has already seen — that
+state is tribal knowledge today. Issue #435 tracks adding a `schema_migrations`
+ledger and a runner.
+
+Re-applying `01-schema.sql` to an existing database is the other half of the
+workflow: it is how new tables and columns arrive between migrations. That is
+why the file has to stay idempotent — DDL uses `IF NOT EXISTS` / `OR REPLACE`,
+and every seed `INSERT` names an explicit `ON CONFLICT` arbiter backed by a real
+unique index. A bare `ON CONFLICT DO NOTHING` is not a guard: on a table whose
+only unique constraint is a serial primary key it never fires, and the seed row
+is inserted again on every run. That is exactly how a second default world view
+appeared (#434). `backend/src/db/schemaSeeds.test.ts` guards the rule.
+
+A migration that adds a constraint the existing rows violate has to run *before*
+the next re-application of `01-schema.sql`, since the schema file will otherwise
+fail on the same constraint. Each such migration says so in its header.

--- a/docs/tech/world-views.md
+++ b/docs/tech/world-views.md
@@ -55,6 +55,24 @@ A named collection of regions representing a custom way of organizing the world:
 - "My Travel Map" - personal organization of visited areas
 - "Sales Territories" - business regions
 
+#### The default World View
+
+GADM is the default World View, seeded with `is_default = true` by
+`db/init/01-schema.sql`. The partial unique index
+`idx_world_views_single_default` (`ON world_views(is_default) WHERE is_default`)
+enforces **at most one** default — zero would satisfy it as well, so the second
+half of the invariant lives in the API: `deleteWorldView` refuses to delete the
+default World View. Together they keep it at exactly one.
+
+The index is also the `ON CONFLICT` arbiter that keeps the seed idempotent when
+the schema file is re-applied to an existing database. Databases created before
+it exists get both the cleanup and the index from
+`db/migrations/006-single-default-world-view.sql`.
+
+The default World View is admin-only — `useNavigation` hides it from everyone
+else — so a duplicate default row is visible only to admins, as a repeated
+"GADM (Default)" entry in the World View picker.
+
 ### Region
 A node in the World View hierarchy that can contain:
 - **Administrative Divisions** - direct references to GADM boundaries


### PR DESCRIPTION
## Description

The World View picker listed **two "GADM (Default)" entries** to admins.
Both were real rows: `world_views` held id=1 (2026-06-02) and an exact
copy at id=3 (2026-07-18), the latter with no regions, no import runs
and no cached render geometry.

Root cause is the GADM seed in `db/init/01-schema.sql`. It was guarded
by a bare `ON CONFLICT DO NOTHING`, but `world_views` has no unique
constraint beyond its serial primary key, so there was nothing for the
guard to fire on and a fresh serial id never collides. Every
re-application of the schema file to an existing database — the way a
running dev database picks up new tables and columns until the first
release — inserted another default row. The contrast is visible in the
same file: `experience_categories` has `UNIQUE(name)` and its seeds,
pinned with `ON CONFLICT (name)`, never duplicated.

The duplicate also made the auto-selected world view nondeterministic:
`getWorldViews` orders by `(is_default, name)`, on which the two GADM
rows tie exactly.

This branch adds a partial unique index on `is_default`, which states
the domain invariant — exactly one default world view — and makes the
seed idempotent as a consequence, since the seed's `ON CONFLICT` now
names it as arbiter. The index is mirrored in the Drizzle schema, and a
test asserts every seed in the file names an explicit arbiter.

## Related Issues

None — no open issue covers this.

## How Was This Tested?

New `backend/src/db/schemaSeeds.test.ts` (2 cases): every seed names an
explicit `ON CONFLICT` arbiter, and the arbiter index is declared before
the INSERT that uses it. Verified red against the pre-fix schema (2
failed) and green after.

Behaviour was checked against a throwaway database, since the unit tier
runs without Docker and cannot reach one:

- pre-fix, applying `01-schema.sql` twice produced two `GADM (Default)`
  rows; post-fix, three consecutive applications leave exactly one, with
  no errors
- a second default row is rejected by the index; non-default world views
  are unaffected
- with the index in place, even the old bare `ON CONFLICT DO NOTHING`
  can no longer duplicate — three such inserts yield one row
- the test stack's fresh database, built from `db/init`, carries the
  index and exactly one default; the E2E fixture seeds `isDefault:
  false`, so it is unaffected

Gates on this branch: lint + typecheck + knip + lint:extra + npm audit
green, unit tests 377/377, E2E smoke 4/4, Semgrep Node and Python 0
findings, Trivy on the cv-python image 0 fixable HIGH/CRITICAL.

## Checklist

- [x] Commit messages follow the standard template.
- [x] All commits are signed.
- [x] Related issues are mentioned in the description above.
- [x] Linter checks have been passed.

## Additional Comments

Two things a reviewer should know.

**Existing databases do not get the index.** There is no migration
runner yet, so only fresh databases from `db/init` — and those where the
schema is re-applied — pick it up. A database that already carries a
duplicate default will reject the index until the extra row is removed.
The dev database was cleaned with the statement below, written so it
cannot touch the real GADM row or any row carrying data:

```sql
DELETE FROM world_views
 WHERE is_default
   AND id <> (SELECT min(id) FROM world_views WHERE is_default)
   AND NOT EXISTS (SELECT 1 FROM regions r            WHERE r.world_view_id = world_views.id)
   AND NOT EXISTS (SELECT 1 FROM import_runs i        WHERE i.world_view_id = world_views.id)
   AND NOT EXISTS (SELECT 1 FROM region_render_geom g WHERE g.world_view_id = world_views.id);
```

**Python-side gates were not run locally** — this machine has no
`cv-python/.venv`, so `check:py`, Bandit, pip-audit and `test:py` were
skipped. The diff contains no Python; CI's `check` and `python-tests`
jobs cover them.

Unrelated to this diff but found while running the pre-push tier:
`npm run security:image` cannot work on a developer machine as written.
It runs the Trivy container without mounting the Docker socket, so the
scanner never sees the image it just built, and it omits the
`--ignore-unfixed` that the CI job passes — without which unfixed base
image CVEs fail the scan locally while CI stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HGqDhVo3CtLNgb7Kig6Lov