### PR TITLE
Give every gated thing somewhere to say nobody has looked yet

### DIFF
--- a/backend/src/controllers/experience/curationController.createManualExperience.test.ts
+++ b/backend/src/controllers/experience/curationController.createManualExperience.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockPoolQuery, mockClientQuery, mockPoolConnect } = vi.hoisted(() => {
+  const clientQuery = vi.fn();
+  return {
+    mockPoolQuery: vi.fn(),
+    mockClientQuery: clientQuery,
+    mockPoolConnect: vi.fn(async () => ({ query: clientQuery, release: vi.fn() })),
+  };
+});
+
+vi.mock('../../db/index.js', () => ({
+  pool: { query: mockPoolQuery, connect: mockPoolConnect },
+}));
+
+import { createManualExperience } from './curationController.js';
+
+const ADMIN = { id: 1, role: 'admin' };
+const CATEGORY_ID = 3;
+const REGION_ID = 20;
+const EXPERIENCE_ID = 555;
+const LOCATION_ID = 777;
+
+const BODY = {
+  name: 'Hand-placed Overlook',
+  shortDescription: 'A curator saw it and typed it in',
+  longitude: 10.5,
+  latitude: 50.5,
+  regionId: REGION_ID,
+  categoryId: CATEGORY_ID,
+};
+
+function makeRes() {
+  return { json: vi.fn(), status: vi.fn().mockReturnThis() };
+}
+
+/**
+ * Queues what `pool.query` answers. The admin role short-circuits
+ * `checkCuratorScope` before it asks the database anything, so the only
+ * `pool.query` call `createManualExperience` makes is the category lookup.
+ * `client.query` then answers the two RETURNING-id inserts the rest of the
+ * write depends on, and `{ rows: [] }` for everything else (BEGIN, the two
+ * link inserts, the audit log insert, COMMIT).
+ */
+function queueQueries() {
+  mockPoolQuery.mockReset();
+  mockClientQuery.mockReset();
+  mockPoolConnect.mockClear();
+  mockPoolQuery.mockResolvedValueOnce({ rows: [{ id: CATEGORY_ID }] });
+  mockClientQuery.mockImplementation(async (sql: string) => {
+    if (typeof sql === 'string' && sql.includes('INSERT INTO experiences')) {
+      return { rows: [{ id: EXPERIENCE_ID }] };
+    }
+    if (typeof sql === 'string' && sql.includes('INSERT INTO experience_locations')) {
+      return { rows: [{ id: LOCATION_ID }] };
+    }
+    return { rows: [] };
+  });
+}
+
+function callCreateManualExperience() {
+  const res = makeRes();
+  return {
+    res,
+    done: createManualExperience(
+      { body: BODY, user: ADMIN } as never,
+      res as never,
+    ),
+  };
+}
+
+/** The SQL text of the `client.query` call whose statement matches `pattern`. */
+function statementFor(pattern: RegExp): string {
+  const call = mockClientQuery.mock.calls.find(
+    ([sql]) => typeof sql === 'string' && pattern.test(sql),
+  ) as [string, unknown[]] | undefined;
+  expect(call, `expected a client.query call matching ${pattern}`).toBeDefined();
+  return call![0];
+}
+
+describe('createManualExperience curation state', () => {
+  beforeEach(() => {
+    queueQueries();
+  });
+
+  it('writes the experience verified and published now, not read from any gate', async () => {
+    const { res, done } = callCreateManualExperience();
+    await done;
+
+    const sql = statementFor(/INSERT INTO experiences/);
+    expect(sql).toMatch(/curation_state/);
+    expect(sql).toMatch(/'verified'/);
+    expect(sql).toMatch(/published_at/);
+    expect(sql).toMatch(/NOW\(\)/);
+    // A person's judgement does not depend on the source's setting: unlike
+    // the sync writer, nothing here may read experience_categories at all.
+    expect(sql).not.toMatch(/requires_curation/);
+    expect(sql).not.toMatch(/CASE/);
+
+    // Both new values are literals, not new bound parameters - the params
+    // array is unchanged from before this insert carried them.
+    const [, params] = mockClientQuery.mock.calls.find(
+      ([callSql]) => typeof callSql === 'string' && /INSERT INTO experiences/.test(callSql),
+    ) as [string, unknown[]];
+    expect(params).toHaveLength(13);
+
+    expect(res.status).toHaveBeenCalledWith(201);
+  });
+
+  it('writes the location verified too - the curator placed the point by hand', async () => {
+    const { done } = callCreateManualExperience();
+    await done;
+
+    const sql = statementFor(/INSERT INTO experience_locations/);
+    expect(sql).toMatch(/curation_state/);
+    expect(sql).toMatch(/'verified'/);
+    expect(sql).not.toMatch(/requires_curation/);
+    expect(sql).not.toMatch(/CASE/);
+  });
+});

--- a/backend/src/controllers/experience/curationController.ts
+++ b/backend/src/controllers/experience/curationController.ts
@@ -646,6 +646,18 @@ function validateCreateManualInput(body: CreateManualBody): string | null {
   return null;
 }
 
