### PR TITLE
Let a curator's claim on one metadata key survive the next run — and say so

### DIFF
--- a/backend/src/controllers/experience/curationController.ts
+++ b/backend/src/controllers/experience/curationController.ts
@@ -17,6 +17,7 @@ import {
   CURATOR_SCOPED_REGIONS_CTE,
   CURATOR_UNRESTRICTED_SCOPE_EXISTS,
 } from '../../middleware/auth.js';
+import { METADATA_CLAIM_PREFIX } from '../../services/sync/changeSet.js';
 
 const UNSAFE_URL_SCHEMES = /^(javascript|data|vbscript|blob):/i;
 
@@ -378,8 +379,8 @@ function buildUpdateQuery(
   }
 
   const curatedFieldNames = updates.map(u => u.column);
-  if (hasWebsiteUpdate) curatedFieldNames.push('metadata.website');
-  if (hasWikipediaUpdate) curatedFieldNames.push('metadata.wikipediaUrl');
+  if (hasWebsiteUpdate) curatedFieldNames.push(`${METADATA_CLAIM_PREFIX}website`);
+  if (hasWikipediaUpdate) curatedFieldNames.push(`${METADATA_CLAIM_PREFIX}wikipediaUrl`);
   const newCurated = [...new Set([...existingCurated, ...curatedFieldNames])];
   setClauses.push(`curated_fields = $${paramIdx}`);
   values.push(JSON.stringify(newCurated));