+/**
+ * Insert the five rows a hand-made experience needs: the experience itself,
+ * its one location, both region links, and the audit entry.
+ *
+ * The experience and its location are stamped `verified` rather than taking the
+ * column's `auto` default. `auto` means "published unread" (ADR-0025); a curator
+ * who typed this in and placed the point on the map already read it — they wrote
+ * it. There is no source here to gate, so both stamps are the literal rather
+ * than a `CASE` reading `experience_categories.requires_curation` the way the
+ * sync writers do — which is also why neither is the state a sync write would
+ * have produced: that one depends on the source's setting, and this one cannot.
+ */
 async function insertManualExperience(
   client: PoolClient,
   body: CreateManualBody,
@@ -663,11 +675,14 @@ async function insertManualExperience(
     INSERT INTO experiences (
       category_id, external_id, name, short_description, category,
       location, image_url, tags, country_codes, country_names,
-      metadata, is_manual, created_by, status
+      metadata, is_manual, created_by, status, curation_state, published_at
     ) VALUES (
       $1, $2, $3, $4, $5,
       ST_SetSRID(ST_MakePoint($6, $7), 4326), $8, $9, $10, $11,
-      $12, true, $13, 'active'
+      $12, true, $13, 'active',
+      -- Verified from the moment it is created, and visible from the moment
+      -- it exists: see the function comment above.
+      'verified', NOW()
     ) RETURNING id
   `, [
     categoryId,
@@ -687,8 +702,13 @@ async function insertManualExperience(
   const experienceId = expResult.rows[0].id as number;
 
   const locResult = await client.query(`
-    INSERT INTO experience_locations (experience_id, name, ordinal, location)
-    VALUES ($1, $2, 0, ST_SetSRID(ST_MakePoint($3, $4), 4326))
+    INSERT INTO experience_locations (experience_id, name, ordinal, location, curation_state)
+    VALUES (
+      $1, $2, 0, ST_SetSRID(ST_MakePoint($3, $4), 4326),
+      -- Same reasoning as the experience row above: the curator placed this
+      -- point by hand, so it carries the same verdict.
+      'verified'
+    )
     RETURNING id
   `, [experienceId, body.name, body.longitude, body.latitude]);
   const locationId = locResult.rows[0].id as number;

--- a/backend/src/db/schemaMigrationParity.test.ts
+++ b/backend/src/db/schemaMigrationParity.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * The two schema homes must agree.
+ *
+ * `db/init/01-schema.sql` is what an empty database gets and what an existing
+ * one is re-applied to gain new columns; `db/migrations/018-curation-gate.sql`
+ * is what a database already holding data gets by hand. A column added to one
+ * and forgotten in the other is invisible until a fresh database behaves
+ * differently from the dev one — which is exactly the class of bug nobody finds
+ * quickly. There is no database in this suite, so this is a text-level guard;
+ * it cannot prove the SQL runs, only that neither file lost a column.
+ *
+ * Every assertion works on the file with its whitespace collapsed, so the
+ * statements can be indented and wrapped however the files find readable while
+ * the expected text stays a plain literal.
+ */
+const repoRoot = join(__dirname, '..', '..', '..');
+const collapse = (sql: string) => sql.replace(/\s+/g, ' ');
+const schema = collapse(readFileSync(join(repoRoot, 'db', 'init', '01-schema.sql'), 'utf8'));
+const migration = collapse(
+  readFileSync(join(repoRoot, 'db', 'migrations', '018-curation-gate.sql'), 'utf8'),
+);
+/** Uncollapsed, for the one assertion that is about how a line starts. */
+const migrationLines = readFileSync(
+  join(repoRoot, 'db', 'migrations', '018-curation-gate.sql'),
+  'utf8',
+);
+
+const GATE_COLUMNS: Array<[table: string, column: string]> = [
+  ['experiences', 'curation_state'],
+  ['experiences', 'published_at'],
+  ['experiences', 'pending_change_sync_log_id'],
+  ['experience_locations', 'curation_state'],
+  ['experience_treasures', 'curation_state'],
+  ['treasures', 'curation_state'],
+];
+
+/** The three sources that predate the gate and must keep publishing on arrival. */
+const CATEGORIES_BEFORE_THE_GATE = [
+  'UNESCO World Heritage Sites',
+  'Top Art Museums',
+  'Public Art & Monuments',
+];
+
+const STATE_TABLES = ['experiences', 'experience_locations', 'experience_treasures', 'treasures'];
+
+describe('the curation gate exists in both schema homes', () => {
+  for (const [table, column] of GATE_COLUMNS) {
+    it(`01-schema.sql adds ${table}.${column}`, () => {
+      expect(schema).toContain(`ALTER TABLE ${table} ADD COLUMN IF NOT EXISTS ${column}`);
+    });
+
+    it(`migration 018 adds ${table}.${column}`, () => {
+      expect(migration).toContain(`ALTER TABLE ${table} ADD COLUMN IF NOT EXISTS ${column}`);
+    });
+  }
+
+  it('every state column is constrained to the three states, per table, in both files', () => {
+    // A column that accepts any string is a column that will eventually hold
+    // 'Pending' or 'published' and silently stop matching every predicate.
+    // Named per table rather than counted: four occurrences with two on one
+    // table and none on another satisfies a count and leaves a column open.
+    for (const table of STATE_TABLES) {
+      const constraint =
+        `ADD CONSTRAINT ${table}_curation_state_check ` +
+        `CHECK (curation_state IN ('pending', 'auto', 'verified'))`;
+      expect(schema).toContain(constraint);
+      expect(migration).toContain(constraint);
+    }
+  });
+
+  it('both files state the truth about the three categories that predate the gate', () => {
+    // Leaving them `true` would not record that they publish unread,
+    // it would silently change it — every arrival from the next run invisible
+    // with nobody having decided anything. Named one at a time rather than
+    // blanket-updated, so a source added between either file being written and
+    // being applied is not silently trusted.
+    for (const sql of [schema, migration]) {
+      expect(sql).toContain(
+        'UPDATE experience_categories SET requires_curation = false WHERE name IN (',
+      );
+      for (const name of CATEGORIES_BEFORE_THE_GATE) {
+        expect(sql).toContain(`'${name}'`);
+      }
+    }
+  });
+
+  it('creates the gate column and answers for the three predating sources in one guard, identically in both files', () => {
+    // The whole ordering problem lives here. Nothing in this repo records which
+    // of these files a database has seen, and either can reach it first:
+    //
+    //  - an unguarded UPDATE re-runs after an admin has gated a source and
+    //    silently un-gates it;
+    //  - an UPDATE guarded only on the column existing is skipped when the other
+    //    file created the column first, leaving all three gated by the
+    //    `DEFAULT true` backfill — and the next run of each publishing nothing a
+    //    reader can see.
+    //
+    // Creating the column and naming those three inside one guard is what makes
+    // both orders and any number of re-applications come out the same. Asserted
+    // as one block, byte-identical in both files, because a copy that drifted in
+    // either direction is the bug.
+    const named = CATEGORIES_BEFORE_THE_GATE.map(name => `'${name}'`).join(', ');
+    const guard =
+      `DO $$ BEGIN ` +
+      `IF NOT EXISTS ( SELECT 1 FROM information_schema.columns ` +
+      `WHERE table_name = 'experience_categories' AND column_name = 'requires_curation' ` +
+      `) THEN ` +
+      `ALTER TABLE experience_categories ` +
+      `ADD COLUMN requires_curation BOOLEAN NOT NULL DEFAULT true; ` +
+      `UPDATE experience_categories SET requires_curation = false ` +
+      `WHERE name IN (${named}); ` +
+      `END IF; ` +
+      `END $$;`;
+    expect(schema).toContain(guard);
+    expect(migration).toContain(guard);
+  });
+
+  it('never sets requires_curation outside that guard', () => {
+    // An `ADD COLUMN IF NOT EXISTS` for this one column, or a second `UPDATE`
+    // anywhere, reintroduces exactly the ordering hole the guard closes.
+    for (const sql of [schema, migration]) {
+      expect(sql).not.toContain(
+        'ALTER TABLE experience_categories ADD COLUMN IF NOT EXISTS requires_curation',
+      );
+      expect(sql.match(/UPDATE experience_categories SET requires_curation/g) ?? []).toHaveLength(1);
+    }
+  });
+
+  it('every seeded category decides its own gate in 01-schema.sql', () => {
+    // A fresh database gets its categories from these INSERTs and never runs
+    // migration 018, so a seed that omits the column takes the `true` default
+    // and gates a source the migrated database publishes from — the two homes
+    // agreeing about columns while disagreeing about behaviour.
+    const seeds = schema.match(/INSERT INTO experience_categories .*?ON CONFLICT [^;]*;/g) ?? [];
+    // Every seed must be captured, or a future one written without ON CONFLICT
+    // would slip past the loop below without failing anything.
+    expect(seeds.length).toBe((schema.match(/INSERT INTO experience_categories/g) ?? []).length);
+    expect(seeds.length).toBeGreaterThan(0);
+    for (const seed of seeds) {
+      expect(seed).toContain('requires_curation');
+    }
+    // Naming the column is not enough: a seed that names it and passes `true`
+    // would gate a source on every fresh database while the migrated one keeps
+    // publishing from it. The three that predate the gate must say `false`.
+    for (const name of CATEGORIES_BEFORE_THE_GATE) {
+      const seed = seeds.find(statement => statement.includes(`'${name}'`));
+      expect(seed, `${name} is not seeded`).toBeDefined();
+      expect(seed, `${name} is seeded gated`).toContain('false');
+    }
+  });
+
+  it('the migration is not defeated by how it is invoked', () => {
+    // db/migrations/README.md: psql exits 0 when a statement in a piped script
+    // fails, so the file sets this itself rather than trusting the caller.
+    expect(migrationLines).toMatch(/^\\set ON_ERROR_STOP on$/m);
+  });
+});

--- a/backend/src/services/sync/curationDecay.test.ts
+++ b/backend/src/services/sync/curationDecay.test.ts
@@ -1,0 +1,58 @@
+/**
+ * The statement that retires a container's pass when new content arrives.
+ *
+ * A mocked runner can only pin the statement's text. That it actually moves a
+ * `verified` row under a trusted source and leaves one under a gated source was
+ * proved by executing this statement against a real database, both ways, in the
+ * commit that introduced it.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+import { retirePassAfterNewContent } from './curationDecay.js';
+
+function fakeRunner() {
+  const calls: Array<[string, unknown[]]> = [];
+  return {
+    calls,
+    runner: {
+      query: vi.fn(async (sql: string, params: unknown[]) => {
+        calls.push([sql, params]);
+        return { rows: [] };
+      }),
+    },
+  };
+}
+
+describe('retirePassAfterNewContent', () => {
+  it('moves only a verified row, and only for a source nobody gated', async () => {
+    const { calls, runner } = fakeRunner();
+
+    await retirePassAfterNewContent(runner, 501);
+
+    const [sql, params] = calls[0];
+    expect(sql).toContain("SET curation_state = 'auto'");
+    // Scoped to `verified`, so the statement can only ever move a row one way.
+    // A `pending` row is not published and has nothing to decay; an `auto` row
+    // is already there.
+    expect(sql).toContain("e.curation_state = 'verified'");
+    // The gate is read through the experience, because these writers have an
+    // experience id and no category id. Under a gated source the new content was
+    // written `pending` — nothing a reader sees changed, so the pass still holds.
+    expect(sql).toContain('c.id = e.category_id AND c.requires_curation');
+    expect(sql).toContain('NOT EXISTS');
+    expect(params).toEqual([501]);
+  });
+
+  it('never writes any state but auto', async () => {
+    const { calls, runner } = fakeRunner();
+
+    await retirePassAfterNewContent(runner, 501);
+
+    // A run may retire a pass; it may not award one, and it may not hide a row
+    // that is already published.
+    const [sql] = calls[0];
+    expect(sql).not.toContain("SET curation_state = 'pending'");
+    expect(sql).not.toContain("SET curation_state = 'verified'");
+  });
+});

--- a/backend/src/services/sync/curationDecay.ts
+++ b/backend/src/services/sync/curationDecay.ts
@@ -1,0 +1,45 @@
+/**
+ * New content retires the pass that covered its container.
+ *
+ * A curator's `verified` pass covers an experience as it stood when they looked
+ * — its points, and the works a museum was holding. A point or a work the run
+ * has just added is content that pass never covered, so the container goes back
+ * to `auto` and says so (ADR-0025).
+ *
+ * Only under a **trusted** source. A gated one writes its new content
+ * `pending`, so nothing a reader sees has changed and the pass still describes
+ * what is live; retiring it there would punish the row for an arrival nobody
+ * has been shown. The flag is read in SQL through the experience, because these
+ * writers have an experience id and no category id, and a parameter would be a
+ * second source of truth that could disagree with the column between the check
+ * and the write.
+ *
+ * Newly written content only. A point the source stopped offering and now
+ * offers again is not new — the curator saw it before it went missing, and its
+ * row, id and assignments are the same ones.
+ */
+
+/** Whatever runs the statement: a pooled client inside a transaction, or the pool. */
+export interface QueryRunner {
+  query(sql: string, params: unknown[]): Promise<unknown>;
+}
+
+/**
+ * Return `experienceId` from `verified` to `auto`, if a trusted source has just
+ * given it content nobody has passed. A no-op for every other state, and for a
+ * gated source.
+ */
+export async function retirePassAfterNewContent(
+  runner: QueryRunner,
+  experienceId: number,
+): Promise<void> {
+  await runner.query(
+    `UPDATE experiences e SET curation_state = 'auto'
+      WHERE e.id = $1 AND e.curation_state = 'verified'
+        AND NOT EXISTS (
+          SELECT 1 FROM experience_categories c
+           WHERE c.id = e.category_id AND c.requires_curation
+        )`,
+    [experienceId],
+  );
+}

--- a/backend/src/services/sync/locationWriter.test.ts
+++ b/backend/src/services/sync/locationWriter.test.ts
@@ -49,6 +49,10 @@ const RESURRECT = /missing_since = NULL/;
 const KEEP = /SET ordinal = i\.ordinal/;
 /** The arm that records that the source stopped offering a point. */
 const MARK = /missing_since = NOW\(\)/;
+/** The arm that writes a point the experience did not have. */
+const INSERT = /INSERT INTO experience_locations/;
+/** The statement that retires the venue's pass because it gained a point. */
+const DECAY = /UPDATE experiences e SET curation_state = 'auto'/;
 
 describe('writeExperienceLocations', () => {
   beforeEach(() => {
@@ -343,5 +347,32 @@ describe('a new point arrives stamped', () => {
     expect(returned).not.toMatch(/curation_state/);
     expect(kept).not.toMatch(/curation_state/);
     expect(marked).not.toMatch(/curation_state/);
+  });
+
+  it('retires the venue pass when it actually gained a point', async () => {
+    mockedQuery.mockResolvedValue({ rows: [{ stored: '0', matched: '0', ids: null }] });
+    const { client, statements } = fakeClient([[INSERT, { rows: [{ id: 12 }] }]]);
+    mockedConnect.mockResolvedValue(client);
+
+    await writeExperienceLocations(1, [A]);
+
+    // A curator's pass covered the venue with the points it had. In the same
+    // transaction as the insert, because the two are one fact about the object.
+    const decay = statements.find(s => DECAY.test(s));
+    expect(decay).toBeDefined();
+    expect(decay).toMatch(/e\.curation_state = 'verified'/);
+    expect(statements.indexOf(decay!)).toBeLessThan(statements.indexOf('COMMIT'));
+  });
+
+  it('leaves the venue pass alone when no point was added', async () => {
+    mockedQuery.mockResolvedValue({ rows: [{ stored: '1', matched: '0', ids: [7] }] });
+    const { client, statements } = fakeClient();
+    mockedConnect.mockResolvedValue(client);
+
+    await writeExperienceLocations(1, [A]);
+
+    // A point that came back, or one renumbered in place, is not new: the
+    // curator saw it, and the row, its id and its assignments are the same ones.
+    expect(statements.find(s => DECAY.test(s))).toBeUndefined();
   });
 });

--- a/backend/src/services/sync/locationWriter.test.ts
+++ b/backend/src/services/sync/locationWriter.test.ts
@@ -305,3 +305,43 @@ describe('the match predicate', () => {
     });
   });
 });
+
+describe('a new point arrives stamped', () => {
+  // What a mocked client can see is the statement: that the insert decides the
+  // state from the gate and names both outcomes, and that no statement about a
+  // point which already existed touches the column. That the decision comes out
+  // `pending` under a gated source and `auto` under a trusted one was proved by
+  // executing this statement against a real database, both ways.
+  it('decides a new point state from the gate, and leaves an existing point alone', async () => {
+    mockedQuery.mockResolvedValue({ rows: [{ stored: '0', matched: '0', ids: null }] });
+    const { client, statements } = fakeClient();
+    mockedConnect.mockResolvedValue(client);
+
+    await writeExperienceLocations(1, [A]);
+
+    const insert = statements.find(s => /INSERT INTO experience_locations/.test(s));
+    expect(insert).toBeDefined();
+    expect(insert).toMatch(/curation_state/);
+    // The gate is reached through the experience, because this writer has an
+    // experienceId and no categoryId — one subselect rather than a parameter
+    // threaded through three services.
+    expect(insert).toMatch(/FROM experiences[\s\S]*JOIN experience_categories/);
+    // Both branches named, so an edit that stamped every row 'auto' (or every
+    // row 'pending') fails this test instead of passing on column presence alone.
+    expect(insert).toMatch(/THEN 'pending' ELSE 'auto' END/);
+
+    // A returning point, a point renumbered in place, and a point just marked
+    // missing all already had rows before this run started — a curator may
+    // already have passed one of them, so none of these three may touch the
+    // column at all.
+    const returned = statements.find(s => RESURRECT.test(s));
+    const kept = statements.find(s => KEEP.test(s) && !RESURRECT.test(s));
+    const marked = statements.find(s => MARK.test(s));
+    expect(returned).toBeDefined();
+    expect(kept).toBeDefined();
+    expect(marked).toBeDefined();
+    expect(returned).not.toMatch(/curation_state/);
+    expect(kept).not.toMatch(/curation_state/);
+    expect(marked).not.toMatch(/curation_state/);
+  });
+});

--- a/backend/src/services/sync/locationWriter.ts
+++ b/backend/src/services/sync/locationWriter.ts
@@ -58,6 +58,7 @@
  */
 
 import { pool } from '../../db/index.js';
+import { retirePassAfterNewContent } from './curationDecay.js';
 
 export interface IncomingLocation {
   name: string | null;
@@ -287,6 +288,11 @@ export async function writeExperienceLocations(
        RETURNING id`,
       params,
     );
+
+    // A point the curator has never seen is content their pass did not cover,
+    // so the venue stops claiming to have been passed. In the same transaction
+    // as the insert that caused it: the two are one fact about the object.
+    if (inserted.rows.length > 0) await retirePassAfterNewContent(client, experienceId);
 
     await client.query('COMMIT');
 

--- a/backend/src/services/sync/locationWriter.ts
+++ b/backend/src/services/sync/locationWriter.ts
@@ -260,9 +260,23 @@ export async function writeExperienceLocations(
     // visit record pointing at whichever of them the reader is not shown.
     const inserted = await client.query(
       `WITH ${cte}
-       INSERT INTO experience_locations (experience_id, name, external_ref, ordinal, location)
+       INSERT INTO experience_locations (experience_id, name, external_ref, ordinal, location, curation_state)
        SELECT $1, i.name, i.external_ref, i.ordinal,
-              ST_SetSRID(ST_MakePoint(i.lon, i.lat), 4326)
+              ST_SetSRID(ST_MakePoint(i.lon, i.lat), 4326),
+              -- A pending point is written, indexed and placed into regions like
+              -- any other, and no reader-facing read may offer it (ADR-0025):
+              -- keeping it off those reads is one predicate's job rather than a
+              -- reason to withhold the row. Withholding it would leave a region
+              -- curator nothing to review for an arrival.
+              --
+              -- Read from the experience rather than passed in: this writer has
+              -- an experience id and no category id, and a parameter would be a
+              -- second source of truth that could disagree with the column
+              -- between the check and the write.
+              CASE WHEN (SELECT c.requires_curation
+                           FROM experiences e JOIN experience_categories c ON c.id = e.category_id
+                          WHERE e.id = $1)
+                   THEN 'pending' ELSE 'auto' END
        FROM incoming i
        WHERE NOT EXISTS (
          SELECT 1 FROM experience_locations el

--- a/backend/src/services/sync/museumSyncService.treasures.test.ts
+++ b/backend/src/services/sync/museumSyncService.treasures.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Tests for the works a museum puts on show.
+ *
+ * One promise on this path lives in a parameter number and does not announce
+ * itself when it breaks. A treasure is globally shared, so its `curation_state`
+ * cannot be reached through an experience and reads the gate from the museum
+ * category, bound positionally as the last of twelve parameters whose other
+ * members are mostly numbers — swap it with a sitelink threshold and the
+ * statement still runs, still type-checks, and stamps by whether `140` happens
+ * to be a gated category id.
+ *
+ * The stamps themselves were proved against a real database in the commit that
+ * added them: a gated category writing `pending`, a trusted one writing `auto`,
+ * and a stored work keeping the state a curator gave it. What a live run cannot
+ * tell apart from luck is which value the gate was reading, which is what these
+ * pin.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../db/index.js', () => ({
+  pool: { query: vi.fn() },
+  db: {},
+}));
+
+import { pool } from '../../db/index.js';
+import { upsertMuseumTreasures } from './museumSyncService.js';
+import type { ProcessedContent } from './types.js';
+
+const mockedQuery = pool.query as unknown as ReturnType<typeof vi.fn>;
+
+/** `Top Art Museums` — the category a treasure's gate is read from. */
+const MUSEUM_CATEGORY_ID = 2;
+const EXPERIENCE_ID = 77;
+
+function artwork(overrides: Partial<ProcessedContent> = {}): ProcessedContent {
+  return {
+    externalId: 'Q12418',
+    name: 'Mona Lisa',
+    treasureType: 'painting',
+    artist: 'Leonardo da Vinci',
+    year: 1503,
+    imageUrl: 'https://upload.wikimedia.org/mona-lisa.jpg',
+    sitelinksCount: 140,
+    ...overrides,
+  };
+}
+
+/** Answer the two statements each work sends: the treasure upsert, then its link. */
+function scriptWorks(count: number) {
+  for (let index = 0; index < count; index += 1) {
+    mockedQuery.mockResolvedValueOnce({ rows: [{ id: 900 + index }] });
+    mockedQuery.mockResolvedValueOnce({ rows: [] });
+  }
+}
+
+const treasureCall = () => mockedQuery.mock.calls[0];
+const linkCall = () => mockedQuery.mock.calls[1];
+
+describe('a work arrives marked as unread', () => {
+  beforeEach(() => {
+    mockedQuery.mockReset();
+  });
+
+  it('reads the gate from the museum category, whatever number that parameter takes', async () => {
+    scriptWorks(1);
+
+    await upsertMuseumTreasures(EXPERIENCE_ID, [artwork()]);
+
+    // Resolved through the statement rather than asserted as `$12`: the position
+    // is not the promise, the value reaching it is. Renumber the list and this
+    // still passes; bind the gate to `ICONIC_RELEASE` and it fails.
+    const sql = String(treasureCall()[0]);
+    const gate = /requires_curation FROM experience_categories WHERE id = \$(\d+)\)/.exec(sql);
+    expect(gate, 'the treasure insert no longer reads the gate at all').not.toBeNull();
+
+    const params = treasureCall()[1] as unknown[];
+    expect(params[Number(gate![1]) - 1]).toBe(MUSEUM_CATEGORY_ID);
+  });
+
+  it('stamps a work on arrival only, so a pass on a stored work survives the run', async () => {
+    scriptWorks(1);
+
+    await upsertMuseumTreasures(EXPERIENCE_ID, [artwork()]);
+
+    // A treasure is shared by every museum holding it, and a run that found it
+    // again has learnt nothing about whether a person has looked at it.
+    const sql = String(treasureCall()[0]);
+    const onUpdate = sql.slice(sql.indexOf('DO UPDATE SET'));
+    expect(sql.slice(0, sql.indexOf('DO UPDATE SET'))).toContain('curation_state');
+    expect(onUpdate).not.toContain('curation_state');
+  });
+
+  it('reads a link\'s gate through the experience the work is shown in', async () => {
+    scriptWorks(1);
+
+    await upsertMuseumTreasures(EXPERIENCE_ID, [artwork()]);
+
+    // Unlike the treasure, a link belongs to one museum, so it can reach the
+    // category the way every other content row does.
+    const sql = String(linkCall()[0]);
+    expect(sql).toMatch(/FROM experiences e JOIN experience_categories c ON c\.id = e\.category_id/);
+    expect(sql).toMatch(/WHERE e\.id = \$1/);
+    expect(linkCall()[1]).toEqual([EXPERIENCE_ID, 900]);
+  });
+});

--- a/backend/src/services/sync/museumSyncService.treasures.test.ts
+++ b/backend/src/services/sync/museumSyncService.treasures.test.ts
@@ -1,19 +1,22 @@
 /**
  * Tests for the works a museum puts on show.
  *
- * One promise on this path lives in a parameter number and does not announce
- * itself when it breaks. A treasure is globally shared, so its `curation_state`
- * cannot be reached through an experience and reads the gate from the museum
- * category, bound positionally as the last of twelve parameters whose other
- * members are mostly numbers — swap it with a sitelink threshold and the
- * statement still runs, still type-checks, and stamps by whether `140` happens
- * to be a gated category id.
+ * Two promises on this path live in a parameter number and a `RETURNING` clause,
+ * and neither announces itself when it breaks. A treasure is globally shared, so
+ * its `curation_state` cannot be reached through an experience and reads the gate
+ * from the museum category, bound positionally as the last of twelve parameters
+ * whose other members are mostly numbers — swap it with a sitelink threshold and
+ * the statement still runs, still type-checks, and stamps by whether `140`
+ * happens to be a gated category id. And the link's `ON CONFLICT DO NOTHING ...
+ * RETURNING treasure_id` is the only thing telling "the museum gained a work"
+ * from "the run listed one it already had", which is what decides whether a
+ * curator's pass over the whole museum is retired.
  *
  * The stamps themselves were proved against a real database in the commit that
  * added them: a gated category writing `pending`, a trusted one writing `auto`,
  * and a stored work keeping the state a curator gave it. What a live run cannot
- * tell apart from luck is which value the gate was reading, which is what these
- * pin.
+ * tell apart from luck is which value the gate was reading, and whether a link
+ * that was already there counted as an arrival — which is what these pin.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -23,11 +26,17 @@ vi.mock('../../db/index.js', () => ({
   db: {},
 }));
 
+vi.mock('./curationDecay.js', () => ({
+  retirePassAfterNewContent: vi.fn(),
+}));
+
 import { pool } from '../../db/index.js';
+import { retirePassAfterNewContent } from './curationDecay.js';
 import { upsertMuseumTreasures } from './museumSyncService.js';
 import type { ProcessedContent } from './types.js';
 
 const mockedQuery = pool.query as unknown as ReturnType<typeof vi.fn>;
+const mockedRetire = retirePassAfterNewContent as unknown as ReturnType<typeof vi.fn>;
 
 /** `Top Art Museums` — the category a treasure's gate is read from. */
 const MUSEUM_CATEGORY_ID = 2;
@@ -46,12 +55,18 @@ function artwork(overrides: Partial<ProcessedContent> = {}): ProcessedContent {
   };
 }
 
-/** Answer the two statements each work sends: the treasure upsert, then its link. */
-function scriptWorks(count: number) {
-  for (let index = 0; index < count; index += 1) {
+/**
+ * Answer the two statements each work sends, in order: the treasure upsert always
+ * returns an id, and the link returns a row only when it was really inserted —
+ * `DO NOTHING` returns none.
+ */
+function scriptWorks(...links: Array<'new' | 'already linked'>) {
+  links.forEach((kind, index) => {
     mockedQuery.mockResolvedValueOnce({ rows: [{ id: 900 + index }] });
-    mockedQuery.mockResolvedValueOnce({ rows: [] });
-  }
+    mockedQuery.mockResolvedValueOnce({
+      rows: kind === 'new' ? [{ treasure_id: 900 + index }] : [],
+    });
+  });
 }
 
 const treasureCall = () => mockedQuery.mock.calls[0];
@@ -60,10 +75,11 @@ const linkCall = () => mockedQuery.mock.calls[1];
 describe('a work arrives marked as unread', () => {
   beforeEach(() => {
     mockedQuery.mockReset();
+    mockedRetire.mockReset();
   });
 
   it('reads the gate from the museum category, whatever number that parameter takes', async () => {
-    scriptWorks(1);
+    scriptWorks('new');
 
     await upsertMuseumTreasures(EXPERIENCE_ID, [artwork()]);
 
@@ -79,7 +95,7 @@ describe('a work arrives marked as unread', () => {
   });
 
   it('stamps a work on arrival only, so a pass on a stored work survives the run', async () => {
-    scriptWorks(1);
+    scriptWorks('new');
 
     await upsertMuseumTreasures(EXPERIENCE_ID, [artwork()]);
 
@@ -92,7 +108,7 @@ describe('a work arrives marked as unread', () => {
   });
 
   it('reads a link\'s gate through the experience the work is shown in', async () => {
-    scriptWorks(1);
+    scriptWorks('new');
 
     await upsertMuseumTreasures(EXPERIENCE_ID, [artwork()]);
 
@@ -102,5 +118,47 @@ describe('a work arrives marked as unread', () => {
     expect(sql).toMatch(/FROM experiences e JOIN experience_categories c ON c\.id = e\.category_id/);
     expect(sql).toMatch(/WHERE e\.id = \$1/);
     expect(linkCall()[1]).toEqual([EXPERIENCE_ID, 900]);
+  });
+});
+
+describe('new works retire the pass that covered the museum', () => {
+  beforeEach(() => {
+    mockedQuery.mockReset();
+    mockedRetire.mockReset();
+  });
+
+  it('retires the pass when the museum gained a work', async () => {
+    scriptWorks('new');
+
+    await upsertMuseumTreasures(EXPERIENCE_ID, [artwork()]);
+
+    expect(mockedRetire).toHaveBeenCalledTimes(1);
+    expect(mockedRetire).toHaveBeenCalledWith(pool, EXPERIENCE_ID);
+  });
+
+  it('retires nothing when every work was already on show', async () => {
+    scriptWorks('already linked', 'already linked');
+
+    await upsertMuseumTreasures(EXPERIENCE_ID, [artwork(), artwork({ externalId: 'Q45585' })]);
+
+    // The whole point of `RETURNING treasure_id` on a `DO NOTHING`: a run that
+    // re-lists the same twelve paintings has not changed what is on show, and
+    // retiring a curator's pass over it every night would leave the queue saying
+    // nothing. Without the returned row this is indistinguishable from an insert.
+    expect(mockedRetire).not.toHaveBeenCalled();
+  });
+
+  it('retires once for a museum that gained two works, not once per work', async () => {
+    scriptWorks('new', 'already linked', 'new');
+
+    await upsertMuseumTreasures(EXPERIENCE_ID, [
+      artwork(),
+      artwork({ externalId: 'Q45585' }),
+      artwork({ externalId: 'Q19911' }),
+    ]);
+
+    // The fact is that the pass no longer covers everything on show, and it is
+    // one fact whether one work arrived or twelve.
+    expect(mockedRetire).toHaveBeenCalledTimes(1);
   });
 });

--- a/backend/src/services/sync/museumSyncService.ts
+++ b/backend/src/services/sync/museumSyncService.ts
@@ -12,6 +12,7 @@
 
 import { pool } from '../../db/index.js';
 import { upsertExperienceRecord, upsertSingleLocation } from './syncUtils.js';
+import { retirePassAfterNewContent } from './curationDecay.js';
 import { orchestrateSync, getSyncStatus, cancelSync, type FilteredEntity } from './syncOrchestrator.js';
 import type { ProcessItemResult, SyncRunContext } from './syncOrchestrator.js';
 import type { ChangeSetResult } from './changeSet.js';
@@ -180,6 +181,8 @@ export async function upsertMuseumTreasures(
   experienceId: number,
   artworks: ProcessedContent[]
 ): Promise<void> {
+  let linked = false;
+
   for (const artwork of artworks) {
     // Step 1: Upsert into treasures (globally unique by external_id)
     //
@@ -234,17 +237,26 @@ export async function upsertMuseumTreasures(
     // so it is reached the same way the location insert reaches it. Links are
     // never deleted (ADR-0023), so a link a curator already passed must keep
     // that state when a later run finds it again — insert-only, same as above.
-    await pool.query(
+    const link = await pool.query(
       `INSERT INTO experience_treasures (experience_id, treasure_id, curation_state)
        VALUES ($1, $2,
          CASE WHEN (SELECT c.requires_curation
                       FROM experiences e JOIN experience_categories c ON c.id = e.category_id
                      WHERE e.id = $1)
               THEN 'pending' ELSE 'auto' END)
-       ON CONFLICT (experience_id, treasure_id) DO NOTHING`,
+       ON CONFLICT (experience_id, treasure_id) DO NOTHING
+       RETURNING treasure_id`,
       [experienceId, treasureId]
     );
+    // `DO NOTHING` returns no row when the link was already there, so this is
+    // "the museum gained a work", not "the run mentioned one".
+    if (link.rows.length > 0) linked = true;
   }
+
+  // Once for the museum rather than once per painting: the fact is that a
+  // curator's pass no longer covers everything on show, and it is the same fact
+  // whether one work arrived or twelve.
+  if (linked) await retirePassAfterNewContent(pool, experienceId);
 }
 
 /**

--- a/backend/src/services/sync/museumSyncService.ts
+++ b/backend/src/services/sync/museumSyncService.ts
@@ -172,18 +172,30 @@ async function upsertMuseumExperience(
  * `is_iconic` is sticky on the way down: a work joins the highlights at `ICONIC_SITELINKS` and
  * only leaves below `ICONIC_RELEASE`, so the badge does not flicker on and off as Wikipedia
  * grows. Selection upstream uses the single threshold; only the stored flag has hysteresis.
+ *
+ * Exported for its test and called nowhere else: two of its promises live in a
+ * parameter number and a `RETURNING` clause, which no caller can observe.
  */
-async function upsertMuseumTreasures(
+export async function upsertMuseumTreasures(
   experienceId: number,
   artworks: ProcessedContent[]
 ): Promise<void> {
   for (const artwork of artworks) {
     // Step 1: Upsert into treasures (globally unique by external_id)
+    //
+    // `curation_state` is bound to `MUSEUM_CATEGORY_ID` directly rather than
+    // reached through an experience: a treasure is globally shared and is not
+    // owned by any one of them. It is set on insert only — absent from
+    // `DO UPDATE SET` — because a work already stored may already have been
+    // passed by a curator, and this run must not reset that (ADR-0025).
     const treasureResult = await pool.query(
       `INSERT INTO treasures (
         external_id, name, treasure_type, artist, year,
-        image_url, sitelinks_count, is_iconic, metadata, created_at, updated_at
-      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW(), NOW())
+        image_url, sitelinks_count, is_iconic, metadata, curation_state, created_at, updated_at
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9,
+        CASE WHEN (SELECT requires_curation FROM experience_categories WHERE id = $12)
+             THEN 'pending' ELSE 'auto' END,
+        NOW(), NOW())
       ON CONFLICT (external_id) DO UPDATE SET
         name = EXCLUDED.name,
         treasure_type = EXCLUDED.treasure_type,
@@ -211,15 +223,24 @@ async function upsertMuseumTreasures(
         null, // metadata
         ICONIC_SITELINKS,
         ICONIC_RELEASE,
+        MUSEUM_CATEGORY_ID,
       ]
     );
 
     const treasureId = treasureResult.rows[0].id;
 
-    // Step 2: Link treasure to experience via junction table
+    // Step 2: Link treasure to experience via junction table. Unlike the
+    // treasure above, a link does have an experience to read the gate through,
+    // so it is reached the same way the location insert reaches it. Links are
+    // never deleted (ADR-0023), so a link a curator already passed must keep
+    // that state when a later run finds it again — insert-only, same as above.
     await pool.query(
-      `INSERT INTO experience_treasures (experience_id, treasure_id)
-       VALUES ($1, $2)
+      `INSERT INTO experience_treasures (experience_id, treasure_id, curation_state)
+       VALUES ($1, $2,
+         CASE WHEN (SELECT c.requires_curation
+                      FROM experiences e JOIN experience_categories c ON c.id = e.category_id
+                     WHERE e.id = $1)
+              THEN 'pending' ELSE 'auto' END)
        ON CONFLICT (experience_id, treasure_id) DO NOTHING`,
       [experienceId, treasureId]
     );

--- a/backend/src/services/sync/syncUtils.ts
+++ b/backend/src/services/sync/syncUtils.ts
@@ -94,7 +94,9 @@ function snapshotFromParams(params: ExperienceUpsertParams): ExperienceSnapshot 
  */
 async function previewUpsert(params: ExperienceUpsertParams): Promise<UpsertOutcome> {
   const result = await pool.query(
-    `SELECT id, curated_fields, missing_since, source_membership, ${SNAPSHOT_COLUMNS.join(', ')},
+    `SELECT id, curated_fields, missing_since, source_membership, curation_state,
+            (SELECT requires_curation FROM experience_categories WHERE id = $1) AS gated,
+            ${SNAPSHOT_COLUMNS.join(', ')},
             ST_X(location) AS lon, ST_Y(location) AS lat
      FROM experiences
      WHERE category_id = $1 AND external_id = $2`,
@@ -115,14 +117,23 @@ async function previewUpsert(params: ExperienceUpsertParams): Promise<UpsertOutc
   const row = result.rows[0];
   const curatedFields: string[] = row.curated_fields ?? [];
 
+  // Both reasons the run would keep the stored name: the curator claimed it, or
+  // the row is held — a gated source may not overwrite what a reader can already
+  // see. Emulated here rather than left to the write path because the whole
+  // point of a preview is to say what the run it stands in for would do, and a
+  // preview that labelled the row with a rename the run would refuse would
+  // mislabel it in the one direction that matters.
+  const heldFromView = Boolean(row.gated) && row.curation_state !== 'pending';
+
   return {
     experienceId: row.id,
+    // The change set still reports what the source proposes, held or not: under
+    // a gate the proposal is what a curator is being asked about, so a preview
+    // that reported "nothing would change" would hide the question.
     changeSet: computeChangeSet(snapshotFromRow(row, ''), incoming, curatedFields),
-    // Emulates the upsert's own CASE guard rather than picking a side: a
-    // curated name stays as the curator wrote it, an ordinary rename shows the
-    // new name. Reading the stored name unconditionally would make a preview
-    // label a renamed row differently from the run it stands in for.
-    nameSnapshot: curatedFields.includes('name') ? (row.name as string) : params.name,
+    nameSnapshot: curatedFields.includes('name') || heldFromView
+      ? (row.name as string)
+      : params.name,
     returnedFromMissing: row.missing_since !== null || row.source_membership === 'former',
   };
 }
@@ -140,6 +151,18 @@ export async function upsertExperienceRecord(
   options: { dryRun?: boolean; syncLogId?: number | null } = {},
 ): Promise<UpsertOutcome> {
   if (options.dryRun) return previewUpsert(params);
+
+  // A gated source may not overwrite what a reader can already see: there is no
+  // second row to hide the unreviewed value behind, which is the one case
+  // writing contents invisible does not cover (ADR-0025 decision 5, and
+  // `docs/tech/experiences.md` § Change provenance for the rule as shipped). A
+  // row still `pending` has nothing to protect, so it keeps being refreshed in
+  // place and the curator reviews the newest state rather than whatever arrived
+  // first.
+  //
+  // `experiences.curation_state` is the PRE-update value here, which is what
+  // makes this expressible in SQL at all.
+  const held = `((SELECT requires_curation FROM gate) AND experiences.curation_state <> 'pending')`;
 
   const result = await pool.query(
     `WITH before AS (
@@ -167,16 +190,16 @@ export async function upsertExperienceRecord(
         CASE WHEN (SELECT requires_curation FROM gate) THEN NULL ELSE NOW() END
       )
       ON CONFLICT (category_id, external_id) DO UPDATE SET
-        name = CASE WHEN experiences.curated_fields ? 'name' THEN experiences.name ELSE EXCLUDED.name END,
-        name_local = CASE WHEN experiences.curated_fields ? 'name_local' THEN experiences.name_local ELSE EXCLUDED.name_local END,
-        description = CASE WHEN experiences.curated_fields ? 'description' THEN experiences.description ELSE EXCLUDED.description END,
-        short_description = CASE WHEN experiences.curated_fields ? 'short_description' THEN experiences.short_description ELSE EXCLUDED.short_description END,
-        category = CASE WHEN experiences.curated_fields ? 'category' THEN experiences.category ELSE EXCLUDED.category END,
-        tags = CASE WHEN experiences.curated_fields ? 'tags' THEN experiences.tags ELSE EXCLUDED.tags END,
-        location = CASE WHEN experiences.curated_fields ? 'location' THEN experiences.location ELSE EXCLUDED.location END,
-        country_codes = CASE WHEN experiences.curated_fields ? 'country_codes' THEN experiences.country_codes ELSE EXCLUDED.country_codes END,
-        country_names = CASE WHEN experiences.curated_fields ? 'country_names' THEN experiences.country_names ELSE EXCLUDED.country_names END,
-        image_url = CASE WHEN experiences.curated_fields ? 'image_url' THEN experiences.image_url ELSE EXCLUDED.image_url END,
+        name = CASE WHEN experiences.curated_fields ? 'name' OR ${held} THEN experiences.name ELSE EXCLUDED.name END,
+        name_local = CASE WHEN experiences.curated_fields ? 'name_local' OR ${held} THEN experiences.name_local ELSE EXCLUDED.name_local END,
+        description = CASE WHEN experiences.curated_fields ? 'description' OR ${held} THEN experiences.description ELSE EXCLUDED.description END,
+        short_description = CASE WHEN experiences.curated_fields ? 'short_description' OR ${held} THEN experiences.short_description ELSE EXCLUDED.short_description END,
+        category = CASE WHEN experiences.curated_fields ? 'category' OR ${held} THEN experiences.category ELSE EXCLUDED.category END,
+        tags = CASE WHEN experiences.curated_fields ? 'tags' OR ${held} THEN experiences.tags ELSE EXCLUDED.tags END,
+        location = CASE WHEN experiences.curated_fields ? 'location' OR ${held} THEN experiences.location ELSE EXCLUDED.location END,
+        country_codes = CASE WHEN experiences.curated_fields ? 'country_codes' OR ${held} THEN experiences.country_codes ELSE EXCLUDED.country_codes END,
+        country_names = CASE WHEN experiences.curated_fields ? 'country_names' OR ${held} THEN experiences.country_names ELSE EXCLUDED.country_names END,
+        image_url = CASE WHEN experiences.curated_fields ? 'image_url' OR ${held} THEN experiences.image_url ELSE EXCLUDED.image_url END,
         -- Two claim shapes reach this column, and only one of them used to work.
         -- editExperience claims per key -- 'metadata.website',
         -- 'metadata.wikipediaUrl' -- and ? 'metadata' is false for those, so
@@ -185,7 +208,7 @@ export async function upsertExperienceRecord(
         -- column; a per-key claim now re-applies just those keys over whatever
         -- the source sent, so an unclaimed key still updates.
         metadata = CASE
-          WHEN experiences.curated_fields ? 'metadata' THEN experiences.metadata
+          WHEN experiences.curated_fields ? 'metadata' OR ${held} THEN experiences.metadata
           ELSE COALESCE(EXCLUDED.metadata, '{}'::jsonb) || COALESCE((
                  SELECT jsonb_object_agg(claimed.k, experiences.metadata -> claimed.k)
                  FROM (
@@ -196,6 +219,16 @@ export async function upsertExperienceRecord(
                  WHERE experiences.metadata ? claimed.k
                ), '{}'::jsonb)
         END,
+        -- The pointer says which run's proposal is being held, so the curator's
+        -- screen can find it. This statement can only ever clear it: whether a
+        -- proposal exists at all is a question about whether anything actually
+        -- differs, and the CASE guards above fire either way. So a held row keeps
+        -- the pointer it has and a row that is not held loses it, because a run
+        -- that is free to write the content leaves nothing waiting. Setting it
+        -- needs the computed change set, so it happens after this statement.
+        pending_change_sync_log_id = CASE WHEN ${held}
+                                         THEN experiences.pending_change_sync_log_id
+                                         ELSE NULL END,
         last_seen_sync_log_id = COALESCE(EXCLUDED.last_seen_sync_log_id, experiences.last_seen_sync_log_id),
         last_seen_at = NOW(),
         missing_since = NULL,

--- a/backend/src/services/sync/syncUtils.ts
+++ b/backend/src/services/sync/syncUtils.ts
@@ -222,10 +222,11 @@ export async function upsertExperienceRecord(
         -- The pointer says which run's proposal is being held, so the curator's
         -- screen can find it. This statement can only ever clear it: whether a
         -- proposal exists at all is a question about whether anything actually
-        -- differs, and the CASE guards above fire either way. So a held row keeps
-        -- the pointer it has and a row that is not held loses it, because a run
-        -- that is free to write the content leaves nothing waiting. Setting it
-        -- needs the computed change set, so it happens after this statement.
+        -- differs, and the CASE guards above fire either way — the same reason
+        -- the decay below is resolved in TypeScript. So a held row keeps the
+        -- pointer it has and a row that is not held loses it, because a run that
+        -- is free to write the content leaves nothing waiting. Setting it is
+        -- done after this statement, and only for a run that proposed something.
         pending_change_sync_log_id = CASE WHEN ${held}
                                          THEN experiences.pending_change_sync_log_id
                                          ELSE NULL END,
@@ -241,7 +242,8 @@ export async function upsertExperienceRecord(
         -- visibility, so a source outage still cannot hide anything (ADR-0020).
         source_membership = 'present',
         updated_at = NOW()
-      RETURNING id, (xmax = 0) AS inserted, curated_fields, ${SNAPSHOT_COLUMNS.join(', ')},
+      RETURNING id, (xmax = 0) AS inserted, curated_fields, pending_change_sync_log_id,
+                ${SNAPSHOT_COLUMNS.join(', ')},
                 ST_X(location) AS lon, ST_Y(location) AS lat
     )
     SELECT ins.*,
@@ -271,10 +273,100 @@ export async function upsertExperienceRecord(
 
   const row = result.rows[0];
   const before = row.inserted ? null : snapshotFromRow(row, 'old_');
+  const changeSet = computeChangeSet(before, snapshotFromParams(params), row.curated_fields ?? []);
+
+  // A curator's pass covered the object that was there; a changed object has not
+  // been passed (ADR-0025). Resolved here rather than in SQL because the
+  // statement cannot tell a content change from a provenance-only pass — its
+  // CASE guards fire either way — and resolved inside this function rather than
+  // in the three sync services, which would be three places to forget.
+  //
+  // Only a **trusted** source's change retires a pass, and the reason is the
+  // hold above: under a gated source the changed values were not written, so
+  // what a reader sees is still exactly what the curator passed. Decaying there
+  // would retire a pass over a change the same statement had just refused to
+  // apply, on every run, for as long as the proposal went unanswered.
+  //
+  // Scoped to `verified` so it can only ever move one way. A `pending` row is
+  // untouched: it is not published, so there is nothing to decay.
+  //
+  // Its own statement, so a failure here throws after the content is already
+  // committed and the run reports that object as failed. Deliberate: the
+  // alternative is to swallow the error, which leaves a row saying `verified`
+  // about content nobody passed, and the next run finds nothing changed and so
+  // never decays it. A failed item is visible in the run's report; a silent one
+  // is not.
+  const wroteContent = changeSet.changedFields.length > 0;
+  // The pointer follows every proposal this statement refused, not only the ones
+  // it wrote — and a claimed field is refused too. `computeChangeSet` files a
+  // field a curator has claimed under `curatedConflicts` and leaves
+  // `changedFields` empty, so keying the pointer on `changedFields` alone would
+  // clear it on a run whose proposal is still standing and still unanswered:
+  // "nothing is held" about a row that is holding something. `significance` in
+  // `changeSet.ts` weighs both buckets for the same reason — the refused half is
+  // the half needing a decision, so it cannot be the hidden one.
+  const proposedAnything = wroteContent || changeSet.curatedConflicts.length > 0;
+
+  if (wroteContent) {
+    await pool.query(
+      `UPDATE experiences SET curation_state = 'auto'
+        WHERE id = $1 AND curation_state = 'verified'
+          AND NOT EXISTS (
+            SELECT 1 FROM experience_categories
+             WHERE id = $2 AND requires_curation
+          )`,
+      [row.id, params.categoryId],
+    );
+  }
+
+  if (proposedAnything) {
+    // And the mirror image of the decay: where the source IS gated and the row
+    // was visible, the statement above kept the stored content and this run's
+    // proposal is what a curator will be shown, so the row points at this run.
+    // Only here, because only here is it known that something was actually
+    // proposed — the upsert cannot tell a content change from a pass that
+    // touched nothing, and a pointer set on every pass would tell a curator that
+    // 1200 rows were waiting on a decision when none of them were.
+    //
+    // A run with no log id writes nothing here rather than writing NULL. The id
+    // is what a curator's screen resolves to see the proposal, so a run that
+    // cannot name itself has nothing to offer the column — and NULL is not
+    // "unknown run", it is "nothing is held", which would be a lie about a row
+    // whose content this run just held.
+    if (options.syncLogId != null) {
+      await pool.query(
+        `UPDATE experiences SET pending_change_sync_log_id = $3
+          WHERE id = $1 AND curation_state <> 'pending'
+            AND EXISTS (
+              SELECT 1 FROM experience_categories
+               WHERE id = $2 AND requires_curation
+            )`,
+        [row.id, params.categoryId, options.syncLogId],
+      );
+    }
+  } else if (row.pending_change_sync_log_id !== null) {
+    // The complement, and the reason the column can be trusted to mean what its
+    // comment says. A run that proposed nothing at all — nothing written and
+    // nothing refused — has nothing held: the source has come back to what is
+    // stored, so a pointer left in place would name a proposal that no longer
+    // exists, a decision waiting on a curator's screen that the source has
+    // already withdrawn. Only reached when the row actually carries a pointer,
+    // which is why the upsert returns it: otherwise every unchanged row in every
+    // run would spend a statement on this.
+    await pool.query(
+      `UPDATE experiences SET pending_change_sync_log_id = NULL
+        WHERE id = $1 AND curation_state <> 'pending'
+          AND EXISTS (
+            SELECT 1 FROM experience_categories
+             WHERE id = $2 AND requires_curation
+          )`,
+      [row.id, params.categoryId],
+    );
+  }
 
   return {
     experienceId: row.id,
-    changeSet: computeChangeSet(before, snapshotFromParams(params), row.curated_fields ?? []),
+    changeSet,
     // RETURNING carries the name after the curated_fields guards, so a
     // protected name labels the changeset row with what is actually stored.
     nameSnapshot: (row.name as string) ?? params.name,

--- a/backend/src/services/sync/syncUtils.ts
+++ b/backend/src/services/sync/syncUtils.ts
@@ -147,15 +147,24 @@ export async function upsertExperienceRecord(
              ST_X(location) AS lon, ST_Y(location) AS lat
       FROM experiences
       WHERE category_id = $1 AND external_id = $2
+    ), gate AS (
+      SELECT requires_curation FROM experience_categories WHERE id = $1
     ), ins AS (
       INSERT INTO experiences (
         category_id, external_id, name, name_local, description, short_description,
         category, tags, location, country_codes, country_names, image_url, metadata,
-        first_seen_sync_log_id, last_seen_sync_log_id, last_seen_at, created_at, updated_at
+        first_seen_sync_log_id, last_seen_sync_log_id, last_seen_at, created_at, updated_at,
+        curation_state, published_at
       ) VALUES (
         $1, $2, $3, $4, $5, $6, $7, $8,
         ST_SetSRID(ST_MakePoint($9, $10), 4326),
-        $11, $12, $13, $14, $15, $15, NOW(), NOW(), NOW()
+        $11, $12, $13, $14, $15, $15, NOW(), NOW(), NOW(),
+        -- A gated source's arrival waits for a person; a trusted source's is
+        -- live the moment it lands, and says so (ADR-0025). Read from the
+        -- category rather than passed in, so the check and the write cannot
+        -- disagree.
+        CASE WHEN (SELECT requires_curation FROM gate) THEN 'pending' ELSE 'auto' END,
+        CASE WHEN (SELECT requires_curation FROM gate) THEN NULL ELSE NOW() END
       )
       ON CONFLICT (category_id, external_id) DO UPDATE SET
         name = CASE WHEN experiences.curated_fields ? 'name' THEN experiences.name ELSE EXCLUDED.name END,

--- a/backend/src/services/sync/syncUtils.upsert.test.ts
+++ b/backend/src/services/sync/syncUtils.upsert.test.ts
@@ -85,6 +85,9 @@ function returnedRow(overrides: Record<string, unknown> = {}) {
     id: 501,
     inserted: false,
     curated_fields: [],
+    // The upsert returns this so an unchanged row with nothing held costs no
+    // further statement; a test that omitted it would exercise the wrong branch.
+    pending_change_sync_log_id: null,
     name: PARAMS.name,
     name_local: PARAMS.nameLocal,
     description: PARAMS.description,
@@ -112,6 +115,11 @@ function returnedRow(overrides: Record<string, unknown> = {}) {
     old_missing_since: null,
     ...overrides,
   };
+}
+
+/** Every statement the call sent, in order. */
+function sentSql(): string[] {
+  return mockedQuery.mock.calls.map(call => String(call[0]));
 }
 
 describe('upsertExperienceRecord', () => {
@@ -515,20 +523,105 @@ describe('a gated run holds a visible row content, not a pending one', () => {
 
   it('lets the upsert clear the held pointer but never set it', async () => {
     mockedQuery.mockResolvedValueOnce({ rows: [returnedRow()] });
+    mockedQuery.mockResolvedValue({ rows: [] });
 
     await upsertExperienceRecord(PARAMS, { syncLogId: 42 });
 
     // Whether a proposal exists is a question about whether anything differs,
     // and this statement's guards fire either way. So a held row keeps the
     // pointer it has, a row that is no longer held loses it, and nothing here
-    // writes a run id — a pointer set on every pass would tell a curator that
-    // 1200 rows were waiting on a decision when none of them were.
+    // writes a run id.
     const assigned = assignmentsOf(mockedQuery.mock.calls[0][0]);
     const pointer = assigned.get('pending_change_sync_log_id');
     expect(pointer).toContain(HOLD);
     expect(pointer).toContain('THEN experiences.pending_change_sync_log_id');
     expect(pointer).toContain('ELSE NULL');
     expect(pointer).not.toContain('$15');
+  });
+
+  it('points a held row at the run that proposed something, and no other run', async () => {
+    mockedQuery.mockResolvedValueOnce({ rows: [returnedRow({ old_name: 'An older name' })] });
+    mockedQuery.mockResolvedValue({ rows: [] });
+
+    await upsertExperienceRecord(PARAMS, { syncLogId: 42 });
+
+    // The mirror image of the decay: a changed row either loses its pass
+    // (trusted source) or records where the held proposal came from (gated).
+    const pointer = sentSql().find(sql => /SET pending_change_sync_log_id/.test(sql));
+    expect(pointer).toBeDefined();
+    expect(pointer).toMatch(/curation_state <> 'pending'/);
+    expect(pointer).toMatch(
+      /EXISTS \(\s*SELECT 1 FROM experience_categories\s*WHERE id = \$2 AND requires_curation\s*\)/,
+    );
+    expect(mockedQuery.mock.calls.at(-1)?.[1]).toEqual([501, PARAMS.categoryId, 42]);
+  });
+
+  it('records no held proposal for a pass that proposed nothing', async () => {
+    mockedQuery.mockResolvedValueOnce({ rows: [returnedRow()] });
+    mockedQuery.mockResolvedValue({ rows: [] });
+
+    await upsertExperienceRecord(PARAMS, { syncLogId: 42 });
+
+    // A gated run that reaches 1200 unchanged rows must not tell a curator that
+    // 1200 decisions are waiting — and must not spend a statement per row
+    // saying so either, which is why a row with no pointer is left alone.
+    // `SET pending_…` matches only the follow-up statements: inside the upsert
+    // the column is assigned within its `DO UPDATE SET` list, not after a `SET`.
+    expect(sentSql().some(sql => /SET pending_change_sync_log_id/.test(sql))).toBe(false);
+  });
+
+  it('clears a held pointer when the source has come back to what is stored', async () => {
+    mockedQuery.mockResolvedValueOnce({
+      rows: [returnedRow({ pending_change_sync_log_id: 41 })],
+    });
+    mockedQuery.mockResolvedValue({ rows: [] });
+
+    await upsertExperienceRecord(PARAMS, { syncLogId: 42 });
+
+    // Run 41 proposed a change; the source then reverted it. Nothing is held any
+    // more, so the pointer must not go on naming a proposal that no longer
+    // exists — the column means "NULL when nothing is held".
+    const cleared = sentSql().find(sql => /SET pending_change_sync_log_id = NULL/.test(sql));
+    expect(cleared).toBeDefined();
+    expect(cleared).toMatch(/curation_state <> 'pending'/);
+    expect(cleared).toMatch(/EXISTS \(/);
+    expect(mockedQuery.mock.calls.at(-1)?.[1]).toEqual([501, PARAMS.categoryId]);
+  });
+
+  it('points a held row at the run whose proposal a claim refused', async () => {
+    mockedQuery.mockResolvedValueOnce({
+      rows: [returnedRow({
+        curated_fields: ['short_description'],
+        old_short_description: 'Curator wording.',
+        pending_change_sync_log_id: 41,
+      })],
+    });
+    mockedQuery.mockResolvedValue({ rows: [] });
+
+    await upsertExperienceRecord(PARAMS, { syncLogId: 42 });
+
+    // The source proposed a value and a claim refused it, so `changedFields` is
+    // empty and `curatedConflicts` carries the proposal. A pointer keyed on
+    // written fields alone would clear here — telling the curator that nothing
+    // waits on them about the very row whose proposal is still standing.
+    const pointer = sentSql().find(sql => /SET pending_change_sync_log_id/.test(sql));
+    expect(pointer).toBeDefined();
+    expect(pointer).not.toMatch(/= NULL/);
+    expect(mockedQuery.mock.calls.at(-1)?.[1]).toEqual([501, PARAMS.categoryId, 42]);
+  });
+
+  it('leaves the pointer alone when the run cannot name itself', async () => {
+    mockedQuery.mockResolvedValueOnce({
+      rows: [returnedRow({ old_name: 'An older name', pending_change_sync_log_id: 41 })],
+    });
+    mockedQuery.mockResolvedValue({ rows: [] });
+
+    await upsertExperienceRecord(PARAMS);
+
+    // The id is what a curator's screen resolves to see the proposal, so a run
+    // with none has nothing to offer the column. Writing NULL would not say
+    // "unknown run", it would say "nothing is held" about a row this run held.
+    expect(sentSql().some(sql => /SET pending_change_sync_log_id/.test(sql))).toBe(false);
   });
 
   it('leaves the provenance columns outside every guard', async () => {
@@ -554,5 +647,70 @@ describe('a gated run holds a visible row content, not a pending one', () => {
     expect(assigned.get('last_seen_at')).toBe('NOW(),');
     expect(assigned.get('missing_since')).toBe('NULL,');
     expect(assigned.get('source_membership')).toBe("'present',");
+  });
+});
+
+describe('a trusted source decays a curator pass', () => {
+  beforeEach(() => mockedQuery.mockReset());
+
+  it('decays only when the change set says something changed', async () => {
+    // The diff computeChangeSet runs is old_* (the stored "before") vs PARAMS
+    // (what the source proposes now), exactly like every other test in this
+    // file -- overriding the bare, post-write `name` column here would leave
+    // the diff empty and this case would never fire.
+    mockedQuery.mockResolvedValueOnce({ rows: [returnedRow({ old_name: 'An older name' })] });
+    mockedQuery.mockResolvedValue({ rows: [] });
+
+    await upsertExperienceRecord(PARAMS, { syncLogId: 42 });
+
+    const decay = sentSql().find(sql => /curation_state = 'auto'/.test(sql));
+    expect(decay).toBeDefined();
+    expect(decay).toMatch(/WHERE id = \$1[\s\S]*curation_state = 'verified'/);
+  });
+
+  it('leaves a pass alone when the source is gated, since nothing was written', async () => {
+    mockedQuery.mockResolvedValueOnce({ rows: [returnedRow({ old_name: 'An older name' })] });
+    mockedQuery.mockResolvedValue({ rows: [] });
+
+    await upsertExperienceRecord(PARAMS, { syncLogId: 42 });
+
+    // Under a gated source the hold refused the change, so what a reader sees is
+    // still what the curator passed. The condition rides in the statement rather
+    // than being decided here for the same reason the hold does: a parameter is
+    // a second source of truth that can disagree with the column.
+    const decayCall = mockedQuery.mock.calls.find(call =>
+      /SET curation_state = 'auto'/.test(String(call[0])),
+    );
+    expect(decayCall?.[0]).toMatch(
+      /NOT EXISTS \(\s*SELECT 1 FROM experience_categories\s*WHERE id = \$2 AND requires_curation\s*\)/,
+    );
+    expect(decayCall?.[1]).toEqual([501, PARAMS.categoryId]);
+  });
+
+  it('sends no decay statement for a provenance-only pass', async () => {
+    // returnedRow() with no overrides is byte-identical to PARAMS, so the
+    // change set is empty — the guards fired but nothing differs.
+    mockedQuery.mockResolvedValueOnce({ rows: [returnedRow()] });
+    mockedQuery.mockResolvedValue({ rows: [] });
+
+    await upsertExperienceRecord(PARAMS, { syncLogId: 42 });
+
+    expect(sentSql().some(sql => /curation_state = 'auto'/.test(sql))).toBe(false);
+  });
+
+  it('sends no decay statement when the only divergence is one the curator claimed', async () => {
+    // A claimed field the source disagrees with is a conflict, not a change:
+    // the stored value did not move, so the pass still covers what is live.
+    // `changedFields` and `curatedConflicts` are separate lists, which is what
+    // makes this hold — pinned here so a future merge of the two cannot pass.
+    mockedQuery.mockResolvedValueOnce({
+      rows: [returnedRow({ curated_fields: ['short_description'], old_short_description: 'Curator wording.' })],
+    });
+    mockedQuery.mockResolvedValue({ rows: [] });
+
+    const result = await upsertExperienceRecord(PARAMS, { syncLogId: 42 });
+
+    expect(result.changeSet.curatedConflicts.map(f => f.field)).toEqual(['shortDescription']);
+    expect(sentSql().some(sql => /curation_state = 'auto'/.test(sql))).toBe(false);
   });
 });

--- a/backend/src/services/sync/syncUtils.upsert.test.ts
+++ b/backend/src/services/sync/syncUtils.upsert.test.ts
@@ -198,6 +198,40 @@ describe('upsertExperienceRecord', () => {
     expect(result.experienceId).toBe(0);
   });
 
+  it('labels a dry run of a held row with the name the run would keep', async () => {
+    mockedQuery.mockResolvedValueOnce({
+      rows: [{
+        id: 501,
+        curated_fields: [],
+        curation_state: 'auto',
+        gated: true,
+        name: 'The name a reader sees',
+        name_local: PARAMS.nameLocal,
+        description: null,
+        short_description: PARAMS.shortDescription,
+        category: 'natural',
+        tags: ['natural'],
+        lon: PARAMS.lon,
+        lat: PARAMS.lat,
+        country_codes: ['TZ'],
+        country_names: ['Tanzania'],
+        image_url: PARAMS.imageUrl,
+        metadata: PARAMS.metadata,
+      }],
+    });
+
+    const result = await upsertExperienceRecord(PARAMS, { dryRun: true });
+
+    // A preview exists to say what the run it stands in for would do. Under a
+    // gated source that run would hold the stored name, so labelling the row
+    // with the proposed one would mislabel it in the one direction that matters.
+    expect(result.nameSnapshot).toBe('The name a reader sees');
+    // The proposal is still reported: under a gate it is exactly what the
+    // curator is being asked about, so a preview that said "nothing would
+    // change" would hide the question.
+    expect(result.changeSet.changedFields.map(f => f.field)).toEqual(['name']);
+  });
+
   it('stamps provenance on the written row', async () => {
     mockedQuery.mockResolvedValueOnce({ rows: [returnedRow()] });
 
@@ -432,5 +466,93 @@ describe('the curation gate stamps a new row', () => {
     const assigned = assignmentsOf(mockedQuery.mock.calls[0][0]);
     expect([...assigned.keys()]).not.toContain('published_at');
     expect([...assigned.keys()]).not.toContain('curation_state');
+  });
+});
+
+describe('a gated run holds a visible row content, not a pending one', () => {
+  beforeEach(() => mockedQuery.mockReset());
+
+  // Declared once, and reused verbatim as the `held` constant in syncUtils.ts,
+  // so the test and the SQL cannot drift apart in wording while both look right.
+  const HOLD = "((SELECT requires_curation FROM gate) AND experiences.curation_state <> 'pending')";
+
+  it('guards every content column with the hold condition as well as the claim', async () => {
+    mockedQuery.mockResolvedValueOnce({ rows: [returnedRow()] });
+
+    await upsertExperienceRecord(PARAMS, { syncLogId: 42 });
+
+    const assigned = assignmentsOf(mockedQuery.mock.calls[0][0]);
+    // Named individually rather than counted: a count goes stale the moment a
+    // twelfth content column is added, and the failure would read as a passing
+    // test with one column unguarded. Each column's own expression is examined,
+    // so a lost hold on `description` cannot pass by matching the text of
+    // `short_description`'s arm.
+    for (const column of [
+      'name', 'name_local', 'description', 'short_description', 'category',
+      'tags', 'location', 'country_codes', 'country_names', 'image_url', 'metadata',
+    ]) {
+      const arm = assigned.get(column);
+      expect(arm, `${column} is not assigned`).toBeDefined();
+      expect(arm, `${column} has no CASE arm`).toMatch(/^CASE/);
+      expect(arm, `${column} is not held`).toContain(HOLD);
+    }
+  });
+
+  it('reads the stored state, not the value it is about to write', async () => {
+    mockedQuery.mockResolvedValueOnce({ rows: [returnedRow()] });
+
+    await upsertExperienceRecord(PARAMS, { syncLogId: 42 });
+
+    const text = String(mockedQuery.mock.calls[0][0]);
+    // `experiences.curation_state` inside ON CONFLICT is the pre-update value.
+    // EXCLUDED is the incoming row, whose curation_state is what task 3's own
+    // CASE just computed ('pending' for a gated source) -- guarding on that
+    // would make `requires_curation AND EXCLUDED.curation_state <> 'pending'`
+    // collapse to `true AND false`, and the hold would never fire for anyone.
+    expect(text).toMatch(/experiences\.curation_state <> 'pending'/);
+    expect(text).not.toMatch(/EXCLUDED\.curation_state/);
+  });
+
+  it('lets the upsert clear the held pointer but never set it', async () => {
+    mockedQuery.mockResolvedValueOnce({ rows: [returnedRow()] });
+
+    await upsertExperienceRecord(PARAMS, { syncLogId: 42 });
+
+    // Whether a proposal exists is a question about whether anything differs,
+    // and this statement's guards fire either way. So a held row keeps the
+    // pointer it has, a row that is no longer held loses it, and nothing here
+    // writes a run id — a pointer set on every pass would tell a curator that
+    // 1200 rows were waiting on a decision when none of them were.
+    const assigned = assignmentsOf(mockedQuery.mock.calls[0][0]);
+    const pointer = assigned.get('pending_change_sync_log_id');
+    expect(pointer).toContain(HOLD);
+    expect(pointer).toContain('THEN experiences.pending_change_sync_log_id');
+    expect(pointer).toContain('ELSE NULL');
+    expect(pointer).not.toContain('$15');
+  });
+
+  it('leaves the provenance columns outside every guard', async () => {
+    mockedQuery.mockResolvedValueOnce({ rows: [returnedRow()] });
+
+    await upsertExperienceRecord(PARAMS, { syncLogId: 42 });
+
+    const assigned = assignmentsOf(mockedQuery.mock.calls[0][0]);
+    // A gated run still records that the source listed the object,
+    // or missing detection starts flagging everything the gate holds and one
+    // gated source manufactures a category-wide false alarm.
+    // Every one of the five named individually: naming three of them and
+    // calling it "the provenance columns" would pass while a guard sat on
+    // either of the other two.
+    for (const column of [
+      'last_seen_sync_log_id', 'last_seen_at', 'missing_since', 'source_membership', 'updated_at',
+    ]) {
+      const assignment = assigned.get(column);
+      expect(assignment, `${column} is not assigned at all`).toBeDefined();
+      expect(assignment, `${column} is guarded`).not.toMatch(/^CASE/);
+    }
+    // What those assignments have to say, not merely that they are unguarded.
+    expect(assigned.get('last_seen_at')).toBe('NOW(),');
+    expect(assigned.get('missing_since')).toBe('NULL,');
+    expect(assigned.get('source_membership')).toBe("'present',");
   });
 });

--- a/backend/src/services/sync/syncUtils.upsert.test.ts
+++ b/backend/src/services/sync/syncUtils.upsert.test.ts
@@ -41,6 +41,44 @@ const PARAMS: ExperienceUpsertParams = {
   metadata: { inDanger: false, dateInscribed: 1981 },
 };
 
+/**
+ * Every `column = expression` the upsert's `ON CONFLICT DO UPDATE SET` list
+ * assigns, by column.
+ *
+ * Read as assignments rather than matched as text, so a column is judged by
+ * what the statement does to it: an assignment is found however it is written,
+ * a comment that merely names a column is not one, and `RETURNING` and the
+ * outer `SELECT` — which may legitimately name any of these columns, and which
+ * later rules read the stored state through — are outside the slice entirely.
+ */
+function assignmentsOf(sql: unknown): Map<string, string> {
+  const text = String(sql);
+  const afterConflict = text.slice(text.indexOf('DO UPDATE SET'));
+  const setList = afterConflict.slice(0, afterConflict.indexOf('RETURNING'));
+
+  const assignments = new Map<string, string>();
+  let column: string | null = null;
+  let expression: string[] = [];
+  const flush = () => {
+    if (column) assignments.set(column, expression.join('\n').trim());
+  };
+
+  for (const line of setList.split('\n')) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith('--')) continue;
+    const starts = /^([a-z_]+) = (.*)$/.exec(trimmed);
+    if (starts) {
+      flush();
+      [, column] = starts;
+      expression = [starts[2]];
+    } else if (column) {
+      expression.push(trimmed);
+    }
+  }
+  flush();
+  return assignments;
+}
+
 /** The row shape the CTE returns: new values, plus `old_*` for the prior row. */
 function returnedRow(overrides: Record<string, unknown> = {}) {
   return {
@@ -350,5 +388,49 @@ describe('metadata is guarded per claimed key, not per column', () => {
     // whatever real value the source just sent -- clobbering it. Do not delete this
     // assertion as noise; it is what stops that regression from going unnoticed.
     expect(text).toMatch(/WHERE experiences\.metadata \? claimed\.k/);
+  });
+});
+
+describe('the curation gate stamps a new row', () => {
+  beforeEach(() => mockedQuery.mockReset());
+
+  it('reads the gate from the category rather than being told', async () => {
+    mockedQuery.mockResolvedValueOnce({ rows: [returnedRow()] });
+
+    await upsertExperienceRecord(PARAMS, { syncLogId: 42 });
+
+    const [sql] = mockedQuery.mock.calls[0];
+    const text = String(sql);
+    // A parameter would be a second source of truth that can disagree with the
+    // column between the check and the write.
+    expect(text).toMatch(/FROM experience_categories WHERE id = \$1/);
+  });
+
+  it('inserts pending with no published_at when the source is gated', async () => {
+    mockedQuery.mockResolvedValueOnce({ rows: [returnedRow()] });
+
+    await upsertExperienceRecord(PARAMS, { syncLogId: 42 });
+
+    const text = String(mockedQuery.mock.calls[0][0]);
+    expect(text).toMatch(/curation_state/);
+    expect(text).toMatch(/published_at/);
+    // The two move together: a pending row has no publication moment, and an
+    // auto row's publication moment is now. Anchored on the gate, so neither
+    // can be written without the other having been decided.
+    expect(text).toMatch(/CASE WHEN \(SELECT requires_curation FROM gate\) THEN 'pending' ELSE 'auto' END/);
+    expect(text).toMatch(/CASE WHEN \(SELECT requires_curation FROM gate\) THEN NULL ELSE NOW\(\) END/);
+  });
+
+  it('never restarts published_at on a row that already has one', async () => {
+    mockedQuery.mockResolvedValueOnce({ rows: [returnedRow()] });
+
+    await upsertExperienceRecord(PARAMS, { syncLogId: 42 });
+
+    // Neither column is a run's to change on a row that already exists.
+    // Publishing is a curator's act, and re-stamping published_at would move
+    // every touched row's "New" chip.
+    const assigned = assignmentsOf(mockedQuery.mock.calls[0][0]);
+    expect([...assigned.keys()]).not.toContain('published_at');
+    expect([...assigned.keys()]).not.toContain('curation_state');
   });
 });

--- a/db/init/01-schema.sql
+++ b/db/init/01-schema.sql
@@ -1618,14 +1618,45 @@ COMMENT ON COLUMN experience_categories.display_priority IS 'Display order in ex
 ALTER TABLE experience_categories ADD COLUMN IF NOT EXISTS new_badge_days INTEGER NOT NULL DEFAULT 30;
 COMMENT ON COLUMN experience_categories.new_badge_days IS 'How long an object created by the latest run keeps the "New" chip. Per category, because sources have different cadences.';
 
+-- The curation gate (ADR-0025). A category is a source here, and this is the
+-- per-source decision: does what a run brings in wait for a person, or publish
+-- on arrival. The default is `true` so a source nobody has decided about does
+-- not publish unread.
+--
+-- The three sources that predate the gate are the exception, and creating the
+-- column is the only moment at which they can be given their answer. So the
+-- two happen inside one guard, atomically, in both schema homes: whichever of
+-- this file and migration 018 reaches a database first creates the column and
+-- names those three in the same breath, and every later application of either
+-- file sees the column and does nothing. That is what keeps an admin's later
+-- decision safe -- `true` on a source they chose to gate survives any number of
+-- re-applications -- and it is also why the guard cannot be `ADD COLUMN IF NOT
+-- EXISTS`: on a database that predates the column, the `DEFAULT true` backfill
+-- would gate all three, and a separate `UPDATE` outside the guard would then be
+-- either unsafe (resetting the admin) or skipped (leaving them gated).
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+         WHERE table_name = 'experience_categories' AND column_name = 'requires_curation'
+    ) THEN
+        ALTER TABLE experience_categories
+            ADD COLUMN requires_curation BOOLEAN NOT NULL DEFAULT true;
+        UPDATE experience_categories SET requires_curation = false
+         WHERE name IN ('UNESCO World Heritage Sites', 'Top Art Museums', 'Public Art & Monuments');
+    END IF;
+END $$;
+COMMENT ON COLUMN experience_categories.requires_curation IS 'Does a run from this source wait for a curator before its rows reach a reader (ADR-0025). Only an admin sets it; no run ever changes it.';
+
 -- Seed UNESCO as the first category
-INSERT INTO experience_categories (name, description, api_endpoint, api_config, display_priority)
+INSERT INTO experience_categories (name, description, api_endpoint, api_config, display_priority, requires_curation)
 VALUES (
     'UNESCO World Heritage Sites',
     'Official UNESCO World Heritage List - Cultural, Natural, and Mixed sites worldwide',
     'https://data.unesco.org/api/explore/v2.1/catalog/datasets/whc001/records',
     '{"pageSize": 100}'::jsonb,
-    1
+    1,
+    false
 )
 ON CONFLICT (name) DO NOTHING;
 
@@ -1859,6 +1890,29 @@ COMMENT ON COLUMN experiences.admission_reason IS
 
 CREATE INDEX IF NOT EXISTS idx_experiences_admission ON experiences(admission) WHERE admission <> 'admitted';
 
+-- The fourth column that can take a row off a reader's screen, and it is not
+-- interchangeable with the other three (ADR-0025): `existence` answers is it
+-- still standing, `admission` does it belong in this catalogue,
+-- `missing_since` does the source still offer this point, and this one answers
+-- has anyone looked at it yet. They compose rather than collapse.
+--
+-- Default `auto`, not `pending`: the sync path sets `pending` explicitly
+-- because it knows about the gate, so a writer that forgets this column keeps
+-- today's behaviour. The other default would let such a writer remove its rows
+-- from the product silently.
+ALTER TABLE experiences ADD COLUMN IF NOT EXISTS curation_state VARCHAR(10) NOT NULL DEFAULT 'auto';
+ALTER TABLE experiences ADD COLUMN IF NOT EXISTS published_at TIMESTAMPTZ;
+-- ON DELETE SET NULL, like the two provenance pointers beside it: deleting a
+-- sync log is a supported operation here, and a pointer to a log that no longer
+-- exists names nothing. The hold itself is carried by `curation_state`, so
+-- losing the pointer loses the way to find the proposal, not the hold.
+ALTER TABLE experiences ADD COLUMN IF NOT EXISTS pending_change_sync_log_id INTEGER
+    REFERENCES experience_sync_logs(id) ON DELETE SET NULL;
+COMMENT ON COLUMN experiences.curation_state IS 'pending = arrived from a gated source and nobody has passed it; auto = published unread; verified = a curator passed what is live now. No reader-facing read may offer a pending row (ADR-0025).';
+COMMENT ON COLUMN experiences.published_at IS 'When the row became visible. NULL while pending and for every row that predates the gate. The "New" chip counts from the run that first saw a row; a gated row is seen months before a reader can see it, so publication is the moment the chip should count from instead.';
+COMMENT ON COLUMN experiences.pending_change_sync_log_id IS 'The run whose content proposal is held for an already-visible row. NULL when nothing is held. Contents need no equivalent — a content row is held by being written pending rather than withheld.';
+CREATE INDEX IF NOT EXISTS idx_experiences_curation_state ON experiences(curation_state) WHERE curation_state = 'pending';
+
 -- Per-object record of what a run did. 'unchanged' is deliberately NOT stored;
 -- it is only counted, or every UNESCO run would write 1247 rows of noise.
 CREATE TABLE IF NOT EXISTS experience_sync_changes (
@@ -1940,6 +1994,9 @@ CREATE INDEX IF NOT EXISTS idx_experience_locations_location ON experience_locat
 CREATE INDEX IF NOT EXISTS idx_experience_locations_offered
     ON experience_locations(experience_id) WHERE missing_since IS NULL;
 
+ALTER TABLE experience_locations ADD COLUMN IF NOT EXISTS curation_state VARCHAR(10) NOT NULL DEFAULT 'auto';
+COMMENT ON COLUMN experience_locations.curation_state IS 'A pending point is written, indexed and placed into regions like any other; keeping it off reader-facing reads is the job of one predicate rather than a reason to withhold the row (ADR-0025).';
+
 -- User visited locations (tracks visits to individual locations)
 CREATE TABLE IF NOT EXISTS user_visited_locations (
     id SERIAL PRIMARY KEY,
@@ -1978,24 +2035,26 @@ CREATE INDEX IF NOT EXISTS idx_experience_location_regions_region ON experience_
 -- sculptures). Used for ranking museums by artwork fame.
 
 -- Seed "Top Art Museums" as experience category
-INSERT INTO experience_categories (name, description, api_endpoint, api_config, display_priority)
+INSERT INTO experience_categories (name, description, api_endpoint, api_config, display_priority, requires_curation)
 VALUES (
     'Top Art Museums',
     'World''s most notable museums ranked by artwork fame, sourced from Wikidata',
     'https://query.wikidata.org/sparql',
     '{"userAgent": "TrackYourRegions/1.0"}'::jsonb,
-    2
+    2,
+    false
 )
 ON CONFLICT (name) DO NOTHING;
 
 -- Seed "Public Art & Monuments" as experience category
-INSERT INTO experience_categories (name, description, api_endpoint, api_config, display_priority)
+INSERT INTO experience_categories (name, description, api_endpoint, api_config, display_priority, requires_curation)
 VALUES (
     'Public Art & Monuments',
     'Notable outdoor sculptures and monuments worldwide, sourced from Wikidata',
     'https://query.wikidata.org/sparql',
     '{"userAgent": "TrackYourRegions/1.0"}'::jsonb,
-    3
+    3,
+    false
 )
 ON CONFLICT (name) DO NOTHING;
 
@@ -2034,6 +2093,13 @@ CREATE INDEX IF NOT EXISTS idx_treasures_type ON treasures(treasure_type);
 CREATE INDEX IF NOT EXISTS idx_treasures_sitelinks ON treasures(sitelinks_count DESC);
 CREATE INDEX IF NOT EXISTS idx_treasures_iconic ON treasures(is_iconic) WHERE is_iconic = true;
 
+-- A work carries state here and its link carries state too, and they answer
+-- different questions (ADR-0025): this one says the work is real and correctly
+-- described, checked once globally; the link says it is here, which is the fact
+-- that changes as works are sold, moved and lent.
+ALTER TABLE treasures ADD COLUMN IF NOT EXISTS curation_state VARCHAR(10) NOT NULL DEFAULT 'auto';
+COMMENT ON COLUMN treasures.curation_state IS 'Whether this work has been passed by a curator — checked once, globally (ADR-0025).';
+
 -- Junction table: many-to-many between experiences and treasures
 CREATE TABLE IF NOT EXISTS experience_treasures (
     id SERIAL PRIMARY KEY,
@@ -2047,6 +2113,32 @@ COMMENT ON TABLE experience_treasures IS 'Links treasures to experiences (many-t
 
 CREATE INDEX IF NOT EXISTS idx_experience_treasures_experience ON experience_treasures(experience_id);
 CREATE INDEX IF NOT EXISTS idx_experience_treasures_treasure ON experience_treasures(treasure_id);
+
+ALTER TABLE experience_treasures ADD COLUMN IF NOT EXISTS curation_state VARCHAR(10) NOT NULL DEFAULT 'auto';
+COMMENT ON COLUMN experience_treasures.curation_state IS 'Whether this work has been passed as being HERE. A link may be offered to a reader only when neither it nor its work is pending (ADR-0025).';
+
+-- Guarded rather than dropped-and-added: these are new constraints, not widened
+-- ones, so the drop/add idiom used for the changeset's change_type check would
+-- be doing nothing on a fresh database and hiding a failure on an old one.
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'experiences_curation_state_check') THEN
+        ALTER TABLE experiences ADD CONSTRAINT experiences_curation_state_check
+            CHECK (curation_state IN ('pending', 'auto', 'verified'));
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'experience_locations_curation_state_check') THEN
+        ALTER TABLE experience_locations ADD CONSTRAINT experience_locations_curation_state_check
+            CHECK (curation_state IN ('pending', 'auto', 'verified'));
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'experience_treasures_curation_state_check') THEN
+        ALTER TABLE experience_treasures ADD CONSTRAINT experience_treasures_curation_state_check
+            CHECK (curation_state IN ('pending', 'auto', 'verified'));
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'treasures_curation_state_check') THEN
+        ALTER TABLE treasures ADD CONSTRAINT treasures_curation_state_check
+            CHECK (curation_state IN ('pending', 'auto', 'verified'));
+    END IF;
+END $$;
 
 -- =============================================================================
 -- User Viewed Treasures (artwork "seen" tracking)

--- a/db/migrations/018-curation-gate.sql
+++ b/db/migrations/018-curation-gate.sql
@@ -1,0 +1,93 @@
+-- 018: a source is trusted or it is not (ADR-0025)
+--
+-- Seven columns and one UPDATE. The columns give every gated thing somewhere to
+-- say whether anyone has looked at it: the experience, its points, its links to
+-- works, and the works themselves. Nothing reads them yet — sub-branch 2 adds
+-- the reader-side predicate — so applying this file changes what nobody sees.
+--
+-- Every existing row takes the `auto` default: visible exactly as today, marked
+-- truthfully as unread. There is nothing to backfill and nothing to lose.
+-- Contrast migration 009, which did write a value and credited 1547 rows to a
+-- run that never saw them.
+--
+-- The UPDATE is the honest half. All three existing categories have been
+-- publishing unread for months; leaving them `requires_curation = true` would
+-- not record that, it would silently change it — every arrival from the next
+-- UNESCO run invisible, 55 of them in the last round, with nobody having
+-- decided anything. The column default stays `true` so a NEW source is
+-- untrusted until someone says so, and switching these three on stays a
+-- deliberate act by an admin, which is where that decision belongs.
+--
+-- Order: this file may run before or after the next re-application of
+-- `01-schema.sql`, in either order and any number of times. It adds only
+-- nullable or defaulted columns and new CHECKs no existing row can violate
+-- (every row takes 'auto'), and the one value it writes sits inside the same
+-- guard as the column it belongs to, so whichever file gets there first does the
+-- whole job and the other does nothing.
+--
+-- Apply with:
+--   npm run db:run-sql -- -v ON_ERROR_STOP=1 < db/migrations/018-curation-gate.sql
+
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+-- Creating the gate column and answering for the three sources that predate it
+-- are one act, so they sit inside one guard -- byte-identical to the guard in
+-- `01-schema.sql`, because whichever file reaches a database first has to do
+-- both, and every later application of either has to do neither.
+--
+-- Nothing in this repository records which of these files a database has already
+-- seen; that is tribal knowledge today (db/migrations/README.md, #435). So this
+-- is the only statement here that writes a value, and it has to be inert by
+-- itself. Two ways to get that wrong, both of which this shape avoids: an
+-- unguarded `UPDATE` re-runs after an admin has deliberately gated a source and
+-- silently un-gates it, and an `UPDATE` guarded merely on the column's existence
+-- is skipped when `01-schema.sql` created the column first -- leaving all three
+-- gated by its `DEFAULT true` backfill, and the next run of each publishing
+-- nothing a reader can see.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+         WHERE table_name = 'experience_categories' AND column_name = 'requires_curation'
+    ) THEN
+        ALTER TABLE experience_categories
+            ADD COLUMN requires_curation BOOLEAN NOT NULL DEFAULT true;
+        UPDATE experience_categories SET requires_curation = false
+         WHERE name IN ('UNESCO World Heritage Sites', 'Top Art Museums', 'Public Art & Monuments');
+    END IF;
+END $$;
+
+ALTER TABLE experiences ADD COLUMN IF NOT EXISTS curation_state VARCHAR(10) NOT NULL DEFAULT 'auto';
+ALTER TABLE experiences ADD COLUMN IF NOT EXISTS published_at TIMESTAMPTZ;
+ALTER TABLE experiences ADD COLUMN IF NOT EXISTS pending_change_sync_log_id INTEGER
+    REFERENCES experience_sync_logs(id) ON DELETE SET NULL;
+
+ALTER TABLE experience_locations ADD COLUMN IF NOT EXISTS curation_state VARCHAR(10) NOT NULL DEFAULT 'auto';
+ALTER TABLE experience_treasures ADD COLUMN IF NOT EXISTS curation_state VARCHAR(10) NOT NULL DEFAULT 'auto';
+ALTER TABLE treasures ADD COLUMN IF NOT EXISTS curation_state VARCHAR(10) NOT NULL DEFAULT 'auto';
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'experiences_curation_state_check') THEN
+        ALTER TABLE experiences ADD CONSTRAINT experiences_curation_state_check
+            CHECK (curation_state IN ('pending', 'auto', 'verified'));
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'experience_locations_curation_state_check') THEN
+        ALTER TABLE experience_locations ADD CONSTRAINT experience_locations_curation_state_check
+            CHECK (curation_state IN ('pending', 'auto', 'verified'));
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'experience_treasures_curation_state_check') THEN
+        ALTER TABLE experience_treasures ADD CONSTRAINT experience_treasures_curation_state_check
+            CHECK (curation_state IN ('pending', 'auto', 'verified'));
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'treasures_curation_state_check') THEN
+        ALTER TABLE treasures ADD CONSTRAINT treasures_curation_state_check
+            CHECK (curation_state IN ('pending', 'auto', 'verified'));
+    END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_experiences_curation_state ON experiences(curation_state) WHERE curation_state = 'pending';
+
+COMMIT;

--- a/docs/decisions/0025-per-source-curation-gate.md
+++ b/docs/decisions/0025-per-source-curation-gate.md
@@ -1,0 +1,135 @@
+# ADR-0025: A source is trusted or it is not, and the product says which
+
+**Date:** 2026-08-10
+**Status:** Accepted
+
+---
+
+## Context
+
+The catalogue is built by sync runs against Wikidata or an official register, and a run's
+output is live the moment it lands. Before this decision, nothing between the fetch and the page
+a visitor loads asked whether a person had looked at what the run wrote. A curator can create an
+experience by hand instead — `curationController.ts` has that path — but measured against the
+live database on 2026-08-09, none of its 1603 experiences came any other way: `is_manual` is
+true on zero of them.
+
+The catalogue holds 1603 experiences, 6678 locations and 1340 works. Twelve rows carry any
+record of a human decision — nine of them the admission verdicts a curator gave in the days
+after ADR-0024 shipped, three of them hand-edited text. Measured that day, twelve rows out of
+1603 were the entire human contribution to what a traveller was shown.
+
+The sources behind those rows are not one kind of thing. One publishes an official register
+under stable identifiers. The others are built from Wikidata's community edits, and among them
+the museum importer has already had to correct itself more than once — entering curatorial
+departments and dead collectors' estates as museums before the works-first rule replaced that
+logic (ADR-0023), and still needing a rule of its own to refuse archaeological sites, natural
+history collections and churches that the same query keeps returning (ADR-0024).
+
+A single rule applied to every source is wrong however it is set. Requiring a curator's sign-off
+on everything makes a curator the bottleneck in front of a register that a review would rarely
+improve. Requiring nothing leaves the community-edited sources open to exactly the kind of error
+the same importer has already had to correct, and once a source is wrong the only remedy today
+is to switch it off entirely — there is no way to hold one source to a stricter standard than
+another. Either setting, applied to the whole catalogue, answers a question that only makes
+sense asked one source at a time.
+
+## Decision
+
+**1. The gate is set per source, not once for the whole catalogue.**
+`experience_categories.requires_curation` is a boolean on the table that already stands for a
+source — each source is one category and one sync service — so trusting one source while
+holding another back needs no new concept of what "a source" is. A single global rule is wrong
+in both directions at once, for the reasons above: applied everywhere it makes a curator the
+bottleneck in front of a register that a review would rarely improve; applied nowhere it leaves
+community data unchecked with no lever but switching the source off.
+
+**2. Three states — `pending`, `auto`, `verified` — apply to four things a reader can see, not
+to the experience alone.** `experiences`, `experience_locations`, `experience_treasures` and
+`treasures` each gains the same three-state column. Curation is not a property of the
+experience; it is a property of anything a run writes that a reader can see, and the product
+already tracks an experience, a location and a treasure as separate facts elsewhere in the
+schema — a visit, a location visit and a viewed treasure are each held in their own table. This
+decision extends that same granularity rather than inventing a new one.
+
+The split is measured and load-bearing, not decorative. Complex geometry lives entirely in
+UNESCO, the source least likely to be gated, and treasures live entirely in Top Art Museums, the
+source the gate exists for. A design that protects an experience's row and leaves its contents
+alone protects the wrong thing: it would let a gated museum publish new paintings the moment a
+run finds them, through the one table the gate never reached.
+
+**3. The default is `auto`, not `pending`.** This is a safety choice, not a claim about what is
+typical. The sync path for a gated source sets `pending` explicitly, because that path already
+knows about the gate. A writer that does not — an existing call site this decision does not
+touch, or a future one written without reading it — leaves the column at its default and
+reproduces exactly today's behaviour, publishing what it writes. Defaulting to `pending` instead
+would let that same forgetful writer remove rows from the product silently, by doing nothing.
+
+**4. Admission is asked before publication.** Whether an object belongs in this catalogue at
+all is a question a category's own rule answers (ADR-0024); whether anyone has looked at it yet
+is a different question, asked only once the first has been answered yes. The gate must not
+reuse `admission` to mean "unpublished": "our rule said no" and "nobody has looked" are opposite
+statements, and a row carrying both needs to say both.
+
+**5. Contents are held by being written invisible, not by being withheld.** A gated run writes
+what it finds in full: the rows exist, carry their geometry, are indexed, and are placed into
+regions. One predicate is what keeps them off a reader-facing read. Publishing is an update to
+that predicate, not a replay of a proposal that had nowhere to live until a curator asked for
+it. The predicate is a claim on every reader-facing read, and the order in which the two halves
+arrive is part of the decision: `pending` is a word the writer says and the reader obeys, so no
+source may be gated before every such read honours it. Gated first, the rows would reach readers
+exactly as they do today while a curator was told they were waiting — the one state this gate
+must never produce, because it is the only one in which the gate is believed and absent at the
+same time.
+
+## Alternatives Considered
+
+| Option | Why rejected |
+|---|---|
+| One global gate | Wrong in both directions at once — see Context. |
+| Gate the experience only, not its contents | Treasures are 1370 links in `Top Art Museums`, the source the gate exists for; a museum that gained twelve unchecked paintings would publish them. |
+| Withhold contents instead of writing them invisible | Up to 77 kB of jsonb proposal for a 758-point site, needs a geometry probe extracted from the writer, holds a whole museum for one new painting, and pending points would not be placed into regions — so a region curator's queue would be empty. |
+| Reuse `admission = 'refused'` for "unpublished" | Opposite statements. A refused row and an unread row need different answers from the curator and different words to the reader. |
+| A reader-side "only human-checked" filter | Puts the judgement on whoever is least equipped to make it. Rejected as the *mechanism*; not excluded as a later addition. |
+| Approve a run rather than an object | A run is ~1900 items. |
+
+## Consequences
+
+**Positive:**
+
+- A source can be held back without the rest of the catalogue waiting on it, and trusted
+  without every other source inheriting that trust.
+- A run's mistake is caught at the size it actually occurs: a wrong location or a wrong
+  treasure link holds only that row, not the whole experience it belongs to.
+- The column defaults to the safe side of a mistake — a writer that forgets the gate keeps
+  behaving exactly as it always has, rather than silently withholding something no curator ever
+  asked it to hold.
+
+**Negative / Trade-offs:**
+
+- Every experience that exists today takes `auto` the moment this ships — all 1603 of them, of
+  which 1576 are the ones a reader is offered — and their locations, their treasures and the links
+  between them take it with them. That is stated plainly rather than softened: they are
+  published, unread, and the product will now say so instead of leaving the question unasked.
+- The gate is `curation_state`, the fourth column that can take a row off a reader's screen,
+  after `existence`, `admission` and `missing_since`. Each answers its own question — does it
+  still stand, does this catalogue accept it, does its source still offer this point, has anyone
+  looked at it yet — and they compose rather than collapse: a row can be admitted, extant,
+  offered by its source and still unread, all at once. Merging any two of the four into a single
+  predicate is forbidden, because collapsing two of those questions into one column would make it
+  impossible to ask about either separately again.
+
+## References
+
+- [ADR-0020](0020-experience-lifecycle-and-run-changeset.md) — the changeset and the two
+  lifecycle axes, `source_membership` and `existence`, that this gate leaves untouched and sits
+  alongside
+- [ADR-0021](0021-source-may-restore-membership.md) — a sync may restore `source_membership` in
+  one direction only
+- [ADR-0022](0022-locations-are-marked-not-deleted.md) — a location a source withdraws is
+  marked, not deleted; this gate marks a row `pending` rather than deleting or withholding it,
+  for a different reason
+- [ADR-0024](0024-a-category-may-refuse-what-the-source-still-lists.md) — `admission`, the axis
+  this gate answers a different question from and must never stand in for
+- Issue #500 — "Publish a source's content only when a curator has passed it"
+- Issue #501 — "Treasures reach readers unchecked"

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -35,6 +35,7 @@ a multi-decision ADR to revise one of them would retire the decisions that still
 | [0022](0022-locations-are-marked-not-deleted.md) | A location is marked, not deleted, and no run may empty a category | Accepted | 2026-08-05 |
 | [0023](0023-works-first-museum-selection.md) | Museum selection is works-first, with no institutional term and no cap | Accepted | 2026-08-07 |
 | [0024](0024-a-category-may-refuse-what-the-source-still-lists.md) | A category may refuse what the source still lists | Accepted | 2026-08-07 |
+| [0025](0025-per-source-curation-gate.md) | A source is trusted or it is not, and the product says which | Accepted | 2026-08-10 |
 | [adr-template](adr-template.md) | — Template — | — | — |
 
 ## When to create an ADR

--- a/docs/tech/experiences.md
+++ b/docs/tech/experiences.md
@@ -166,9 +166,12 @@ whether or not a value actually differs from what is stored — the SQL has no w
 change from a no-op pass, only the computed change set does, and collapsing the decay into the
 `SET` list would retire a curator's pass on every run, changed or not. The `UPDATE` is scoped to
 `WHERE curation_state = 'verified'`, so it can only ever move a row one way: a `pending` row is
-not published and has nothing to decay, and an `auto` row is already there. Nothing writes
-`verified` yet — the curator-facing endpoint that publishes a gated row arrives with the rest of
-this feature — so today this statement is live code that matches no row in the catalogue.
+not published and has nothing to decay, and an `auto` row is already there. The only rows that
+carry `verified` today are ones `createManualExperience` wrote by hand — each one's
+`curator-<id>-<ts>` external id is never in a source listing (see below), so no sync run's
+upsert ever reaches it, and this statement's `WHERE` matches nothing a sync run has ever
+touched. The endpoint that lets a curator promote an existing `pending` or `auto` row to
+`verified` arrives with the rest of this feature.
 
 **`total_updated` changed meaning.** It used to count every row that passed through
 `ON CONFLICT DO UPDATE`, identical or not. Since migration 009 it counts rows that actually
@@ -443,8 +446,11 @@ source's points and works are exactly what a run can add unchecked between one c
 the next. It answers a question none of the other three do: has anyone looked at this row yet —
 not whether the source still lists it, not whether it still exists, not whether this category
 accepts it. A sync run writes it — `pending` for a row from a gated source, `auto` everywhere
-else — but no reader-facing query consults it yet; the predicate that hides a `pending` row and
-the endpoint a curator uses to publish one arrive with the curator-facing half of this feature.
+else. `createManualExperience` writes `verified` instead, on both the experience and its one
+location: there is no source here to gate, and the curator who typed the row in and placed the
+point already read it — `auto` would say "published unread" about something a person wrote. No
+reader-facing query consults the column yet; the predicate that hides a `pending` row and the
+endpoint a curator uses to publish one arrive with the curator-facing half of this feature.
 `existence`, `admission`, `missing_since` and `curation_state` answer different questions and
 compose rather than collapse: merging any two into one column is forbidden, because it would make
 it impossible to ask about either again.

--- a/docs/tech/experiences.md
+++ b/docs/tech/experiences.md
@@ -160,6 +160,7 @@ provenance-only pass, one that reaches the row and changes nothing, leaves `veri
 So does a change from a **gated** source: there the same statement's hold refused to write the new
 values, so what a reader sees is still exactly what the curator passed, and retiring the pass would
 punish the row for a proposal nobody has answered yet.
+
 The rule is resolved in TypeScript, against the change set `computeChangeSet` already produces,
 rather than folded into the upsert's own `SET` list, because the statement's `CASE` guards fire
 whether or not a value actually differs from what is stored — the SQL has no way to tell a content
@@ -172,6 +173,16 @@ carry `verified` today are ones `createManualExperience` wrote by hand — each 
 upsert ever reaches it, and this statement's `WHERE` matches nothing a sync run has ever
 touched. The endpoint that lets a curator promote an existing `pending` or `auto` row to
 `verified` arrives with the rest of this feature.
+
+**New content retires its container's pass too.** A pass covers the experience as it stood — its
+points, and the works a museum was holding — so a point or a work the run has just added is content
+that pass never covered. `retirePassAfterNewContent` (`services/sync/curationDecay.ts`) is the one
+statement both writers use for it: `writeExperienceLocations` calls it in the same transaction as the
+insert that caused it, and the museum sync calls it once per museum rather than once per painting,
+because the fact is the same whether one work arrived or twelve. It moves a row only from `verified`,
+and only for a source nobody gated — a gated source writes its new content `pending`, so nothing a
+reader sees has changed. A point the source stopped offering and now offers again is not new: the
+curator saw it, and its row, its id and its region assignments are the same ones.
 
 **`total_updated` changed meaning.** It used to count every row that passed through
 `ON CONFLICT DO UPDATE`, identical or not. Since migration 009 it counts rows that actually

--- a/docs/tech/experiences.md
+++ b/docs/tech/experiences.md
@@ -396,7 +396,20 @@ say it without asserting something false. `hideRefusedSql()` is a separate fragm
 independently: `includeLost` is a reader asking to see what is gone, and it must leave
 admission alone.
 
-Its row in the table above reads "Visit history: shown" beside "Card: not reachable", and those two
+`curation_state` ([ADR-0025](../decisions/0025-per-source-curation-gate.md)) is the fourth column
+that can take a row off a reader's screen, carried by `experiences`, `experience_locations`,
+`experience_treasures` and `treasures` rather than by the experience alone, because a gated
+source's points and works are exactly what a run can add unchecked between one curator visit and
+the next. It answers a question none of the other three do: has anyone looked at this row yet —
+not whether the source still lists it, not whether it still exists, not whether this category
+accepts it. A sync run writes it — `pending` for a row from a gated source, `auto` everywhere
+else — but no reader-facing query consults it yet; the predicate that hides a `pending` row and
+the endpoint a curator uses to publish one arrive with the curator-facing half of this feature.
+`existence`, `admission`, `missing_since` and `curation_state` answer different questions and
+compose rather than collapse: merging any two into one column is forbidden, because it would make
+it impossible to ask about either again.
+
+The `admission` row in the table above reads "Visit history: shown" beside "Card: not reachable", and those two
 cells are not a contradiction — reading them as one is what let another by-id read stay open for a
 whole slice. The line they fall either side of: **the catalogue's reads refuse a kept-out row; a
 record of what a person did is theirs and stays.** A read that describes an experience — its detail,

--- a/docs/tech/experiences.md
+++ b/docs/tech/experiences.md
@@ -130,6 +130,20 @@ would have hidden it.
 rejected it**, marked `curatedConflict`. That is what makes a curator's later "accept source"
 possible; without it the proposed value exists nowhere.
 
+**A gated source may not overwrite what a reader can already see.** Contents arriving from a gated
+source are written invisible rather than withheld ([ADR-0025](../decisions/0025-per-source-curation-gate.md)),
+but an experience row that is already published has no second row to hide an unreviewed value behind
+— so for that row alone the run keeps the stored content instead. The condition is
+`requires_curation AND experiences.curation_state <> 'pending'`, computed inside the upsert because it
+depends on the stored state the same statement is about to write, and it rides on every content column
+beside that column's own `curated_fields` guard. A row still `pending` is *not* held: nobody can see
+it, so the run refreshes it in place and the curator reviews the newest state rather than whatever
+landed first.
+
+The proposal itself is already recorded, per object, in the run's changeset. What the row adds is
+`pending_change_sync_log_id`, the pointer saying whose proposal is being held, so the curator's screen
+can find it.
+
 **`total_updated` changed meaning.** It used to count every row that passed through
 `ON CONFLICT DO UPDATE`, identical or not. Since migration 009 it counts rows that actually
 changed, and `total_unchanged` absorbs the rest. Logs 1–4 are therefore not comparable with

--- a/docs/tech/experiences.md
+++ b/docs/tech/experiences.md
@@ -142,7 +142,33 @@ landed first.
 
 The proposal itself is already recorded, per object, in the run's changeset. What the row adds is
 `pending_change_sync_log_id`, the pointer saying whose proposal is being held, so the curator's screen
-can find it.
+can find it. It is written only by a run that actually proposed something — the upsert's own guards
+fire whether or not a value differs, so the statement cannot tell a change from a pass that touched
+nothing. *Proposed* counts both kinds of refusal: a value the hold kept out and a value
+`curated_fields` kept out are both decisions waiting on a curator, so a row whose only difference is
+in a claimed field is still holding a proposal and still points at the run that made it. The pointer
+is cleared again when a later run proposes nothing at all — nothing written and nothing refused —
+because a source that has come back to what is stored is no longer proposing anything. A row that is
+no longer held loses the pointer too: a run free to write the content leaves nothing waiting.
+
+**A `verified` row decays when a trusted source changes it.** `curation_state`
+([ADR-0025](../decisions/0025-per-source-curation-gate.md)) can also hold `verified`: a curator's
+pass on the object as it stood when they looked. `upsertExperienceRecord` returns a `verified` row
+to `auto` the moment a run from a source nobody gated writes a real change
+to it — the pass covered the object that was there, and a changed object has not been passed. A
+provenance-only pass, one that reaches the row and changes nothing, leaves `verified` standing.
+So does a change from a **gated** source: there the same statement's hold refused to write the new
+values, so what a reader sees is still exactly what the curator passed, and retiring the pass would
+punish the row for a proposal nobody has answered yet.
+The rule is resolved in TypeScript, against the change set `computeChangeSet` already produces,
+rather than folded into the upsert's own `SET` list, because the statement's `CASE` guards fire
+whether or not a value actually differs from what is stored — the SQL has no way to tell a content
+change from a no-op pass, only the computed change set does, and collapsing the decay into the
+`SET` list would retire a curator's pass on every run, changed or not. The `UPDATE` is scoped to
+`WHERE curation_state = 'verified'`, so it can only ever move a row one way: a `pending` row is
+not published and has nothing to decay, and an `auto` row is already there. Nothing writes
+`verified` yet — the curator-facing endpoint that publishes a gated row arrives with the rest of
+this feature — so today this statement is live code that matches no row in the catalogue.
 
 **`total_updated` changed meaning.** It used to count every row that passed through
 `ON CONFLICT DO UPDATE`, identical or not. Since migration 009 it counts rows that actually


### PR DESCRIPTION
## Description

Stage 1 of the curation roadmap, sub-branch 1 of three: **every gated thing gets a state column, and a
run writes the right state into it.**

**Nothing any visitor or curator sees changes, and that is the intended outcome.** No source is gated —
migration 018 sets `requires_curation = false` on all three existing categories and `01-schema.sql`
seeds them the same way, so a fresh database matches. Nothing reads the new columns: there is no
reader-side predicate, no publish endpoint, no admin switch and no queue in this branch. Those arrive in
sub-branch 2 (the reader-side predicate, the three queue kinds, publishing) and sub-branch 3 (the admin
switch, "publish all waiting", the New chip, and gating Top Art Museums for real). **If you go looking
for the half that answers a `pending` row, it is deliberately absent** — the columns have to exist and be
written correctly before anything filters on them, and a run must never have written a state nobody can
undo.

The decision is [ADR-0025](docs/decisions/0025-per-source-curation-gate.md). What forces it is measured:
1603 experiences, 6678 locations, 1340 works, and **twelve** rows that carry any record of a human
decision. A run's output is live the moment it lands.

### The seven columns (commit 2)

`experience_categories.requires_curation`; `experiences.curation_state` + `published_at` +
`pending_change_sync_log_id`; and `curation_state` again on `experience_locations`,
`experience_treasures` and `treasures` — because complex geometry lives entirely in UNESCO, the source
least likely to be gated, and treasures live entirely in Top Art Museums, the source the gate exists for.
A design that protects an experience's row and leaves its contents alone protects the wrong thing.

The default is `auto`, not `pending`, and that is a safety choice: the sync path sets `pending`
explicitly because it knows about the gate, so a writer that forgets the column keeps today's behaviour.
The other default would let such a writer remove rows from the product by doing nothing.

`curation_state` is the **fourth** column that can take a row off a reader's screen, after `existence`,
`admission` and `missing_since`. They answer four different questions and compose rather than collapse;
ADR-0025 says merging any two is forbidden.

### The five writing rules (commits 3-8)

- **An arrival is stamped** — `pending`/NULL when the source is gated, `auto`/`NOW()` when trusted — on
  **insert only**. Publishing is a curator's act, and re-stamping `published_at` would restart the "New"
  chip for every row a run touches.
- **An already-visible row's content is held** when a gated run brings a change, because there is no
  second row to hide an unreviewed value behind. A still-`pending` row keeps being refreshed in place:
  nobody can see it, so the curator should review the newest state rather than whatever landed first.
- **Contents arrive stamped** — written invisible rather than withheld, so a point exists, is indexed and
  is placed into regions, and a region curator's queue is not empty for an arrival.
- **A trusted source's change retires a `verified` pass.** Only a trusted one: under a gated source the
  hold refused to write the values, so what a reader sees is still exactly what the curator passed.
- **New content retires its container's pass**, for the same reason: a pass covered the venue with the
  points and works it had.

The gate flag is read in SQL in every one of them, never passed as a parameter — a subselect cannot go
stale between the check and the write, and it keeps three sync services from each needing to be told.

## Related Issues

Groundwork for #500 (publish a source's content only when a curator has passed it) and #501 (treasures
reach readers unchecked). **Neither is closed here** — both need the publish path and the reader-side
predicate from sub-branch 2.

## How Was This Tested?

Because a mocked pool cannot tell valid SQL from invalid, **every statement this branch changes was
executed against a real PostgreSQL database**, extracted from its module mechanically rather than
retyped, in a throwaway database that was dropped afterwards. `track_regions` was never used to exercise
a gated source, since `requires_curation` there is live product configuration.

- **The arrival stamp**, all three cases: gated → `pending`/NULL; trusted → `auto`/`NOW()`; and the same
  row again with the gate flipped → **still `pending`, still NULL**, `inserted = f`. That last one is the
  insert-only rule: a later run cannot publish a row no curator has passed.
- **The content hold**, all four combinations of gate × stored state, reading `pending_change_sync_log_id`
  out of the table rather than out of `RETURNING`: held only for gated × visible, refreshed in the other
  three, the pointer written only where content was held. Provenance survived the hold on every row
  (`last_seen_at` stamped, `missing_since` cleared, `source_membership = 'present'`) — otherwise one gated
  source would manufacture a category-wide missing-detection false alarm.
- **The content stamps**, five cases including a work re-upserted with the gate flipped, which stayed
  `pending`.
- **Both decays**, over all four state × gate combinations: a `verified` row under a trusted source moved
  to `auto`; a `verified` row under a gated source stayed; `auto` and `pending` rows were untouched.
- **A hand-made experience**, run with the category's gate switched **on**: the experience came out
  `verified` and published, and so did the point the curator placed. A person's judgement does not depend
  on the source's setting.
- **Migration 018 applied twice**: the first application reported `UPDATE 3`; then with Top Art Museums
  gated by hand, the second reported `UPDATE 0` and it stayed gated. Nothing in this repo records which
  migrations a database has seen, so the one statement here that writes a value has to be inert by itself.
- **A fresh database**, built from `01-schema.sql` alone: all three categories come out
  `requires_curation = false`, matching the migrated one. `backend/src/db/schemaMigrationParity.test.ts`
  guards both homes at the text level — columns, per-table CHECKs, the scoped `UPDATE`, its
  re-application guard, and that every seeded category names the column *and says `false`*.

**And one real sync run through the admin UI** — Public Art & Monuments, log 56: 208 fetched, 1 created,
7 updated, 192 unchanged. The arrival came in `auto` with `published_at` set; **zero** of the 7 updated
rows gained a `published_at`; locations went 6678 → 6680, all `auto`; the count a reader is offered went
1576 → 1577, exactly the one new object.

Gates: `npm run lint` (zero warnings), `npm run typecheck`, `TEST_REPORT_LOCAL=1 npm test`, `knip`,
`lint:extra` (madge finds no cycle, shellcheck, hadolint), full Semgrep (**0 findings** — this branch also
removed the repo's only two, by replacing two dynamic `new RegExp` test helpers with literal matching),
Trivy, `test:e2e:smoke`, and `/security-check`: no findings, and the branch adds no linter suppression at
all. No `.py` file and no `cv-python` file is touched, so the Python gates have nothing to say.

## Checklist

- [x] Commit messages follow the standard template.
- [x] All commits are signed.
- [x] Related issues are mentioned in the description above.
- [x] Linter checks have been passed.

## Additional Comments

**Fixed after the first review round, in the commits they belong to:** the pointer
(`pending_change_sync_log_id`) now follows every proposal the statement refused, not only the ones it
wrote — a field a curator has claimed empties `changedFields` too, so keying on that alone cleared the
pointer on a row whose proposal was still standing. The decay stays keyed to fields actually written. A
run with no log id now leaves the column alone rather than writing NULL, which the column defines as
"nothing is held".

**And the museum path now has tests**, which it had none of: `museumSyncService.treasures.test.ts`, six cases
split across the two commits whose behaviour they pin. Two promises there were held only by a live run — the
treasure's gate is bound positionally (last of twelve parameters, the others mostly numbers), and the link's
`RETURNING treasure_id` on a `DO NOTHING` is the only thing separating "the museum gained a work" from "the
run listed one it already had", which is what decides whether the curator's pass over the museum is retired.
The gate case resolves the placeholder out of the statement and asserts the value arriving there, so a
renumbering keeps it green while binding the gate to `ICONIC_RELEASE` reddens it. Each promise was
mutation-probed and reddened exactly one test.

**Deliberately deferred, so sub-branch 2 decides them rather than inheriting them:**

- **A held field is reported as an applied change, not as a refused one.** `computeChangeSet` is handed
  `curated_fields` and knows nothing about the hold, so a field the hold refused to write lands in
  `changedFields` rather than `curatedConflicts`. Under a gated source that makes `total_updated` count a
  row where nothing changed, records the changeset row as `updated` with `curatedConflict: false` — so a
  curator's screen would render the held value as the one now live — and repeats every run, because the
  stored value never moves toward the proposal. Raised by `claude[bot]` on this PR and **deliberately
  deferred to sub-branch 2**, not because it is small but because the fix needs a decision this branch
  cannot make well: whether a held field is a `curatedConflict` or wants a third word of its own, and the
  surface that consumes that word — the curator's queue and the proposal view — is sub-branch 2's subject.
  Deciding the vocabulary here, without its consumer, is the mistake this branch has otherwise avoided.
  Unreachable until sub-branch 3 gates a source, which lands after sub-branch 2. **Filed as #519**, with
  the failure path, the scope list, and the vocabulary question stated in the curator's terms — the
  difference between "I already decided this" and "this is waiting for me". The follow-up guard it warned
  about is already discharged: the pointer now keys on `changedFields` + `curatedConflicts` (see below),
  so moving held fields out of `changedFields` will not leave it behind.

- **The paired withdrawal.** Deferring a withdrawal needs somewhere to store the deferral, and only the
  publish transaction can release it. Until then a gated run marks a withdrawal exactly as today — which
  is honest, because no source is gated until sub-branch 3.
- **A source-driven rename of an existing visible point**, and a work's name/artist/image on the
  `ON CONFLICT` path. Neither is covered by the design's matrix: it has rows for a *new* point and a
  *moved* one, and it measured work names to decide something else. Low product cost — sub-place labels,
  and no measured bad work names — but these are unwritten cells, not decided ones.
- **`treasures.curated_fields`.** Answered by measurement: nothing in the backend can write a work's name,
  so there is no value to protect. Seven columns, not eight.

`docs/security/SECURITY.md:72` still reads truthfully at this HEAD — a `pending` row is fully visible, so
a run still cannot remove content from public view. That sentence becomes sub-branch 2's to update, when
the reader-side predicate opens the second path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RhiJYv1wtHY94ribzNhgDc