--- a/backend/src/services/sync/changeSet.test.ts
+++ b/backend/src/services/sync/changeSet.test.ts
@@ -7,7 +7,9 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { computeChangeSet, type ExperienceSnapshot } from './changeSet.js';
+import {
+  computeChangeSet, CURATED_KEY_BY_FIELD, METADATA_CLAIM_PREFIX, type ExperienceSnapshot,
+} from './changeSet.js';
 
 function snapshot(overrides: Partial<ExperienceSnapshot> = {}): ExperienceSnapshot {
   return {
@@ -119,6 +121,14 @@ describe('computeChangeSet', () => {
 
     expect(result.significance).toBe('minor');
     expect(result.changedFields.map(f => f.field)).toEqual(['metadata']);
+
+    // The catch-all's payload is stripped of the major keys too, not only a
+    // claimed one: `inDanger`/`dateInscribed` get their own entry whenever
+    // they change, so carrying them here as well -- unchanged, in this
+    // fixture -- would put the same value in two rows, one of them
+    // mislabelled as something this run "applied" alongside areaHectares.
+    expect(result.changedFields[0].old).toEqual({ areaHectares: 1476300 });
+    expect(result.changedFields[0].new).toEqual({ areaHectares: 1476999 });
   });
 
   it('records a curated field as a conflict and not as an applied change', () => {
@@ -166,5 +176,77 @@ describe('computeChangeSet', () => {
     const result = computeChangeSet(snapshot(), incoming, []);
 
     expect(result.significance).toBe('major');
+  });
+});
+
+describe('a metadata key claimed per key', () => {
+  const before = snapshot({ metadata: { website: 'https://curator.example', artworkCount: 5 } });
+  const incoming = snapshot({ metadata: { website: 'https://source.example', artworkCount: 9 } });
+
+  it('reports the claimed key as a conflict, not as an applied change', () => {
+    const result = computeChangeSet(before, incoming, ['metadata.website']);
+
+    const conflictFields = result.curatedConflicts.map(c => c.field);
+    expect(conflictFields).toContain('metadata.website');
+    expect(result.changedFields.map(c => c.field)).not.toContain('metadata.website');
+  });
+
+  it('still reports the unclaimed keys as applied, because the run applied them', () => {
+    const result = computeChangeSet(before, incoming, ['metadata.website']);
+
+    // Exactly one applied field, named 'metadata', and exactly one conflict —
+    // not just "changedFields contains 'metadata' somewhere", which would
+    // hold even if the claimed key leaked into the same catch-all entry.
+    expect(result.changedFields.map(c => c.field)).toEqual(['metadata']);
+    expect(result.curatedConflicts).toHaveLength(1);
+    expect(result.changeType).toBe('updated');
+
+    // The applied row's own payload must not carry the value that was not
+    // applied — only what this run actually wrote lives in the row labelled
+    // applied (#488, one layer in).
+    const applied = result.changedFields[0];
+    expect(applied.old).not.toHaveProperty('website');
+    expect(applied.new).not.toHaveProperty('website');
+    expect(applied.new).toMatchObject({ artworkCount: 9 });
+  });
+
+  it('keeps a whole-column claim as a conflict, with nothing else applied', () => {
+    const result = computeChangeSet(before, incoming, ['metadata']);
+
+    expect(result.curatedConflicts.map(c => c.field)).toContain('metadata');
+    expect(result.changedFields).toHaveLength(0);
+    expect(result.changeType).toBe('unchanged');
+  });
+
+  it('lets an orphaned claim fall through as applied, because the guard would too', () => {
+    // The claim survives in curated_fields, but the key itself is gone from
+    // the stored row — e.g. wiped by a run that predates this guard. The SQL
+    // guard only re-applies a claimed key that `experiences.metadata ?
+    // claimed.k`, so a missing key gets no protection and the source's value
+    // is written; the report must agree, not raise a conflict over a write
+    // that already happened.
+    const orphanedBefore = snapshot({ metadata: { artworkCount: 5 } });
+    const result = computeChangeSet(orphanedBefore, incoming, ['metadata.website']);
+
+    expect(result.curatedConflicts).toHaveLength(0);
+    expect(result.changedFields.map(c => c.field)).toEqual(['metadata']);
+    expect(result.changedFields[0].new).toMatchObject({ website: 'https://source.example' });
+  });
+});
+
+describe('CURATED_KEY_BY_FIELD', () => {
+  it('keeps every dotted key spelled with the shared claim prefix', () => {
+    const dottedKeys = Object.keys(CURATED_KEY_BY_FIELD).filter(key => key.includes('.'));
+
+    // Not a computed key -- the map stays a readable literal on purpose --
+    // but every dotted entry still has to start with the same prefix the
+    // major-key loop composes a diff's field name from. If the prefix ever
+    // changed here and not there, a diff for `metadata.inDanger` would stop
+    // matching this map's key of the same literal spelling, the `?? diff.field`
+    // fallback would take over, and a whole-column claim on 'metadata' would
+    // stop protecting the major keys -- with no behavioural test catching it,
+    // since none combines a whole-column claim with a major-key change.
+    expect(dottedKeys.length).toBeGreaterThan(0);
+    dottedKeys.forEach(key => expect(key.startsWith(METADATA_CLAIM_PREFIX)).toBe(true));
   });
 });

--- a/backend/src/services/sync/changeSet.ts
+++ b/backend/src/services/sync/changeSet.ts
@@ -50,6 +50,16 @@ export const LOCATION_MAJOR_METERS = 1000;
 /** Metadata keys whose change is a product event, not bookkeeping. */
 const MAJOR_METADATA_KEYS = ['inDanger', 'dateInscribed'] as const;
 
+/**
+ * The `curated_fields` prefix for a per-key metadata claim (`metadata.website`,
+ * never `metadata` itself). The upsert's SQL guard in `syncUtils.ts` parses the
+ * same claims out of the same column and needs the identical prefix to find
+ * them and to know how many characters to strip off the front -- one constant
+ * shared by both, instead of the same literal spelled out independently in
+ * more than one place, where the two could silently drift apart (#488).
+ */
+export const METADATA_CLAIM_PREFIX = 'metadata.';
+
 /** Snapshot fields that are `major` when they differ. `location` is synthetic. */
 const MAJOR_FIELDS = new Set(['name', 'location', 'countryCodes']);
 
@@ -149,7 +159,7 @@ function metadataChanges(
 
   for (const key of MAJOR_METADATA_KEYS) {
     if (!jsonEquals(left[key], right[key])) {
-      changes.push({ field: `metadata.${key}`, old: left[key], new: right[key], significance: 'major' });
+      changes.push({ field: `${METADATA_CLAIM_PREFIX}${key}`, old: left[key], new: right[key], significance: 'major' });
     }
   }
 

--- a/backend/src/services/sync/changeSet.ts
+++ b/backend/src/services/sync/changeSet.ts
@@ -144,14 +144,25 @@ function fieldSignificance(field: string): FieldSignificance {
   return MAJOR_FIELDS.has(field) ? 'major' : 'minor';
 }
 
+/** Keys a curator claimed individually, as bare key names. */
+function claimedMetadataKeys(curatedFields: string[]): string[] {
+  return curatedFields
+    .filter(key => key.startsWith(METADATA_CLAIM_PREFIX))
+    .map(key => key.slice(METADATA_CLAIM_PREFIX.length))
+    .filter(key => !(MAJOR_METADATA_KEYS as readonly string[]).includes(key));
+}
+
 /**
- * Metadata is diffed in two parts: the keys a product decision hangs on
+ * Metadata is diffed in three parts: the keys a product decision hangs on
  * (a site entering the danger list) are reported individually and count as
- * major, and everything else collapses into one minor entry.
+ * major, a key a curator claimed individually is also reported on its own so
+ * a claim on it can be told apart from the catch-all, and everything else
+ * collapses into one minor entry.
  */
 function metadataChanges(
   before: Record<string, unknown> | null,
   incoming: Record<string, unknown> | null,
+  curatedFields: string[],
 ): RawDiff[] {
   const changes: RawDiff[] = [];
   const left = before ?? {};
@@ -163,20 +174,57 @@ function metadataChanges(
     }
   }
 
-  const withoutMajorKeys = (source: Record<string, unknown>) => {
+  // A key the curator claimed is reported on its own, so the queue can name it
+  // and the upsert's per-key guard (#488) has something to correspond to. Left
+  // inside the catch-all it would be invisible: one 'metadata' diff carrying
+  // both the key the run kept and the keys it applied.
+  //
+  // The filter mirrors the guard's own condition, not just its key: the SQL
+  // only re-applies a claimed key when the stored row still carries it
+  // (`experiences.metadata ? claimed.k` in syncUtils.ts). That is key presence,
+  // not value truth — `'{"a":null}'::jsonb ? 'a'` is true — so a curator who
+  // deliberately cleared a value and still claims it stays protected. `hasOwn`
+  // is presence too, which is what makes the two sides agree; a truthiness test
+  // would not (`!!null` is false). A claim whose key the row no longer has falls
+  // straight through in the upsert and the source's value gets written, so
+  // treating it as a conflict here would offer a curator "accept" on a value
+  // that is already applied. Unreachable today — nothing writes such an
+  // orphaned claim — but the two sides should agree by construction.
+  const claimed = claimedMetadataKeys(curatedFields).filter(key => Object.hasOwn(left, key));
+  for (const key of claimed) {
+    if (!jsonEquals(left[key], right[key])) {
+      changes.push({ field: `${METADATA_CLAIM_PREFIX}${key}`, old: left[key], new: right[key], significance: 'minor' });
+    }
+  }
+
+  const ignoredKeys = [...MAJOR_METADATA_KEYS, ...claimed];
+  const withoutReportedKeys = (source: Record<string, unknown>) => {
     const copy = { ...source };
-    for (const key of MAJOR_METADATA_KEYS) delete copy[key];
+    for (const key of ignoredKeys) delete copy[key];
     return copy;
   };
 
-  if (!jsonEquals(withoutMajorKeys(left), withoutMajorKeys(right))) {
-    changes.push({ field: 'metadata', old: before, new: incoming, significance: 'minor' });
+  // Both sides stripped of what was already reported on its own — major or
+  // individually claimed — so the payload matches the label: a key claimed
+  // and kept has already had its say in a conflict row above, and carrying
+  // its value here too would show a curator that value inside a row marked
+  // applied, right next to the row saying it was refused (#488, one layer in:
+  // the field was already reported in the right bucket; this is what that
+  // bucket's own row says happened).
+  const strippedLeft = withoutReportedKeys(left);
+  const strippedRight = withoutReportedKeys(right);
+  if (!jsonEquals(strippedLeft, strippedRight)) {
+    changes.push({ field: 'metadata', old: strippedLeft, new: strippedRight, significance: 'minor' });
   }
 
   return changes;
 }
 
-function collectDifferences(before: ExperienceSnapshot, incoming: ExperienceSnapshot): RawDiff[] {
+function collectDifferences(
+  before: ExperienceSnapshot,
+  incoming: ExperienceSnapshot,
+  curatedFields: string[],
+): RawDiff[] {
   const diffs: RawDiff[] = [];
 
   const textFields = ['name', 'description', 'shortDescription', 'category', 'imageUrl'] as const;
@@ -210,7 +258,7 @@ function collectDifferences(before: ExperienceSnapshot, incoming: ExperienceSnap
     });
   }
 
-  diffs.push(...metadataChanges(before.metadata, incoming.metadata));
+  diffs.push(...metadataChanges(before.metadata, incoming.metadata, curatedFields));
 
   return diffs;
 }
@@ -236,9 +284,12 @@ export function computeChangeSet(
   const changedFields: FieldChange[] = [];
   const curatedConflicts: FieldChange[] = [];
 
-  for (const diff of collectDifferences(before, incoming)) {
-    const protectedBy = CURATED_KEY_BY_FIELD[diff.field];
-    const isProtected = protectedBy !== undefined && curated.has(protectedBy);
+  for (const diff of collectDifferences(before, incoming, curatedFields)) {
+    // Fall back to the field's own name, exactly as `claimKeyFor` does in
+    // lifecycleController: a claim key is not always a column, and
+    // 'metadata.website' is claimed under that literal name (#488).
+    const protectedBy = CURATED_KEY_BY_FIELD[diff.field] ?? diff.field;
+    const isProtected = curated.has(protectedBy);
     const change: FieldChange = { ...diff, curatedConflict: isProtected };
     if (isProtected) curatedConflicts.push(change);
     else changedFields.push(change);

--- a/backend/src/services/sync/syncUtils.ts
+++ b/backend/src/services/sync/syncUtils.ts
@@ -8,7 +8,9 @@ import { eq } from 'drizzle-orm';
 import { pool, db } from '../../db/index.js';
 import { experienceSyncLogs, experienceCategories } from '../../db/schema.js';
 import { writeExperienceLocations, type LocationWriteResult } from './locationWriter.js';
-import { computeChangeSet, type ChangeSetResult, type ExperienceSnapshot } from './changeSet.js';
+import {
+  computeChangeSet, METADATA_CLAIM_PREFIX, type ChangeSetResult, type ExperienceSnapshot,
+} from './changeSet.js';
 
 // =============================================================================
 // Experience Upsert
@@ -166,7 +168,25 @@ export async function upsertExperienceRecord(
         country_codes = CASE WHEN experiences.curated_fields ? 'country_codes' THEN experiences.country_codes ELSE EXCLUDED.country_codes END,
         country_names = CASE WHEN experiences.curated_fields ? 'country_names' THEN experiences.country_names ELSE EXCLUDED.country_names END,
         image_url = CASE WHEN experiences.curated_fields ? 'image_url' THEN experiences.image_url ELSE EXCLUDED.image_url END,
-        metadata = CASE WHEN experiences.curated_fields ? 'metadata' THEN experiences.metadata ELSE EXCLUDED.metadata END,
+        -- Two claim shapes reach this column, and only one of them used to work.
+        -- editExperience claims per key -- 'metadata.website',
+        -- 'metadata.wikipediaUrl' -- and ? 'metadata' is false for those, so
+        -- the guard never fired and EXCLUDED replaced the object, curator's link
+        -- included (#488). A claim on 'metadata' itself still holds the whole
+        -- column; a per-key claim now re-applies just those keys over whatever
+        -- the source sent, so an unclaimed key still updates.
+        metadata = CASE
+          WHEN experiences.curated_fields ? 'metadata' THEN experiences.metadata
+          ELSE COALESCE(EXCLUDED.metadata, '{}'::jsonb) || COALESCE((
+                 SELECT jsonb_object_agg(claimed.k, experiences.metadata -> claimed.k)
+                 FROM (
+                   SELECT substring(key FROM ${METADATA_CLAIM_PREFIX.length + 1}) AS k
+                   FROM jsonb_array_elements_text(experiences.curated_fields) AS t(key)
+                   WHERE key LIKE '${METADATA_CLAIM_PREFIX}%'
+                 ) AS claimed
+                 WHERE experiences.metadata ? claimed.k
+               ), '{}'::jsonb)
+        END,
         last_seen_sync_log_id = COALESCE(EXCLUDED.last_seen_sync_log_id, experiences.last_seen_sync_log_id),
         last_seen_at = NOW(),
         missing_since = NULL,

--- a/backend/src/services/sync/syncUtils.upsert.test.ts
+++ b/backend/src/services/sync/syncUtils.upsert.test.ts
@@ -4,6 +4,12 @@
  * The upsert has to answer two questions in one round trip: what the row looked
  * like before, and what it looks like now. These tests pin the shape of that
  * answer and the promise that a dry run writes nothing.
+ *
+ * A mocked pool only pins the SQL's text; it never runs the query, so it cannot
+ * prove the metadata merge actually behaves as claimed. That proof is at the
+ * database level instead -- a live sync run, and the statement run against real
+ * rows inside BEGIN...ROLLBACK -- documented in the commit that introduced the
+ * per-key guard below, not in these regexes.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -14,6 +20,7 @@ vi.mock('../../db/index.js', () => ({
 
 import { pool } from '../../db/index.js';
 import { upsertExperienceRecord, type ExperienceUpsertParams } from './syncUtils.js';
+import { METADATA_CLAIM_PREFIX } from './changeSet.js';
 
 const mockedQuery = pool.query as unknown as ReturnType<typeof vi.fn>;
 
@@ -302,5 +309,46 @@ describe('upsertExperienceRecord', () => {
     // Split rather than matched: `\s*` beside `\n` is a backtracking hazard
     // the linter rejects, and the assignment list is one clause per line anyway
     expect(sql.split('\n').some(line => /^\s*existence =/.test(line))).toBe(false);
+  });
+});
+
+describe('metadata is guarded per claimed key, not per column', () => {
+  beforeEach(() => mockedQuery.mockReset());
+
+  it('keeps a key the curator claimed and takes the rest from the source', async () => {
+    mockedQuery.mockResolvedValueOnce({ rows: [returnedRow()] });
+
+    await upsertExperienceRecord(PARAMS, { syncLogId: 42 });
+
+    const [sql] = mockedQuery.mock.calls[0];
+    const text = String(sql);
+    // The whole-column guard stays for a claim on `metadata` itself...
+    expect(text).toMatch(/curated_fields \? 'metadata'/);
+    // ...and a per-key claim re-applies just those keys over the source object.
+    expect(text).toMatch(/jsonb_array_elements_text\(experiences\.curated_fields\)/);
+    expect(text).toMatch(/LIKE 'metadata\.%'/);
+    // The prefix's length has to match how many characters get stripped:
+    // `substring(key FROM n)` keeps the (n-1)th character onward, so a prefix
+    // of length p needs n = p + 1. Deriving n from METADATA_CLAIM_PREFIX
+    // instead of writing the number 10 is what stops the two from silently
+    // drifting apart -- none of the regexes around this one would have
+    // noticed an off-by-one here: it would make every claimed key resolve to
+    // the wrong bare name (e.g. 'ebsite' instead of 'website'), the `WHERE
+    // experiences.metadata ? claimed.k` guard below would never find it in
+    // stored metadata, and no per-key claim would ever be re-applied again.
+    expect(text).toContain(`substring(key FROM ${METADATA_CLAIM_PREFIX.length + 1})`);
+    expect(text).toMatch(/jsonb_object_agg/);
+    // EXCLUDED.metadata must be the LEFT operand of `||` -- the source object is
+    // the base and the claimed keys are overlaid on top of it, which is what lets
+    // the claim win over the source's value for that one key. The four assertions
+    // above still match if the operands are swapped; only this one catches it.
+    expect(text).toMatch(/COALESCE\(EXCLUDED\.metadata, '\{\}'::jsonb\) \|\| COALESCE\(\(\s*SELECT jsonb_object_agg/);
+    // This guard is load-bearing, not decoration: without it, `experiences.metadata
+    // -> claimed.k` is SQL NULL for a key the curator claimed but that never actually
+    // landed in stored metadata, jsonb_object_agg accepts a NULL *value* (only a NULL
+    // *key* throws), and the `||` merge above would overlay `"k": null` on top of
+    // whatever real value the source just sent -- clobbering it. Do not delete this
+    // assertion as noise; it is what stops that regression from going unnoticed.
+    expect(text).toMatch(/WHERE experiences\.metadata \? claimed\.k/);
   });
 });

--- a/db/init/01-schema.sql
+++ b/db/init/01-schema.sql
@@ -1876,7 +1876,7 @@ CREATE TABLE IF NOT EXISTS experience_sync_changes (
 
 COMMENT ON TABLE experience_sync_changes IS 'Per-object provenance for a sync run (issue #480). See ADR-0020.';
 COMMENT ON COLUMN experience_sync_changes.name_snapshot IS 'The name at the time of the run, so the report stays readable if the row is later deleted.';
-COMMENT ON COLUMN experience_sync_changes.changed_fields IS 'Array of {field, old, new, significance, curatedConflict}. Holds the value the source proposed even when curated_fields rejected it, so a curator can accept it later.';
+COMMENT ON COLUMN experience_sync_changes.changed_fields IS 'Array of {field, old, new, significance, curatedConflict}. Each entry holds the value the source proposed for that field even when curated_fields rejected it, so a curator can accept it later.';
 
 -- CREATE TABLE IF NOT EXISTS is a no-op where the table already exists, so a
 -- widened CHECK has to be applied on its own or re-applying this file would

--- a/docs/tech/experiences.md
+++ b/docs/tech/experiences.md
@@ -126,9 +126,9 @@ disagree, and `returned`, where an object flagged `missing_since` is listed agai
 unmodified, after a transient source gap, which is precisely when a field-change requirement
 would have hidden it.
 
-`changed_fields` holds the value the source proposed **even when `curated_fields` rejected
-it**, marked `curatedConflict`. That is what makes a curator's later "accept source" possible;
-without it the proposed value exists nowhere.
+`changed_fields` holds the value the source proposed for a field **even when `curated_fields`
+rejected it**, marked `curatedConflict`. That is what makes a curator's later "accept source"
+possible; without it the proposed value exists nowhere.
 
 **`total_updated` changed meaning.** It used to count every row that passed through
 `ON CONFLICT DO UPDATE`, identical or not. Since migration 009 it counts rows that actually
@@ -811,6 +811,38 @@ the upsert guarded metadata only with `curated_fields ? 'metadata'`, which neith
 satisfies. That guard now also honours a per-key claim on each of them directly (#488),
 re-applying just that key over the source's value. `CURATED_KEY_BY_FIELD` still does
 not carry either key, though, so that fallback is still what represents them here.)
+
+`computeChangeSet` now carries that same fallback (#488) for the metadata keys
+`CURATED_KEY_BY_FIELD` does not carry: such a key, claimed individually and still present on
+the stored row, is diffed on its own, under `metadata.<key>`, and checked against that
+identical name, so a curator's claim on it reports as its own conflict rather than
+disappearing inside the catch-all `metadata` diff. (A claim whose key the row no longer
+carries gets none of that: the guard would not re-apply it either, so it falls through and is
+diffed as part of the catch-all instead, exactly like a key nobody claimed.)
+Before this, `metadataChanges` never produced a diff a per-key claim could match against — the
+claimed key and whatever else changed were one `metadata` diff, which `CURATED_KEY_BY_FIELD`
+protects only as a whole-column claim — so a run that correctly kept the curator's value (the
+per-key guard above) still filed `changed_fields: metadata, curatedConflict: false`: a write
+that never happened, reported as one that did, with no conflict for a queue card to raise. The
+keys nobody claimed individually — other than `inDanger`/`dateInscribed`, which the catch-all
+never carries, claimed or not — still fall into the catch-all and still report as applied,
+because the run did apply them; a claim on `metadata` itself is unaffected and still protects
+the whole column.
+
+A claim on a key the map *does* carry — `metadata.inDanger` or `metadata.dateInscribed` — is
+not this fallback's case, and would still be reported as applied, not as a conflict:
+`CURATED_KEY_BY_FIELD` already has an entry for it, so the `?? diff.field` fallback never
+fires, and the diff is checked against a whole-column claim instead of its own name. The
+upsert's SQL guard does not draw that distinction — it re-applies any claimed `metadata.%` key
+still present in the stored row the same way, major or not — so a per-key claim on one of
+these two, provided the row still carries that key, would be honoured in storage and still
+misreported here, #488's exact shape, unfixed for those two keys. No writer
+produces such a claim today: `editExperience` (`curationController.ts`) only ever adds
+`metadata.website` and `metadata.wikipediaUrl` per key, never the two major ones, so this is a
+doc-truth gap rather than a live one. The rule holds for the keys the map does not carry: there,
+the claim key the queue reads and the claim key the upsert honours are the same string, and
+`computeChangeSet` — producing the very `changed_fields` and `curatedConflicts` the queue
+reads — uses that same string too.
 
 Accepting is always a claim release; whether the value is *also* written on the spot is what
 `ACCEPTABLE_FIELDS` (`lifecycleController.ts`) decides — `name`, `shortDescription`,

--- a/docs/tech/experiences.md
+++ b/docs/tech/experiences.md
@@ -806,9 +806,11 @@ and both `metadata.inDanger` and `metadata.dateInscribed` are claimed as plain `
 as a parameter rather than restated. A `curated_fields` entry is **not** reliably a column
 name: `editExperience` claims `metadata.website` and `metadata.wikipediaUrl` per key, which
 no column matches, so the query falls back to the field's own name for keys the map does not
-carry. (Those two keys are also a pre-existing hole in metadata protection — the upsert
-guards metadata with `curated_fields ? 'metadata'`, which neither of them satisfies. Out of
-scope here, but it is why the invariant cannot be assumed.)
+carry. (Those two keys used to be a pre-existing hole in metadata protection too —
+the upsert guarded metadata only with `curated_fields ? 'metadata'`, which neither
+satisfies. That guard now also honours a per-key claim on each of them directly (#488),
+re-applying just that key over the source's value. `CURATED_KEY_BY_FIELD` still does
+not carry either key, though, so that fallback is still what represents them here.)
 
 Accepting is always a claim release; whether the value is *also* written on the spot is what
 `ACCEPTABLE_FIELDS` (`lifecycleController.ts`) decides — `name`, `shortDescription`,


### PR DESCRIPTION
## Description

**"A curator's claim protects a value from a run" is the sentence the whole future curation design rests
on, and it was false for the two fields a curator is most likely to fix.**

`editExperience` records a claim on a **key** — `curated_fields` gains the string `'metadata.website'`.
The sync upsert guarded the whole **column**:

```sql
metadata = CASE WHEN experiences.curated_fields ? 'metadata'
                THEN experiences.metadata ELSE EXCLUDED.metadata END
```

`? 'metadata'` is false for a dotted key, so the guard never fired, `EXCLUDED.metadata` replaced the
object, and the curator's link went with it. Every other field was safe, because its claim key *is* the
column name the guard tests. Two commits: the first makes the storage honour the claim, the second makes
the run's own record say so.

### 1. The upsert honours a per-key claim

The `CASE` arm becomes a per-key merge: the source's object is the base, and each claimed key **that the
stored row still carries** is overlaid on top. So a claimed key survives and an unclaimed key still
updates — a fix that froze the whole object would have been a regression wearing a fix's clothes.

A claim on `metadata` itself still holds the whole column, unchanged.

### 2. The change set reports it as the conflict it is — and this half is not theoretical

With the storage fix alone, the run keeps the curator's value and files it as an **applied change**. I
saw it: after a real sync (log 55, museum 6184), `experience_sync_changes` held

```
field: "metadata",  curatedConflict: false
old.website = "https://curator.example/CURATOR-CLAIM-488"   ← the curator's value
new.website = "https://www.louvre.fr/zh-hans"               ← the source's value
```

while the database still held the curator's value. The record claimed a write that never happened, filed
it as applied, and — because `curatedConflict` was false — raised no queue card, so nobody would ever be
asked about it. The second commit gives a claimed key its own diff and its own conflict, copying the
fallback `lifecycleController` already had: `CURATED_KEY_BY_FIELD[field] ?? field`.

The rule, now written down once: **the claim key the queue reads and the claim key the upsert honours are
the same string** — and, after review, the same *condition* too. The SQL only re-applies a claimed key the
stored row still has; the report now only calls it a conflict under the same test. Both sides check key
*presence*, not value truth (`'{"a":null}'::jsonb ? 'a'` is true, and so is `Object.hasOwn({a:null},'a')`),
so a curator who deliberately clears a value and still claims it stays protected on both sides.

### What this means for the people using it

**A measurement worth knowing: no row has ever carried a `metadata.*` claim.** The only claims in this
database are `["admission"]` (9 rows) and `["short_description"]` (3) — the same 12 human touches across
1603 objects. So #488 never actually destroyed anyone's work. It was a loaded gun that would have fired
the first time a curator fixed a museum's website, which is among the most likely edits there is. **This
lands before the loss, not after it.**

**No `docs/vision/vision.md` edit is owed**, because the branch makes three of its existing promises true
rather than adding any:

- "A sync cannot destroy anything a person recorded… curator edits… all survive it"
- "curator edits are protected from being overwritten by automated syncs"
- and the one that matters most: a metadata key "cannot be applied on the spot; accepting those lifts the
  curator's protection and the next sync brings the value in" — a card that was **unreachable** before the
  second commit and is now exactly what ships.

## Related Issues

Closes: #488

One finding was spun out rather than absorbed: **#516** — a curated conflict carries
`significance: 'minor'`, so a row that both refuses a curator's value *and* applies something else is
dropped by the run report's default "Significant only" filter. The one row where a machine and a person
disagreed is the row an admin does not see. Not a regression (the rule predates this work and already
applies to `short_description` claims, and the curator's own queue does not filter on significance), and
it is an admin-surface filter with its own test rather than part of making storage and record agree.

## How Was This Tested?

**Live, end to end, through the real admin UI and the real sync service.** Museum 6184 (Louvre) was given
a claimed sentinel website and an *impossible* `artworkCount` of `-1`, so the source's correction of the
unclaimed key could not be mistaken for anything else. Sync log 55, `success`, 2419 fetched:

| field | before the run | after |
|---|---|---|
| `last_seen_sync_log_id` | 53 | **55** — the row really was processed this run |
| `website` (**claimed**) | curator's sentinel | **unchanged** |
| `artworkCount` (**unclaimed**) | `-1` | **122** — the source corrected it |

The two halves together are what makes this airtight rather than a coincidence: had the guard not fired
and the whole object come from the source, `website` would be the source's value too. Only a per-key merge
produces both results. The row was then restored and the restoration verified, and the whole table swept
for residue — zero rows.

It took two attempts, and the first is worth reporting: sync log 54 died entirely on Wikidata returning
500/504/502/504 across its retries, `total_fetched = 0`, never reaching the upsert. It recorded itself as
`failed` rather than claiming success.

**Also proved against real rows in a rolled-back transaction**, which the live run cannot do because it
exercises one claim shape: the exact statement — *dumped from the runtime and byte-compared*, not
hand-copied — run inside `BEGIN … ROLLBACK` over all three shapes on three real museums. Per-key claim:
claimed key survived, unclaimed `artworkCount` refreshed 109→1109. Whole-column claim: both frozen. No
claim: both took the source's value.

**Mutation-proved, because a mocked pool asserts SQL text and not SQL meaning.** Five mutations, each
reddening exactly its intended test:

| mutation | result |
|---|---|
| swap the `\|\|` operands (source wins again) | the operand-order assertion fails |
| delete the `? claimed.k` guard | the guard assertion fails |
| restore the whole-object payload | the applied-row test fails on `not.toHaveProperty('website')` |
| drop the `Object.hasOwn` filter | the orphaned-claim test fails |
| shift the prefix offset by one (`FROM 10` → `FROM 11`) | the new `substring` assertion fails — **and all six pre-existing regexes stayed green**, which is the whole point of it existing |

**Gates**, every one by exit code rather than by grepping output: `npm test` (799 backend + frontend),
`lint`, `typecheck`, `knip`, `lint:extra`, `lint:circular`, `security:deps`, `security:scan`,
`security:py:semgrep`, `security:image` (Trivy), `test:e2e:smoke` — all 0. Python gates were not re-run,
and the reason is checked rather than assumed: `git diff <base> -- cv-python` is empty and the branch
touches no Python file.

## Checklist
- [x] Commit messages follow the standard template.
- [x] All commits are signed.
- [x] Related issues are mentioned in the description above.
- [x] Linter checks have been passed.

## Additional Comments (if any):

**The best thing review caught, and it is not in the original plan.** The claim prefix `'metadata.'` was
spelled three times as independent literals — `LIKE 'metadata.%'`, `substring(key FROM 10)`, and
`startsWith('metadata.')` — tied together by nothing but a comment. No test mentioned `substring`, so
changing `FROM 10` to `FROM 11` reinstated #488 in full with the entire suite green. Worse than silent:
the second commit would then have filed the loss as a conflict the run *refused*, while the database held
the source's value — the record would have **hidden** the loss instead of revealing it. There is one
exported `METADATA_CLAIM_PREFIX` now, interpolated into the SQL for both the pattern and the offset, so
the off-by-one is arithmetic on a single constant instead of a number a reader has to verify. That makes
the untested part impossible rather than tested, which is the better trade when there is no DB-backed test
harness to reach for.

**One divergence remains, deliberately, and it is a prerequisite rather than a defect.** A claim on a
*major* metadata key — `metadata.inDanger`, `metadata.dateInscribed` — is honoured by the SQL
(`LIKE 'metadata.%'` matches it) but reported as *applied*, because `CURATED_KEY_BY_FIELD` carries those
keys and resolves them to `'metadata'`, which the claim does not contain. Unreachable today:
`EDIT_FIELD_MAP` is a fixed allowlist and the only writer that adds a dotted key adds exactly two
literals. Closing it takes three places, not one — `computeChangeSet`, the queue's
`COALESCE(keyMap->>field, field)`, and `claimKeyFor` — or the conflict is computed and then filtered out
of `proposed`, producing a card that never appears. It is documented in `experiences.md` where it is
relevant, and it is a hard prerequisite for anything that lets a curator claim an arbitrary metadata key.

**Deliberately not changed**, so the omissions are decisions:

- `museumSyncService.ts` still has an unguarded `metadata = EXCLUDED.metadata` — on **`treasures`**, which
  has no `curated_fields` column at all. That is a known gap in the roadmap's own treasure-state design,
  not this branch's.
- `docs/tech/hacking.md`'s invariant ("`curated_fields` must prevent overwrite from sync upserts") is now
  satisfied for every claim shape that exists, so it needed nothing — it is the sentence this bug
  falsified silently for months.
- No ADR edited: ADRs are immutable here, and ADR-0020/0021 say nothing about claim granularity.
- **No migration for the one-line `COMMENT ON COLUMN` change** in `db/init/01-schema.sql`. The comment
  narrows an overstatement (the proposed value lives on *its own* entry now, not on the catch-all), and
  nothing reads it programmatically — verified: no `obj_description` / `col_description` / `pg_description`
  anywhere in the codebase. An existing database keeps its old comment until the file is re-run; a
  migration for a catalog comment would be ceremony. Say the word if you would rather have one.
