### PR TITLE
front: Hover through the store and a window for every list

### DIFF
--- a/docs/tech/development-guide.md
+++ b/docs/tech/development-guide.md
@@ -169,7 +169,6 @@ components/
 │   ├── NoticeLink.tsx
 │   ├── PlacesCountChip.tsx   ← the count, and the fold it offers
 │   ├── RejectedSection.tsx
-│   ├── VirtualRow.tsx
 │   ├── VisitedStatusButton.tsx
 │   ├── useInViewFilter.ts    ← which rows the map's view leaves
 │   ├── useListScrollAnchor.ts ← every movement of the list
@@ -181,8 +180,9 @@ components/
 │   ├── FoldPlacesControl.tsx
 │   ├── layers.ts
 │   └── useMarkerInteractions.ts ← the map's own listeners: popup, ring, click
-├── regionMap/                ← what came out of RegionMapVT: hooks, and the hover card
+├── regionMap/                ← what came out of RegionMapVT: hooks, and the hover cards
 │   ├── HoverPreviewCard.tsx  ← names what the pointer is over, over the map
+│   ├── HoveredRegionTooltip.tsx ← names the region under the pointer; its own store subscriber
 │   ├── layerStyles.ts
 │   ├── useRegionMetadata.ts
 │   ├── useTileUrls.ts
@@ -261,7 +261,9 @@ Hooks in `frontend/src/hooks/` are app-wide concerns shared across many componen
 | `useNavigation` | World views, divisions, breadcrumbs, tile version |
 | `useAuth` | Authentication state, login/logout |
 | `useExperienceContext` | Experiences, selection, what the map is showing |
-| `useHoverContext` | What the pointer is over — a store, not state, and read where it is drawn |
+| `useHoverContext` | What the pointer is over — a store, not state, and read where it is drawn. Map mode's provider is mounted by `ExperienceProvider`, Discover's by `DiscoverPage` |
+| `useRegionHover` | Which region the pointer is over — the same store shape, mounted by `NavigationProvider`. As context state it re-rendered every `useNavigation` consumer per mouse move |
+| `useSeenWindowIds` | Which rows a windowed list's viewport has held, accumulated and flushed on a timer — what New-badge impressions may honestly report |
 | `useVisitedRegions` | Region visit tracking |
 | `useVisitedExperiences` | Experience visit tracking, mutations |
 | `useDiscoverExperiences` | Discover mode queries |

--- a/docs/tech/experience-map-ui.md
+++ b/docs/tech/experience-map-ui.md
@@ -9,9 +9,15 @@ This document describes how experience markers work in both map surfaces:
 - Discover Mode: `frontend/src/components/discover/DiscoverExperienceView.tsx`, which owns the
   selection and the camera and delegates the rest to one file each: `useDiscoverMap.ts` (the map
   instance and every listener on it), `useDiscoverHover.ts` (hover, in both directions),
-  `discoverMapLayers.ts` (sources and paint) and `DiscoverExperienceList.tsx` (the rows)
+  `discoverMapLayers.ts` (sources and paint) and `DiscoverExperienceList.tsx` (the windowed rows)
 - Shared interaction state: `frontend/src/hooks/useExperienceContext.tsx`, and hover alone in
-  `frontend/src/hooks/useHoverContext.tsx` — see § What a hover is allowed to re-render
+  `frontend/src/hooks/useHoverContext.tsx` — see § What a hover is allowed to re-render. Both
+  surfaces ride that store now (#573): `ExperienceProvider` mounts its provider for Map mode, and
+  `DiscoverPage` mounts one of its own for the whole Discover page — the map and list, and the
+  detail panel's location list, whose hover used to be page state re-rendering all three panels
+  per pointer move. Region hover has the same shape in its own store,
+  `frontend/src/hooks/useRegionHover.tsx`, mounted by `NavigationProvider` — as context state it
+  re-rendered every `useNavigation` consumer, the region map among them, on each mouse move
 
 ## Shared state model
 
@@ -71,6 +77,18 @@ The memos are the other half: `ExperienceListItem`, `ExperienceExpandedDetails` 
 are each wrapped in `memo`, and their props are chosen so it holds. Unwrap any one and the hover
 reaches everything below it again while every test still passes — which is how it regressed before
 (`hoverIsolation.test.tsx` guards the wrappers).
+
+Discover follows the same rules since #573, with its own cast (`discoverListWindow.test.tsx`
+guards its memo and its render counts): `DiscoverExperienceRow` selects "am I the hovered one",
+`DiscoverHoverCard` selects the preview, `PanelLocationRow` selects "is the map pointing at me",
+and `useDiscoverHover` only *writes* the store — its ring drawing stays imperative, and the two
+scroll answers (the card list's and the panel's) are `subscribeToHoverTarget` subscriptions in the
+components that own the virtualisers. A highlight-dot hover names the selected object *and* the
+place (`setHoveredFromMarker(selectedId, locationId)`), which is what lets the panel row highlight
+itself and the card list decline to scroll for it — a dot hover is about the panel's list, and
+moving the card list under a reader looking at the panel was the old behaviour's one kindness,
+kept. The panel-row direction inverts it: the row writes `setHoveredFromList(expId, locationId)`
+and the ring is drawn by `useDiscoverHover`'s subscription, which holds the coordinates.
 
 ## Batch location data
 
@@ -169,7 +187,7 @@ The same reporting covers what happens *inside* an open card — the picture arr
 
 `experience-list-layout.smoke.spec.ts` keeps the opening honest by sampling **every animation frame** rather than polling: the fault it guards against lasted a single frame, and a 50 ms poll steps straight over it. It caught this one when a pre-paint measurement placed in the wrong component looked correct and did nothing.
 
-Rows here are of unequal height — a header is one line, an expanded experience carries its locations — so the sizes are measured rather than assumed, via `measureElement` and a `getItemKey` that keys the measurement cache by the row's identity instead of its index. `admin/WorldViewImportTree.tsx:393,613` is the prior art for that; `RegionList.tsx:238` also virtualises but with a fixed `estimateSize: () => 48`, and needs none of it.
+Rows here are of unequal height — a header is one line, an expanded experience carries its locations — so the sizes are measured rather than assumed, via `measureElement` and a `getItemKey` that keys the measurement cache by the row's identity instead of its index. `admin/WorldViewImportTree.tsx:393,613` is the prior art for that; `RegionList.tsx:265` also virtualises but with a fixed `estimateSize: () => 48`, and needs none of it.
 
 The region is still read whole (`WHOLE_REGION_LIMIT`, see above) and every marker is still built: windowing is about what the DOM holds, not about what was fetched. The scrollbar covers the region, so this is not paging under another name.
 
@@ -254,13 +272,40 @@ Two further things are about promising the space before the content exists:
 
 A card that opens because everything settled has nothing left to append: the queries whose answers used to arrive late — a description that can be one line or ten, an artworks list that can hold twenty items — are among the things it waits for. There is no honest height to reserve for content of unknown length, so the card is not shown at the wrong length instead. The exception is the cap: a card opened because `READY_CAP_MS` ran out is opened incomplete, and whatever was still in flight appends when it lands, which is the old behaviour kept deliberately for the case where a request hangs.
 
+## Discover's card list is windowed too
+
+`DiscoverExperienceList` mounts the rows its scroll window covers (#573), through the same
+`useVirtualizer` + shared `VirtualRow` shape as the map-mode list — up to 683 `ExperienceCard`s
+mounted at once before, a window of them after, each wrapped in the subscribing
+`DiscoverExperienceRow`. The differences from the map-mode list are the
+ones its simpler rows earn: no groups, so the experiences are the rows; and no open state, so the
+84 px estimate is honest and `measureElement` is a correction rather than a requirement.
+
+Three consequences, each the map-mode list met first:
+
+- **A marker hover scrolls by index, not by element.** The row a marker names is usually not
+  mounted, so the `cardRefsMap` of elements went with the windowing; a subscription in the list
+  asks `scrollToIndex` instead. The jump replaces the old smooth `scrollIntoView` — TanStack
+  documents smooth as unsupported beside dynamic measurement, and a jump cannot slide rows under
+  a resting pointer, which is what the old `isAutoScrollingRef` guard existed to absorb.
+- **New-badge impressions report what the window has held**, via `useSeenWindowIds` — the shared
+  accumulate-and-flush both windowed lists use. Reporting the whole filtered set was honest only
+  while every row was mounted; the server keeps the first impression, so a row stamped unrendered
+  spends the reader's week without them.
+- **The name filter keys the measurement cache by row identity** (`getItemKey` = experience id),
+  so a height measured for one row is not handed to whatever the filter moves into its slot.
+
+`RegionList` and `DiscoverRegionList` were windowed already; `DiscoverRegionList`'s hover is pure
+CSS and needed nothing, `RegionList`'s rode the navigation context and now rides the region hover
+store (§ above).
+
 ## Hover preview card placement
 
 Both Map mode and Discover mode render hover cards as React `<Box>` overlays positioned absolutely over the map container — not as MapLibre native popups. This allows consistent styling, image loading, and animation across both surfaces.
 
 Map mode (`regionMap/HoverPreviewCard.tsx`): positioned by marker screen location (left/right and top/bottom) to avoid covering the hovered marker. Its own component and its own subscriber to the hover store, so the map is not one: `RegionMapVT` used to read the preview and render this inline, which meant a mouse move across a list of places re-rendered the whole map. It still needs the map — only the map can say where on screen the described point currently is — and takes `mapRef`/`mapLoaded` as props for that.
 
-Discover mode (`DiscoverExperienceView`): positioned in the bottom-left corner of the map — which is why the fold chip sits at the top centre (`FoldPlacesControl`), since the card would otherwise paint over it. On marker hover, `useDiscoverHover` looks up the experience in the `experiences` array by feature ID to get its image URL and category name. Uses `extractImageUrl()` + `toThumbnailUrl()` for image thumbnails. Both use `objectFit: 'contain'` with `maxHeight` to handle portrait-oriented images without severe cropping.
+Discover mode (`discover/DiscoverHoverCard.tsx`): positioned in the bottom-left corner of the map — which is why the fold chip sits at the top centre (`FoldPlacesControl`), since the card would otherwise paint over it. Its own component and its own subscriber to the hover store, for the same reason as Map mode's: rendered inline by `DiscoverExperienceView`, every marker the pointer crossed re-rendered the component that owns the map. On marker hover, `useDiscoverHover` looks up the experience in the `experiences` array by feature ID and writes the preview into the store. Uses `extractImageUrl()` + `toThumbnailUrl()` for image thumbnails. Both use `objectFit: 'contain'` with `maxHeight` to handle portrait-oriented images without severe cropping.
 
 ## Region visual feedback
 

--- a/docs/tech/shared-frontend-patterns.md
+++ b/docs/tech/shared-frontend-patterns.md
@@ -15,6 +15,7 @@ Quick-reference for reusable components and utilities. Use these instead of writ
 | `MapUnavailable` | Explains that this browser cannot draw maps. Props: `detail?`, `compact?` | `<MapUnavailable detail="The list still works." />` |
 | `LifecycleChip` | Labels a `former` or `lost` experience, nothing for an ordinary one. Props: `state` (`source_membership` / `existence`). Also exports `lifecycleLabel()` and `verdictOf()`, which share the precedence rule: existence answers first | `<LifecycleChip state={experience} />` |
 | `GuardedMap` | `react-map-gl`'s `<Map>` with the WebGL check built in. Extra props: `unavailableDetail?`, `unavailableCompact?` | `import { GuardedMap as MapGL } from '…/GuardedMap'` — alias it to the local name and nothing else changes |
+| `VirtualRow` | One row of a windowed list: places it where the virtualiser says and registers it with `measureElement`. Props: `virtualizer`, `index`, `start`, `children`. Renders a `li` — put it inside a `List` | Both windowed experience lists (`ExperienceList.tsx`, `discover/DiscoverExperienceList.tsx`) |
 
 ## Utility Modules (`frontend/src/utils/`)
 
@@ -60,6 +61,9 @@ Quick-reference for reusable components and utilities. Use these instead of writ
 | Fold an object's places to one pin | `useCollapsedExperiences(regionId)` + `<FoldPlacesControl />` | Local `useState` in a surface, or an effect that clears the set when the region changes — an effect runs after render, which leaves a commit where the new region's rows are drawn against the old region's folds |
 | Rendering any map | `GuardedMap` (aliased to your local name), or an early return on `isWebGLAvailable()` where overlays sit over the map | Importing `Map` straight from `react-map-gl/maplibre`, or a bare `new maplibregl.Map` — both throw without WebGL, and there is no error boundary to catch it |
 | Ask whether a place is inside the map's view | `pointInView(lng, lat, bounds)` | `bounds.contains([lng, lat])`, or a literal `west <= lng && lng <= east` — `LngLatBounds.contains` takes its wrapping branch only on `sw.lng > ne.lng`, which `getBounds()` never produces, so both drop every real longitude over the dateline |
+| Place a windowed list's row | `<VirtualRow virtualizer={v} index={i} start={row.start}>…</VirtualRow>` | A hand-rolled absolutely-positioned `Box` with its own `measureElement` ref — whose inline ref function detaches and reattaches per render, forcing a synchronous layout per mounted row (see the note in `VirtualRow.tsx`) |
+| Share hover state between a list and a map | A store + selectors: `useHoverContext` (experiences/places), `useRegionHover` (regions) | React state in a context — every consumer re-renders per mouse move; `hoverStore.test.tsx` / `regionHoverStore.test.tsx` pin what a hover may re-render |
+| Report New-badge impressions from a windowed list | `useSeenWindowIds(idsInVisibleRange, resetKey)` and hand the accumulated set to `useNewBadgeImpressions` | Reporting the fetched/filtered set — rows the window never held get stamped, and the server keeps the *first* impression, so their "new" week is spent unseen |
 
 ## Maintaining This Doc
 

--- a/frontend/src/components/ExperienceList.tsx
+++ b/frontend/src/components/ExperienceList.tsx
@@ -48,7 +48,7 @@ import { AddExperienceDialog } from './shared/AddExperienceDialog';
 import { invalidateExperiences } from '../utils/queryInvalidation';
 import { LoadingSpinner } from './shared/LoadingSpinner';
 import { ExperienceListItem } from './ExperienceList/ExperienceListItem';
-import { VirtualRow } from './ExperienceList/VirtualRow';
+import { VirtualRow } from './shared/VirtualRow';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { useSeenWindowIds } from '../hooks/useSeenWindowIds';
 

--- a/frontend/src/components/ExperienceList.tsx
+++ b/frontend/src/components/ExperienceList.tsx
@@ -50,15 +50,7 @@ import { LoadingSpinner } from './shared/LoadingSpinner';
 import { ExperienceListItem } from './ExperienceList/ExperienceListItem';
 import { VirtualRow } from './ExperienceList/VirtualRow';
 import { useVirtualizer } from '@tanstack/react-virtual';
-
-/**
- * How often, at most, the rows the window has held are reported as seen.
- *
- * Long enough that a scroll through a freshly published region is a handful of
- * requests rather than one per render, short enough that a reader who glances
- * and leaves has still been counted.
- */
-const SEEN_FLUSH_MS = 800;
+import { useSeenWindowIds } from '../hooks/useSeenWindowIds';
 
 interface ExperienceGroup {
   categoryName: string;
@@ -171,13 +163,6 @@ export function ExperienceList({ scrollContainerRef }: ExperienceListProps) {
 
   // Track which groups are expanded
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
-  // Which experiences the reader's window has held, for the New-badge impression
-  // below. Accumulated across scrolling and reset per region.
-  const [seenExperienceIds, setSeenExperienceIds] = useState<Set<number>>(() => new Set());
-  // Rows seen since the last flush, and the flush itself. Declared here because
-  // the region-change block below clears them, and that block runs during render.
-  const pendingSeen = useRef<Set<number>>(new Set());
-  const seenFlushTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Refs for scrolling to items (experiences and locations)
   const itemRefs = useRef<Map<number, HTMLDivElement>>(new Map());
@@ -226,14 +211,6 @@ export function ExperienceList({ scrollContainerRef }: ExperienceListProps) {
     setTrackedRegionId(regionId);
     hasAutoExpanded.current = false;
     setExpandedGroups(new Set());
-    // What the reader has laid eyes on belongs to the region they were in. Reset
-    // here rather than in an effect for the same reason the rest of this block is
-    // here: one render carrying region B's rows against A's seen-set would report
-    // impressions for rows nobody has seen, and the server keeps the first one.
-    // The rows still waiting to be flushed go with it, or region A's would be
-    // reported once the timer came round against region B's list.
-    setSeenExperienceIds(new Set());
-    pendingSeen.current = new Set();
   }
 
   // The parent's copy stays in an effect — setting another component's state
@@ -411,56 +388,15 @@ export function ExperienceList({ scrollContainerRef }: ExperienceListProps) {
     if (regionId) removeFromRegion({ experienceId: exp.id, rId: regionId });
   }, [regionId, removeFromRegion]);
 
-  // Rows the reader's window has actually held, accumulated. Windowing is what
-  // makes this answerable: before it, expanding a group of 467 stamped all 467 as
-  // seen while the reader had passed ten, and the server keeps the *first*
-  // impression — so those rows spent the reader's personal week unseen, which is
-  // precisely what that week exists to prevent. Accumulated rather than "in view
-  // now", because scrolling away does not unsee a row.
-  //
-  // State rather than a ref, so the memo below has something real to depend on:
-  // a ref mutated in place tells React nothing, and the impressions call would
-  // keep reporting the previous set.
-  //
-  // Flushed on a timer rather than per render, which is what windowing costs
-  // here: the set used to change once per region and now changes as the reader
-  // scrolls, and each change is a request. `authenticatedLimiter` allows 60 a
-  // minute per IP across every authenticated call, and a curator publishing a
-  // sync's arrivals in one go is precisely how a region comes to hold hundreds
-  // of rows carrying the mark. Ids accumulate between flushes, so this bounds
-  // how often the rows are reported, never which of them are.
   const virtualItems = virtualizer.getVirtualItems();
   // What the viewport intersects, which is not what is mounted: `virtualItems`
   // carries the `overscan` rows on either side, deliberately below the fold. Read
   // after `getVirtualItems()` so the range belongs to this render.
   const visibleRange = virtualizer.range;
-  useEffect(() => {
-    const fresh = experienceIdsInVisibleRange(flatRows, visibleRange)
-      .filter(id => !seenExperienceIds.has(id) && !pendingSeen.current.has(id));
-    for (const id of fresh) pendingSeen.current.add(id);
-    if (pendingSeen.current.size === 0 || seenFlushTimer.current) return;
-    seenFlushTimer.current = setTimeout(() => {
-      seenFlushTimer.current = null;
-      const batch = pendingSeen.current;
-      pendingSeen.current = new Set();
-      // Empty when a region change cleared the pending set while this was in
-      // flight; setting state anyway would report the new region's list against
-      // a set that gained nothing.
-      if (batch.size === 0) return;
-      setSeenExperienceIds(prev => {
-        const next = new Set(prev);
-        for (const id of batch) next.add(id);
-        return next;
-      });
-    }, SEEN_FLUSH_MS);
-  }, [visibleRange, flatRows, seenExperienceIds]);
-
-  // A flush landing after the list is gone belongs to nobody.
-  useEffect(() => () => {
-    if (seenFlushTimer.current) clearTimeout(seenFlushTimer.current);
-    seenFlushTimer.current = null;
-    pendingSeen.current = new Set();
-  }, []);
+  // Rows the reader's window has actually held, accumulated per region and
+  // flushed on a timer — the whole argument lives with `useSeenWindowIds`.
+  const seenExperienceIds = useSeenWindowIds(
+    experienceIdsInVisibleRange(flatRows, visibleRange), regionId);
 
   // `activeExperiences`, deliberately not the rows the view leaves: membership in
   // `seenExperienceIds` already means "this row rendered", since it is fed only

--- a/frontend/src/components/RegionList.tsx
+++ b/frontend/src/components/RegionList.tsx
@@ -15,6 +15,7 @@ import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import { useQuery } from '@tanstack/react-query';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { useNavigation } from '../hooks/useNavigation';
+import { useRegionHoverActions, useRegionHoverSelector } from '../hooks/useRegionHover';
 import { useVisitedRegions } from '../hooks/useVisitedRegions';
 import { fetchRootDivisions, fetchSubdivisions, fetchSubregions, fetchRootRegions } from '../api';
 import { LoadingSpinner } from './shared/LoadingSpinner';
@@ -65,129 +66,155 @@ function emptyListMessage(
   return selectedDivision ? 'No subdivisions' : 'No divisions found';
 }
 
+/** The placement the virtualiser hands a row: everything it needs to sit still. */
+interface RowPlacement {
+  size: number;
+  start: number;
+}
+
+interface DivisionRowProps {
+  division: AdministrativeDivision;
+  placement: RowPlacement;
+  onClick: (division: AdministrativeDivision) => void;
+  /** The store's setter — stable, so hovering costs this row's render alone. */
+  onHoverChange: (id: number | null) => void;
+}
+
+/**
+ * One division row, subscribed to its own "am I the hovered one" boolean.
+ *
+ * Hover used to be state in `NavigationContext`, so crossing this list — or the
+ * map, which shares the id — re-rendered the whole list and every other
+ * consumer of that context per mouse move (#573). Now a move re-renders the row
+ * entered and the row left, which is the invariant `regionHoverStore.test.tsx`
+ * pins.
+ */
+function DivisionRow({ division, placement, onClick, onHoverChange }: DivisionRowProps) {
+  const isHovered = useRegionHoverSelector(id => id === division.id);
+  return (
+    <ListItemButton
+      onClick={() => onClick(division)}
+      onMouseEnter={() => onHoverChange(division.id)}
+      onMouseLeave={() => onHoverChange(null)}
+      selected={isHovered}
+      sx={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        width: '100%',
+        height: `${placement.size}px`,
+        transform: `translateY(${placement.start}px)`,
+        backgroundColor: isHovered ? 'action.hover' : 'transparent',
+      }}
+    >
+      <ListItemIcon sx={{ minWidth: 28 }}>
+        <Box
+          sx={{
+            width: division.hasChildren ? 10 : 8,
+            height: division.hasChildren ? 10 : 8,
+            borderRadius: '50%',
+            bgcolor: division.hasChildren ? 'primary.main' : 'grey.400',
+          }}
+        />
+      </ListItemIcon>
+      <ListItemText
+        primary={division.name}
+        primaryTypographyProps={{
+          noWrap: true,
+          sx: { fontSize: '0.9rem' },
+        }}
+      />
+    </ListItemButton>
+  );
+}
+
+interface RegionRowProps {
+  region: Region;
+  placement: RowPlacement;
+  visited: boolean;
+  onClick: (region: Region) => void;
+  onHoverChange: (id: number | null) => void;
+  onToggleVisited: (regionId: number) => void;
+}
+
+function regionRowBackground(visited: boolean, isHovered: boolean): string {
+  if (visited) return 'rgba(76, 175, 80, 0.1)';
+  return isHovered ? 'action.hover' : 'transparent';
+}
+
+/** One region row; the same subscription shape as `DivisionRow` above. */
+function RegionRow({ region, placement, visited, onClick, onHoverChange, onToggleVisited }: RegionRowProps) {
+  const isHovered = useRegionHoverSelector(id => id === region.id);
+  return (
+    <ListItemButton
+      onClick={() => onClick(region)}
+      onMouseEnter={() => onHoverChange(region.id)}
+      onMouseLeave={() => onHoverChange(null)}
+      selected={isHovered}
+      sx={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        width: '100%',
+        height: `${placement.size}px`,
+        transform: `translateY(${placement.start}px)`,
+        backgroundColor: regionRowBackground(visited, isHovered),
+        borderLeft: `4px solid ${region.color || '#3388ff'}`,
+      }}
+    >
+      <ListItemIcon sx={{ minWidth: 28 }}>
+        <Box sx={{ width: 10, height: 10, borderRadius: '50%', bgcolor: region.color || '#3388ff' }} />
+      </ListItemIcon>
+      <ListItemText
+        primary={region.name}
+        primaryTypographyProps={{
+          noWrap: true,
+          sx: { fontSize: '0.9rem' },
+        }}
+      />
+      <Tooltip title={visited ? 'Mark as not visited' : 'Mark as visited'}>
+        <IconButton
+          size="small"
+          onClick={(e) => {
+            e.stopPropagation();
+            onToggleVisited(region.id);
+          }}
+          sx={{
+            ml: 1,
+            color: visited ? 'success.main' : 'action.disabled',
+          }}
+        >
+          {visited
+            ? <CheckCircleIcon fontSize="small" />
+            : <CheckCircleOutlineIcon fontSize="small" />}
+        </IconButton>
+      </Tooltip>
+    </ListItemButton>
+  );
+}
+
 export function RegionList() {
   const {
     selectedWorldView,
     selectedDivision,
     setSelectedDivision,
-    hoveredRegionId,
-    setHoveredRegionId,
     isCustomWorldView,
     selectedRegion,
     setSelectedRegion,
     rootRegions,
     rootRegionsLoading,
   } = useNavigation();
+  // The setter alone: this component renders none of the hover, so a mouse
+  // move across its rows — or across the map, which writes the same store —
+  // must not re-render it. Each row subscribes to its own boolean instead.
+  const { setHoveredRegionId } = useRegionHoverActions();
 
   // Visited regions tracking (only for custom world views)
   const { isVisited, toggleVisited } = useVisitedRegions(
     isCustomWorldView ? selectedWorldView?.id : undefined
   );
 
-  const regionRowBackground = (visited: boolean, isHovered: boolean): string => {
-    if (visited) return 'rgba(76, 175, 80, 0.1)';
-    return isHovered ? 'action.hover' : 'transparent';
-  };
-
   const parentRef = useRef<HTMLDivElement>(null);
-
-  const renderDivisionRow = (
-    division: AdministrativeDivision,
-    virtualRow: { size: number; start: number },
-  ) => {
-    const isHovered = hoveredRegionId === division.id;
-    return (
-      <ListItemButton
-        key={division.id}
-        onClick={() => handleDivisionClick(division)}
-        onMouseEnter={() => setHoveredRegionId(division.id)}
-        onMouseLeave={() => setHoveredRegionId(null)}
-        selected={isHovered}
-        sx={{
-          position: 'absolute',
-          top: 0,
-          left: 0,
-          width: '100%',
-          height: `${virtualRow.size}px`,
-          transform: `translateY(${virtualRow.start}px)`,
-          backgroundColor: isHovered ? 'action.hover' : 'transparent',
-        }}
-      >
-        <ListItemIcon sx={{ minWidth: 28 }}>
-          <Box
-            sx={{
-              width: division.hasChildren ? 10 : 8,
-              height: division.hasChildren ? 10 : 8,
-              borderRadius: '50%',
-              bgcolor: division.hasChildren ? 'primary.main' : 'grey.400',
-            }}
-          />
-        </ListItemIcon>
-        <ListItemText
-          primary={division.name}
-          primaryTypographyProps={{
-            noWrap: true,
-            sx: { fontSize: '0.9rem' },
-          }}
-        />
-      </ListItemButton>
-    );
-  };
-
-  const renderRegionRow = (
-    region: Region,
-    virtualRow: { size: number; start: number },
-  ) => {
-    const isHovered = hoveredRegionId === region.id;
-    const visited = isVisited(region.id);
-    return (
-      <ListItemButton
-        key={region.id}
-        onClick={() => handleRegionClick(region)}
-        onMouseEnter={() => setHoveredRegionId(region.id)}
-        onMouseLeave={() => setHoveredRegionId(null)}
-        selected={isHovered}
-        sx={{
-          position: 'absolute',
-          top: 0,
-          left: 0,
-          width: '100%',
-          height: `${virtualRow.size}px`,
-          transform: `translateY(${virtualRow.start}px)`,
-          backgroundColor: regionRowBackground(visited, isHovered),
-          borderLeft: `4px solid ${region.color || '#3388ff'}`,
-        }}
-      >
-        <ListItemIcon sx={{ minWidth: 28 }}>
-          <Box sx={{ width: 10, height: 10, borderRadius: '50%', bgcolor: region.color || '#3388ff' }} />
-        </ListItemIcon>
-        <ListItemText
-          primary={region.name}
-          primaryTypographyProps={{
-            noWrap: true,
-            sx: { fontSize: '0.9rem' },
-          }}
-        />
-        <Tooltip title={visited ? 'Mark as not visited' : 'Mark as visited'}>
-          <IconButton
-            size="small"
-            onClick={(e) => {
-              e.stopPropagation();
-              toggleVisited(region.id);
-            }}
-            sx={{
-              ml: 1,
-              color: visited ? 'success.main' : 'action.disabled',
-            }}
-          >
-            {visited
-              ? <CheckCircleIcon fontSize="small" />
-              : <CheckCircleOutlineIcon fontSize="small" />}
-          </IconButton>
-        </Tooltip>
-      </ListItemButton>
-    );
-  };
 
   // Fetch divisions for GADM hierarchy
   const { data: divisions = [], isLoading: divisionsLoading } = useQuery({
@@ -284,9 +311,32 @@ export function RegionList() {
           position: 'relative',
         }}
       >
-        {virtualizer.getVirtualItems().map((virtualRow) => isCustomWorldView
-          ? renderRegionRow(regions[virtualRow.index], virtualRow)
-          : renderDivisionRow(divisions[virtualRow.index], virtualRow))}
+        {virtualizer.getVirtualItems().map((virtualRow) => {
+          if (isCustomWorldView) {
+            const region = regions[virtualRow.index];
+            return (
+              <RegionRow
+                key={region.id}
+                region={region}
+                placement={virtualRow}
+                visited={isVisited(region.id)}
+                onClick={handleRegionClick}
+                onHoverChange={setHoveredRegionId}
+                onToggleVisited={toggleVisited}
+              />
+            );
+          }
+          const division = divisions[virtualRow.index];
+          return (
+            <DivisionRow
+              key={division.id}
+              division={division}
+              placement={virtualRow}
+              onClick={handleDivisionClick}
+              onHoverChange={setHoveredRegionId}
+            />
+          );
+        })}
       </List>
     </Paper>
   );

--- a/frontend/src/components/RegionMapVT.tsx
+++ b/frontend/src/components/RegionMapVT.tsx
@@ -25,6 +25,7 @@ import { useNavigation } from '../hooks/useNavigation';
 import { useVisitedRegions } from '../hooks/useVisitedRegions';
 import { useExperienceContext } from '../hooks/useExperienceContext';
 import { HoverPreviewCard } from './regionMap/HoverPreviewCard';
+import { HoveredRegionTooltip } from './regionMap/HoveredRegionTooltip';
 import { ExperienceMarkers } from './ExperienceMarkers';
 import { SelectedObjectFoldControl } from './experienceMarkers/FoldPlacesControl';
 import { MapUnavailable } from './shared/MapUnavailable';
@@ -61,7 +62,6 @@ export function RegionMapVT() {
     selectedWorldView,
     isCustomWorldView,
     selectedRegion,
-    hoveredRegionId,
     regionBreadcrumbs,
   } = useNavigation();
 
@@ -108,7 +108,6 @@ export function RegionMapVT() {
     isCustomWorldView,
     isExploring,
     visitedRegionIds,
-    hoveredRegionId,
     sourceLayerName,
     tileUrl,
     viewingRegionId,
@@ -120,7 +119,6 @@ export function RegionMapVT() {
     handleMouseMove,
     handleMouseLeave,
     handleGoToParent,
-    hoveredRegionName,
     interactiveLayerIds,
   } = useMapInteractions({
     mapRef,
@@ -427,30 +425,15 @@ export function RegionMapVT() {
         )}
       </Map>
 
-      {/* Hovered region tooltip - hidden when exploring */}
-      {hoveredRegionId && hoveredRegionName && !isExploring && (
-        <Box
-          sx={{
-            position: 'absolute',
-            bottom: 16,
-            left: 16,
-            backgroundColor: 'rgba(255,255,255,0.98)',
-            backdropFilter: 'blur(8px)',
-            p: 1.5,
-            px: 2,
-            borderRadius: 2,
-            maxWidth: 300,
-            boxShadow: '0 4px 12px rgba(0,0,0,0.08)',
-            border: '1px solid rgba(0,0,0,0.06)',
-          }}
-        >
-          <Typography variant="subtitle2" sx={{ fontWeight: 500 }}>
-            {hoveredRegionName}
-          </Typography>
-          <Typography variant="caption" color="text.secondary">
-            Click to explore
-          </Typography>
-        </Box>
+      {/* Hovered region tooltip - hidden when exploring. Its own subscriber to
+          the region hover store, so a mouse move re-renders it and not the map. */}
+      {!isExploring && (
+        <HoveredRegionTooltip
+          mapRef={mapRef}
+          metadataById={metadataById}
+          sourceLayerName={sourceLayerName}
+          contextLayerCount={contextLayers.length}
+        />
       )}
 
       {/* Artwork preview overlay */}

--- a/frontend/src/components/discover/DiscoverExperienceList.tsx
+++ b/frontend/src/components/discover/DiscoverExperienceList.tsx
@@ -1,26 +1,86 @@
 /**
- * Discover's experience list: the header, the name filter and the rows.
+ * Discover's experience list: the header, the name filter and the windowed rows.
  *
  * Split out of `DiscoverExperienceView` under the 800-line rule in
- * `docs/tech/development-guide.md` (#562). It is presentational — every piece of
- * state it reads and every handler it calls belongs to the view, which owns the
- * map beside it and the hover that ties the two together. Kept in one component
- * rather than split further because the header, the filter and the rows are one
- * thing to a reader: the list of what is here.
+ * `docs/tech/development-guide.md` (#562). Since #573 it owns its window: the
+ * rows are virtualised — a region can put 683 cards here, and mounting them all
+ * is what made opening one freeze the tab — and with the window comes what only
+ * the window knows: which rows were actually shown (the New-badge impressions)
+ * and how to reach a row that has no element (the scroll a marker hover asks
+ * for). Hover is not a prop: each row subscribes to its own "am I the one", so
+ * a pointer move re-renders the row entered and the row left, not the list.
  */
 
+import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import {
-  Box, Typography, IconButton, TextField, InputAdornment, Button,
+  Box, Typography, IconButton, TextField, InputAdornment, Button, List,
 } from '@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import SearchIcon from '@mui/icons-material/Search';
 import ClearIcon from '@mui/icons-material/Clear';
 import PlaylistAddIcon from '@mui/icons-material/PlaylistAdd';
+import { useVirtualizer } from '@tanstack/react-virtual';
 import type { Experience } from '../../api/experiences';
 import type { ActiveView } from '../../hooks/useDiscoverExperiences';
+import { subscribeToHoverTarget, useHoverActions, useHoverSelector } from '../../hooks/useHoverContext';
+import { useSeenWindowIds } from '../../hooks/useSeenWindowIds';
+import { useNewBadgeImpressions } from '../../hooks/useNewBadgeImpressions';
+import { useAuth } from '../../hooks/useAuth';
 import { LoadingSpinner } from '../shared/LoadingSpinner';
 import { EmptyState } from '../shared/EmptyState';
+import { VirtualRow } from '../shared/VirtualRow';
 import { ExperienceCard } from './ExperienceCard';
+
+interface DiscoverExperienceRowProps {
+  experience: Experience;
+  isVisited: boolean;
+  isSelected: boolean;
+  showCheckbox: boolean;
+  canCurate: boolean;
+  // Every callback takes the experience it concerns rather than closing over
+  // it: this component is memoised, and a closure rebuilt per parent render is
+  // one unstable prop away from the memo doing nothing.
+  onSelect: (id: number) => void;
+  onHoverEnter: (id: number) => void;
+  onHoverLeave: () => void;
+  onVisitedToggle: (experienceId: number, visited: boolean, e: React.MouseEvent) => void;
+  onCurate: (experience: Experience) => void;
+}
+
+/**
+ * One row, subscribed to its own "am I the hovered one" boolean — the shape
+ * `hoverStore.test.tsx` pins. Memoised so the whole-list renders that remain
+ * (scrolling mounts a batch of rows, selection changes two) stay the only ones.
+ * Exported for `discoverListWindow.test.tsx`, which guards the memo.
+ */
+export const DiscoverExperienceRow = memo(function DiscoverExperienceRow({
+  experience,
+  isVisited,
+  isSelected,
+  showCheckbox,
+  canCurate,
+  onSelect,
+  onHoverEnter,
+  onHoverLeave,
+  onVisitedToggle,
+  onCurate,
+}: DiscoverExperienceRowProps) {
+  const isHovered = useHoverSelector(s => s.hoveredExperienceId === experience.id);
+  return (
+    <ExperienceCard
+      experience={experience}
+      isVisited={isVisited}
+      isHovered={isHovered}
+      isSelected={isSelected}
+      onClick={() => onSelect(experience.id)}
+      onMouseEnter={() => onHoverEnter(experience.id)}
+      onMouseLeave={onHoverLeave}
+      onVisitedToggle={(e) => onVisitedToggle(experience.id, isVisited, e)}
+      showCheckbox={showCheckbox}
+      onCurate={canCurate ? () => onCurate(experience) : undefined}
+    />
+  );
+});
 
 interface DiscoverExperienceListProps {
   activeView: ActiveView;
@@ -34,10 +94,7 @@ interface DiscoverExperienceListProps {
   hasCuratorScope: boolean;
   isAuthenticated: boolean;
   visitedIds: Set<number>;
-  hoveredExperienceId: number | null;
   selectedExperienceId: number | null;
-  listContainerRef: React.RefObject<HTMLDivElement | null>;
-  cardRefsMap: React.MutableRefObject<Map<number, HTMLDivElement>>;
   onBack: () => void;
   onSelectExperience: (id: number) => void;
   onCardMouseEnter: (id: number) => void;
@@ -59,10 +116,7 @@ export function DiscoverExperienceList({
   hasCuratorScope,
   isAuthenticated,
   visitedIds,
-  hoveredExperienceId,
   selectedExperienceId,
-  listContainerRef,
-  cardRefsMap,
   onBack,
   onSelectExperience,
   onCardMouseEnter,
@@ -71,6 +125,90 @@ export function DiscoverExperienceList({
   onCurate,
   onAdd,
 }: DiscoverExperienceListProps) {
+  const { user } = useAuth();
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+
+  // A row's identity, not its position: the name filter removes rows above,
+  // and a height measured for "row 40" handed to whatever moved into slot 40
+  // keeps the scrollbar wrong until each row happens to re-render.
+  const getRowKey = useCallback(
+    (index: number) => filteredExperiences[index]?.id ?? index,
+    [filteredExperiences],
+  );
+
+  const virtualizer = useVirtualizer({
+    count: filteredExperiences.length,
+    getScrollElement: () => scrollContainerRef.current,
+    // A card is a fixed-layout strip — 56 px thumbnail, three `noWrap` lines,
+    // padding — so unlike map mode's rows there is no open state to swallow the
+    // estimate. `measureElement` still corrects each row as it mounts.
+    estimateSize: () => 84,
+    getItemKey: getRowKey,
+    overscan: 8,
+  });
+
+  // Where each experience sits, for the scroll a marker hover asks for — the
+  // row it names is usually not mounted, which is the point of windowing.
+  const rowIndexById = useMemo(() => {
+    const map = new Map<number, number>();
+    filteredExperiences.forEach((exp, i) => map.set(exp.id, i));
+    return map;
+  }, [filteredExperiences]);
+  // Read through a ref: the subscription below is registered once, and a hover
+  // is not the moment to re-register it because the rows changed.
+  const rowIndexRef = useRef(rowIndexById);
+  rowIndexRef.current = rowIndexById;
+
+  // ── Map hover → scroll the row into view ──
+  //
+  // Subscribed, never rendered from: a hover changes on every mouse move, and
+  // this component builds every row it has. Only a hover from a *marker* moves
+  // the list, and only one that names no place — a highlight-dot hover names a
+  // place in the detail panel's list, and scrolling this one to the selected
+  // card for it would move the list under a reader who is looking at the panel.
+  // The jump replaces the smooth `scrollIntoView` the unwindowed list used:
+  // TanStack documents smooth scrolling as unsupported beside dynamic
+  // measurement, and a jump cannot slide rows under a resting pointer — which
+  // is what the old `isAutoScrollingRef` guard existed to absorb.
+  const { store } = useHoverActions();
+  useEffect(() => subscribeToHoverTarget(store, ({ hoveredExperienceId, hoveredLocationId, hoverSource }) => {
+    if (hoverSource !== 'marker' || hoveredExperienceId == null || hoveredLocationId != null) return;
+    const index = rowIndexRef.current.get(hoveredExperienceId);
+    if (index != null) virtualizer.scrollToIndex(index, { align: 'center' });
+  }), [store, virtualizer]);
+
+  // ── New-badge impressions: what the window has held, not what the response
+  // holds ──
+  //
+  // The server keeps the *first* impression, so a row stamped while unrendered
+  // spends the reader's personal week without them — before windowing this
+  // reported the whole filtered set, which was honest exactly because every row
+  // was mounted. Now the window is what a reader was shown, and the same
+  // accumulate-and-flush the map-mode list uses answers it. The range excludes
+  // `overscan`, which is mounted precisely because it is *not* in view. Search
+  // does not reset the set: it only narrows a list whose rows were reported
+  // when shown, and a row seen under an earlier filter stays seen.
+  const virtualItems = virtualizer.getVirtualItems();
+  // Read after `getVirtualItems()` so the range belongs to this render — the
+  // property is only assigned inside the virtualiser's accessors, so read
+  // first it is the previous render's. With the name filter that is a stale
+  // `startIndex` sliced into the freshly narrowed array: ids of rows that were
+  // never mounted, stamped as seen (the map-mode list states the same rule).
+  const range = virtualizer.range;
+  const idsInVisibleRange = !isLoading && range
+    ? filteredExperiences.slice(range.startIndex, range.endIndex + 1).map(e => e.id)
+    : [];
+  const seenIds = useSeenWindowIds(
+    idsInVisibleRange, `${activeView.regionId}:${activeView.categoryId}`);
+  // `experiences`, deliberately not the filtered rows: membership in `seenIds`
+  // already means "this row rendered", and narrowing to what the filter leaves
+  // *now* would drop rows the reader did see before typing.
+  const shownExperiences = useMemo(
+    () => experiences.filter(exp => seenIds.has(exp.id)),
+    [experiences, seenIds],
+  );
+  useNewBadgeImpressions(shownExperiences, isAuthenticated, user?.id);
+
   return (
         <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', borderTop: '1px solid', borderColor: 'divider', minHeight: 0 }}>
           {/* List header with back button */}
@@ -148,31 +286,47 @@ export function DiscoverExperienceList({
             </Box>
           )}
 
-          {/* Scrollable experience list */}
-          <Box ref={listContainerRef} sx={{ flex: 1, overflowY: 'auto' }}>
+          {/* Scrollable experience list — windowed: only the rows the scroll
+              window covers are mounted, out of a set that reaches 683. Still a
+              `List`, each row one `li` of it, so a screen reader hears one item
+              per row. */}
+          <Box ref={scrollContainerRef} sx={{ flex: 1, overflowY: 'auto' }}>
             {isLoading && <LoadingSpinner size={24} padding="16px 0" />}
             {!isLoading && filteredExperiences.length === 0 && (
               <EmptyState message={search ? 'No experiences match your filter.' : 'No experiences found.'} />
             )}
-            {!isLoading && filteredExperiences.length > 0 && filteredExperiences.map((exp) => (
-              <ExperienceCard
-                key={exp.id}
-                ref={(el) => {
-                  if (el) cardRefsMap.current.set(exp.id, el);
-                  else cardRefsMap.current.delete(exp.id);
-                }}
-                experience={exp}
-                isVisited={visitedIds.has(exp.id)}
-                isHovered={hoveredExperienceId === exp.id}
-                isSelected={selectedExperienceId === exp.id}
-                onClick={() => onSelectExperience(exp.id)}
-                onMouseEnter={() => onCardMouseEnter(exp.id)}
-                onMouseLeave={onCardMouseLeave}
-                onVisitedToggle={(e) => onVisitedToggle(exp.id, visitedIds.has(exp.id), e)}
-                showCheckbox={isAuthenticated}
-                onCurate={hasCuratorScope ? () => onCurate(exp) : undefined}
-              />
-            ))}
+            {!isLoading && filteredExperiences.length > 0 && (
+              <List
+                disablePadding
+                sx={{ height: virtualizer.getTotalSize(), position: 'relative', width: '100%' }}
+              >
+                {virtualItems.map((virtualRow) => {
+                  const exp = filteredExperiences[virtualRow.index];
+                  if (!exp) return null;
+                  return (
+                    <VirtualRow
+                      key={virtualRow.key}
+                      virtualizer={virtualizer}
+                      index={virtualRow.index}
+                      start={virtualRow.start}
+                    >
+                      <DiscoverExperienceRow
+                        experience={exp}
+                        isVisited={visitedIds.has(exp.id)}
+                        isSelected={selectedExperienceId === exp.id}
+                        showCheckbox={isAuthenticated}
+                        canCurate={hasCuratorScope}
+                        onSelect={onSelectExperience}
+                        onHoverEnter={onCardMouseEnter}
+                        onHoverLeave={onCardMouseLeave}
+                        onVisitedToggle={onVisitedToggle}
+                        onCurate={onCurate}
+                      />
+                    </VirtualRow>
+                  );
+                })}
+              </List>
+            )}
           </Box>
         </Box>
   );

--- a/frontend/src/components/discover/DiscoverExperienceView.tsx
+++ b/frontend/src/components/discover/DiscoverExperienceView.tsx
@@ -25,12 +25,11 @@ import { useCollapsedExperiences } from '../../hooks/useCollapsedExperiences';
 import { buildExperienceMarkers, representablePlaces } from '../experienceMarkers/buildMarkers';
 import { FoldPlacesControl } from '../experienceMarkers/FoldPlacesControl';
 import { DiscoverExperienceList } from './DiscoverExperienceList';
+import { DiscoverHoverCard } from './DiscoverHoverCard';
 import { useAuth } from '../../hooks/useAuth';
-import { useNewBadgeImpressions } from '../../hooks/useNewBadgeImpressions';
 import { useVisitedExperiences } from '../../hooks/useVisitedExperiences';
 import { CurationDialog } from '../shared/CurationDialog';
 import { AddExperienceDialog } from '../shared/AddExperienceDialog';
-import { ImageCreditLine } from '../shared/ImageCreditLine';
 import { MapUnavailable } from '../shared/MapUnavailable';
 import { isWebGLAvailable } from '../../utils/webgl';
 import { SOURCE_ID, HIGHLIGHT_SOURCE_ID } from './discoverMapLayers';
@@ -39,11 +38,6 @@ import { useDiscoverHover } from './useDiscoverHover';
 
 /** Discover shows one category at a time, so the builder's filter has nothing to do. */
 const NO_CATEGORY_FILTER: Set<string> = new Set();
-
-// Stable identity: an inline [] would be a new array every render, and the
-// impression effect keys off the array it is given.
-const EMPTY_EXPERIENCES: Experience[] = [];
-
 
 interface DiscoverExperienceViewProps {
   activeView: ActiveView | null;
@@ -56,10 +50,6 @@ interface DiscoverExperienceViewProps {
   selectedExperienceLocations: { id?: number; lng: number; lat: number; name?: string }[] | null;
   /** That fetch has answered, so the set above is real rather than the fallback. */
   selectedLocationsResolved: boolean;
-  /** External hover coordinates (e.g. from detail panel location list) */
-  externalHoverCoords?: { lng: number; lat: number } | null;
-  /** Called when hovering a highlight dot (red location marker) on the map */
-  onHoverHighlightLocation?: (locationId: number | null) => void;
 }
 
 export function DiscoverExperienceView({
@@ -71,8 +61,6 @@ export function DiscoverExperienceView({
   selectedExperienceId,
   selectedExperienceLocations,
   selectedLocationsResolved,
-  externalHoverCoords,
-  onHoverHighlightLocation,
 }: DiscoverExperienceViewProps) {
   // A batch of its own, and deliberately: `includeChildren` is part of the query
   // key, and Map mode passes `false`, so this is a second, larger answer rather
@@ -186,7 +174,7 @@ export function DiscoverExperienceView({
 
   const mapContainerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<maplibregl.Map | null>(null);
-  const { isAuthenticated, isCurator, user } = useAuth();
+  const { isAuthenticated, isCurator } = useAuth();
   const { visitedIds, markVisited, unmarkVisited } = useVisitedExperiences();
   const [search, setSearch] = useState('');
 
@@ -203,19 +191,20 @@ export function DiscoverExperienceView({
     [experiences],
   );
 
-  // Hover is one mechanism across the map and the list, so it lives in one place
-  // rather than as two halves of this component — see the hook.
-  const {
-    hoveredExperienceId, hoverPreview, cardRefsMap, listContainerRef,
-    mapHoverCallbackRef, highlightHoverCallbackRef, onCardMouseEnter, onCardMouseLeave,
-  } = useDiscoverHover({
-    mapRef, experiences, drawnCoordsRef, selectedExpIdRef,
-    externalHoverCoords, onHoverHighlightLocation,
-  });
-
-  // The selected object's places, for the fit effect's long-lived callbacks.
+  // The selected object's places, for the fit effect's long-lived callbacks
+  // and for the ring a panel-row hover asks the hover hook to draw.
   const selectedLocsRef = useRef(selectedExperienceLocations);
   selectedLocsRef.current = selectedExperienceLocations;
+
+  // Hover is one mechanism across the map and the list, so it lives in one place
+  // rather than as two halves of this component — see the hook. It writes the
+  // shared hover store; nothing here reads it, which is what keeps a pointer
+  // move over a marker from re-rendering the component that owns the map.
+  const {
+    mapHoverCallbackRef, highlightHoverCallbackRef, onCardMouseEnter, onCardMouseLeave,
+  } = useDiscoverHover({
+    mapRef, experiences, drawnCoordsRef, selectedExpIdRef, selectedLocsRef,
+  });
 
   // Not `utils/categoryColors.shortSourceName`: this heading has room for
   // "Public Art" where a chip does not, and the shared one shortens that to
@@ -238,21 +227,9 @@ export function DiscoverExperienceView({
     );
   }, [experiences, search]);
 
-  // Discover renders the same cards from the same response, so a chip shown
-  // here is an impression exactly as one in Map mode is. Reporting from only
-  // one surface would make a reader's week start whenever they happened to use
-  // that one.
-  //
-  // Reported from the filtered set and behind the loading gate — the same two
-  // conditions the card list renders under (below), rather than from the whole
-  // response. Today the two coincide: the query is `enabled` only with an
-  // active view, `isLoading` is false whenever there is data to render, and
-  // search only ever narrows a set already reported. But that is three separate
-  // facts staying true, and the cost of getting it wrong is not recoverable —
-  // the server keeps the first impression, so a row stamped while unrendered
-  // spends the reader's week without them.
-  useNewBadgeImpressions(
-    isLoading ? EMPTY_EXPERIENCES : filteredExperiences, isAuthenticated, user?.id);
+  // New-badge impressions moved into `DiscoverExperienceList` with the window:
+  // what a reader was shown is now what the window has held, and only the list
+  // knows its window.
 
   // Reset search when active view changes
   useEffect(() => {
@@ -584,60 +561,9 @@ export function DiscoverExperienceView({
             </Box>
           </Box>
         )}
-        {/* Hover preview card (map marker hover) */}
-        {hoverPreview && (
-          <Box
-            sx={{
-              position: 'absolute',
-              bottom: 12,
-              left: 12,
-              zIndex: 3,
-              width: 260,
-              maxWidth: 'calc(100% - 24px)',
-              backgroundColor: 'rgba(255,255,255,0.97)',
-              backdropFilter: 'blur(10px)',
-              border: '1px solid rgba(0,0,0,0.08)',
-              borderRadius: 2,
-              overflow: 'hidden',
-              boxShadow: '0 10px 30px rgba(0,0,0,0.20)',
-              pointerEvents: 'none',
-              animation: 'tyrDiscoverHoverIn 170ms cubic-bezier(0.2, 0.8, 0.2, 1)',
-            }}
-          >
-            {hoverPreview.imageUrl && (
-              <Box
-                component="img"
-                src={hoverPreview.imageUrl}
-                alt={hoverPreview.name}
-                sx={{
-                  width: '100%',
-                  maxHeight: 180,
-                  objectFit: 'contain',
-                  display: 'block',
-                  backgroundColor: 'grey.100',
-                }}
-              />
-            )}
-            <Box sx={{ p: 1, display: 'flex', flexDirection: 'column', gap: 0.25 }}>
-              {/* Wherever the work appears, including here. */}
-              {hoverPreview.imageUrl && <ImageCreditLine credit={hoverPreview.imageCredit} />}
-              <Typography variant="subtitle2" sx={{ fontWeight: 700, lineHeight: 1.2 }} noWrap>
-                {hoverPreview.name}
-              </Typography>
-              {hoverPreview.categoryName && (
-                <Typography variant="caption" sx={{ color: 'text.secondary', opacity: 0.85 }} noWrap>
-                  {hoverPreview.categoryName}
-                </Typography>
-              )}
-            </Box>
-          </Box>
-        )}
-        <style>{`
-          @keyframes tyrDiscoverHoverIn {
-            from { opacity: 0; transform: translateY(8px) scale(0.98); }
-            to { opacity: 1; transform: translateY(0) scale(1); }
-          }
-        `}</style>
+        {/* Hover preview card (map marker hover) — its own subscriber to the
+            hover store, so a marker hover re-renders it and not this view. */}
+        <DiscoverHoverCard />
       </Box>
 
       {/* Experience list (below map, only when active view) */}
@@ -654,10 +580,7 @@ export function DiscoverExperienceView({
           hasCuratorScope={hasCuratorScope}
           isAuthenticated={isAuthenticated}
           visitedIds={visitedIds}
-          hoveredExperienceId={hoveredExperienceId}
           selectedExperienceId={selectedExperienceId}
-          listContainerRef={listContainerRef}
-          cardRefsMap={cardRefsMap}
           onBack={onBack}
           onSelectExperience={onSelectExperience}
           onCardMouseEnter={onCardMouseEnter}

--- a/frontend/src/components/discover/DiscoverHoverCard.tsx
+++ b/frontend/src/components/discover/DiscoverHoverCard.tsx
@@ -1,0 +1,73 @@
+/**
+ * Names what the pointer is over, over Discover's map.
+ *
+ * Its own component and its own subscriber to the hover store, the same shape
+ * as map mode's `HoverPreviewCard`: the preview changes on every marker the
+ * pointer crosses, and when `DiscoverExperienceView` held it as state, each
+ * change re-rendered the view that owns the map and every card in the list
+ * (#573). Positioned in the bottom-left corner — which is why the fold chip
+ * sits at the top centre, since the card would otherwise paint over it.
+ */
+
+import { Box, Typography } from '@mui/material';
+import { useHoverSelector } from '../../hooks/useHoverContext';
+import { ImageCreditLine } from '../shared/ImageCreditLine';
+
+export function DiscoverHoverCard() {
+  const hoverPreview = useHoverSelector(s => s.hoverPreview);
+  if (!hoverPreview) return null;
+
+  return (
+    <Box
+      sx={{
+        position: 'absolute',
+        bottom: 12,
+        left: 12,
+        zIndex: 3,
+        width: 260,
+        maxWidth: 'calc(100% - 24px)',
+        backgroundColor: 'rgba(255,255,255,0.97)',
+        backdropFilter: 'blur(10px)',
+        border: '1px solid rgba(0,0,0,0.08)',
+        borderRadius: 2,
+        overflow: 'hidden',
+        boxShadow: '0 10px 30px rgba(0,0,0,0.20)',
+        pointerEvents: 'none',
+        animation: 'tyrDiscoverHoverIn 170ms cubic-bezier(0.2, 0.8, 0.2, 1)',
+      }}
+    >
+      {hoverPreview.imageUrl && (
+        <Box
+          component="img"
+          src={hoverPreview.imageUrl}
+          alt={hoverPreview.experienceName}
+          sx={{
+            width: '100%',
+            maxHeight: 180,
+            objectFit: 'contain',
+            display: 'block',
+            backgroundColor: 'grey.100',
+          }}
+        />
+      )}
+      <Box sx={{ p: 1, display: 'flex', flexDirection: 'column', gap: 0.25 }}>
+        {/* Wherever the work appears, including here. */}
+        {hoverPreview.imageUrl && <ImageCreditLine credit={hoverPreview.imageCredit} />}
+        <Typography variant="subtitle2" sx={{ fontWeight: 700, lineHeight: 1.2 }} noWrap>
+          {hoverPreview.experienceName}
+        </Typography>
+        {hoverPreview.categoryName && (
+          <Typography variant="caption" sx={{ color: 'text.secondary', opacity: 0.85 }} noWrap>
+            {hoverPreview.categoryName}
+          </Typography>
+        )}
+      </Box>
+      <style>{`
+        @keyframes tyrDiscoverHoverIn {
+          from { opacity: 0; transform: translateY(8px) scale(0.98); }
+          to { opacity: 1; transform: translateY(0) scale(1); }
+        }
+      `}</style>
+    </Box>
+  );
+}

--- a/frontend/src/components/discover/DiscoverPage.tsx
+++ b/frontend/src/components/discover/DiscoverPage.tsx
@@ -26,6 +26,7 @@ import HomeIcon from '@mui/icons-material/Home';
 import NavigateNextIcon from '@mui/icons-material/NavigateNext';
 import { useDiscoverExperiences } from '../../hooks/useDiscoverExperiences';
 import { useAuth } from '../../hooks/useAuth';
+import { HoverProvider } from '../../hooks/useHoverContext';
 import { DiscoverRegionList } from './DiscoverRegionList';
 import { DiscoverExperienceView } from './DiscoverExperienceView';
 import { ExperienceDetailPanel } from './ExperienceDetailPanel';
@@ -120,18 +121,15 @@ export function DiscoverPage() {
     setAddTarget({ regionId, regionName });
   }, []);
 
-  // Location hover from detail panel → map hover ring
-  const [hoveredLocationCoords, setHoveredLocationCoords] = useState<{ lng: number; lat: number } | null>(null);
-  const handleHoverLocation = useCallback((coords: { lng: number; lat: number } | null) => {
-    setHoveredLocationCoords(coords);
-  }, []);
-
-  // Highlight dot hover on map → location list auto-scroll
-  const [hoveredLocationId, setHoveredLocationId] = useState<number | null>(null);
-
   const detailOpen = selectedExperienceId !== null && selectedExperience !== null;
 
+  // The hover store serves this whole page: the map and list (the view), and
+  // the detail panel's location list — a panel-row hover rings the place on the
+  // map, and a highlight-dot hover scrolls the panel, both through the store
+  // rather than through state here, which re-rendered all three panels per
+  // pointer move (#573).
   return (
+    <HoverProvider>
     <Box sx={{ display: 'flex', flex: 1, minHeight: 0, overflow: 'hidden' }}>
       {/* ── Left Panel: Tree Navigation ── */}
       <Box
@@ -271,8 +269,6 @@ export function DiscoverPage() {
           selectedExperienceId={selectedExperienceId}
           selectedExperienceLocations={selectedExperienceLocations}
           selectedLocationsResolved={selectedLocationsResolved}
-          externalHoverCoords={hoveredLocationCoords}
-          onHoverHighlightLocation={setHoveredLocationId}
         />
       </Box>
 
@@ -298,8 +294,6 @@ export function DiscoverPage() {
           <ExperienceDetailPanel
             experience={selectedExperience}
             onClose={() => setSelectedExperienceId(null)}
-            onHoverLocation={handleHoverLocation}
-            hoveredLocationId={hoveredLocationId}
             onCurate={isCurator ? () => setDetailCurationTarget(selectedExperience) : undefined}
           />
         )}
@@ -322,5 +316,6 @@ export function DiscoverPage() {
         />
       )}
     </Box>
+    </HoverProvider>
   );
 }

--- a/frontend/src/components/discover/ExperienceCard.tsx
+++ b/frontend/src/components/discover/ExperienceCard.tsx
@@ -3,7 +3,6 @@
  * Shows thumbnail, category, country, name, and visited status.
  */
 
-import { forwardRef } from 'react';
 import { Box, Typography, Chip, Checkbox, Tooltip, IconButton } from '@mui/material';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
@@ -68,234 +67,228 @@ interface ExperienceCardProps {
   onCurate?: () => void;
 }
 
-export const ExperienceCard = forwardRef<HTMLDivElement, ExperienceCardProps>(
-  function ExperienceCard(
-    {
-      experience,
-      isVisited,
-      isHovered = false,
-      isSelected = false,
-      onClick,
-      onMouseEnter,
-      onMouseLeave,
-      onVisitedToggle,
-      showCheckbox,
-      onCurate,
-    },
-    ref,
-  ) {
-    const isRejected = experience.is_rejected;
-    const imageUrl = extractImageUrl(experience.image_url);
-    const colors = CATEGORY_COLORS[experience.category || ''];
-    const catStyle = colors
-      ? { bg: colors.bg, text: colors.text, border: colors.primary }
-      : { bg: '#E0E7FF', text: '#4F46E5', border: '#6366F1' };
+export function ExperienceCard({
+  experience,
+  isVisited,
+  isHovered = false,
+  isSelected = false,
+  onClick,
+  onMouseEnter,
+  onMouseLeave,
+  onVisitedToggle,
+  showCheckbox,
+  onCurate,
+}: ExperienceCardProps) {
+  const isRejected = experience.is_rejected;
+  const imageUrl = extractImageUrl(experience.image_url);
+  const colors = CATEGORY_COLORS[experience.category || ''];
+  const catStyle = colors
+    ? { bg: colors.bg, text: colors.text, border: colors.primary }
+    : { bg: '#E0E7FF', text: '#4F46E5', border: '#6366F1' };
 
-    const cardStyle = computeCardSurfaceStyle({ isRejected, isVisited, isHovered, isSelected, catStyle });
-    const { bgcolor, borderLeftColor, cardOpacity, titleColor } = cardStyle;
+  const cardStyle = computeCardSurfaceStyle({ isRejected, isVisited, isHovered, isSelected, catStyle });
+  const { bgcolor, borderLeftColor, cardOpacity, titleColor } = cardStyle;
 
-    return (
+  return (
+    <Box
+      onClick={onClick}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      sx={{
+        display: 'flex',
+        gap: 1.5,
+        p: 1.25,
+        cursor: 'pointer',
+        bgcolor,
+        borderLeft: '3px solid',
+        borderLeftColor,
+        borderBottom: '1px solid',
+        borderBottomColor: 'divider',
+        transition: 'all 0.15s ease',
+        '&:hover': { bgcolor: 'action.hover' },
+        opacity: cardOpacity,
+      }}
+    >
+      {/* Thumbnail */}
       <Box
-        ref={ref}
-        onClick={onClick}
-        onMouseEnter={onMouseEnter}
-        onMouseLeave={onMouseLeave}
         sx={{
-          display: 'flex',
-          gap: 1.5,
-          p: 1.25,
-          cursor: 'pointer',
-          bgcolor,
-          borderLeft: '3px solid',
-          borderLeftColor,
-          borderBottom: '1px solid',
-          borderBottomColor: 'divider',
-          transition: 'all 0.15s ease',
-          '&:hover': { bgcolor: 'action.hover' },
-          opacity: cardOpacity,
+          width: 56,
+          height: 56,
+          flexShrink: 0,
+          borderRadius: 1,
+          overflow: 'hidden',
+          bgcolor: 'grey.100',
+          position: 'relative',
         }}
       >
-        {/* Thumbnail */}
-        <Box
-          sx={{
-            width: 56,
-            height: 56,
-            flexShrink: 0,
-            borderRadius: 1,
-            overflow: 'hidden',
-            bgcolor: 'grey.100',
-            position: 'relative',
-          }}
-        >
-          {imageUrl ? (
-            <Box
-              component="img"
-              src={toThumbnailUrl(imageUrl, 120)}
-              alt=""
-              loading="lazy"
-              sx={{
-                width: '100%',
-                height: '100%',
-                objectFit: 'cover',
-                filter: isVisited ? 'saturate(0.4)' : 'none',
-              }}
-              onError={(e) => {
-                (e.target as HTMLImageElement).style.display = 'none';
-              }}
-            />
-          ) : (
-            <Box
-              sx={{
-                width: '100%',
-                height: '100%',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                bgcolor: catStyle.bg,
-              }}
-            >
-              <Typography sx={{ fontSize: '0.55rem', color: catStyle.text }}>
-                {experience.category?.charAt(0).toUpperCase() || '?'}
-              </Typography>
-            </Box>
-          )}
-          {isVisited && (
-            <CheckCircleIcon
-              sx={{
-                position: 'absolute',
-                bottom: 1,
-                right: 1,
-                fontSize: 14,
-                color: VISITED_GREEN,
-                bgcolor: 'white',
-                borderRadius: '50%',
-              }}
-            />
-          )}
-        </Box>
+        {imageUrl ? (
+          <Box
+            component="img"
+            src={toThumbnailUrl(imageUrl, 120)}
+            alt=""
+            loading="lazy"
+            sx={{
+              width: '100%',
+              height: '100%',
+              objectFit: 'cover',
+              filter: isVisited ? 'saturate(0.4)' : 'none',
+            }}
+            onError={(e) => {
+              (e.target as HTMLImageElement).style.display = 'none';
+            }}
+          />
+        ) : (
+          <Box
+            sx={{
+              width: '100%',
+              height: '100%',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              bgcolor: catStyle.bg,
+            }}
+          >
+            <Typography sx={{ fontSize: '0.55rem', color: catStyle.text }}>
+              {experience.category?.charAt(0).toUpperCase() || '?'}
+            </Typography>
+          </Box>
+        )}
+        {isVisited && (
+          <CheckCircleIcon
+            sx={{
+              position: 'absolute',
+              bottom: 1,
+              right: 1,
+              fontSize: 14,
+              color: VISITED_GREEN,
+              bgcolor: 'white',
+              borderRadius: '50%',
+            }}
+          />
+        )}
+      </Box>
 
-        {/* Text content */}
-        <Box sx={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', justifyContent: 'center', gap: 0.25 }}>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minWidth: 0 }}>
-            <Typography
-              variant="body2"
-              noWrap
+      {/* Text content */}
+      <Box sx={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', justifyContent: 'center', gap: 0.25 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minWidth: 0 }}>
+          <Typography
+            variant="body2"
+            noWrap
+            sx={{
+              fontWeight: 600,
+              fontSize: '0.8rem',
+              lineHeight: 1.3,
+              textDecoration: (isRejected || isVisited) ? 'line-through' : 'none',
+              color: titleColor,
+            }}
+          >
+            {experience.name}
+          </Typography>
+          {experience.is_new && (
+            <Chip
+              label="New"
+              size="small"
+              color="success"
               sx={{
+                height: 16,
+                fontSize: '0.55rem',
+                fontWeight: 700,
+                '& .MuiChip-label': { px: 0.5 },
+                flexShrink: 0,
+              }}
+            />
+          )}
+          <LifecycleChip state={experience} />
+          {(experience.location_count ?? 0) > 1 && (
+            <Chip
+              icon={<PlaceIcon sx={{ fontSize: '0.6rem !important' }} />}
+              label={experience.location_count}
+              size="small"
+              sx={{
+                height: 16,
+                fontSize: '0.55rem',
                 fontWeight: 600,
-                fontSize: '0.8rem',
-                lineHeight: 1.3,
-                textDecoration: (isRejected || isVisited) ? 'line-through' : 'none',
-                color: titleColor,
+                '& .MuiChip-label': { px: 0.5 },
+                '& .MuiChip-icon': { ml: 0.25 },
+                flexShrink: 0,
               }}
-            >
-              {experience.name}
-            </Typography>
-            {experience.is_new && (
-              <Chip
-                label="New"
-                size="small"
-                color="success"
-                sx={{
-                  height: 16,
-                  fontSize: '0.55rem',
-                  fontWeight: 700,
-                  '& .MuiChip-label': { px: 0.5 },
-                  flexShrink: 0,
-                }}
-              />
-            )}
-            <LifecycleChip state={experience} />
-            {(experience.location_count ?? 0) > 1 && (
-              <Chip
-                icon={<PlaceIcon sx={{ fontSize: '0.6rem !important' }} />}
-                label={experience.location_count}
-                size="small"
-                sx={{
-                  height: 16,
-                  fontSize: '0.55rem',
-                  fontWeight: 600,
-                  '& .MuiChip-label': { px: 0.5 },
-                  '& .MuiChip-icon': { ml: 0.25 },
-                  flexShrink: 0,
-                }}
-              />
-            )}
-          </Box>
-          <Box sx={{ display: 'flex', gap: 0.5, alignItems: 'center' }}>
-            {isRejected && (
-              <Chip
-                icon={<BlockIcon sx={{ fontSize: '0.6rem !important' }} />}
-                label="Rejected"
-                size="small"
-                color="error"
-                variant="outlined"
-                sx={{
-                  height: 16,
-                  fontSize: '0.55rem',
-                  '& .MuiChip-label': { px: 0.5 },
-                  '& .MuiChip-icon': { ml: 0.25 },
-                }}
-              />
-            )}
-            {experience.category && (
-              <Chip
-                label={experience.category}
-                size="small"
-                sx={{
-                  bgcolor: catStyle.bg,
-                  color: catStyle.text,
-                  fontWeight: 600,
-                  fontSize: '0.55rem',
-                  height: 16,
-                  textTransform: 'capitalize',
-                  '& .MuiChip-label': { px: 0.5 },
-                }}
-              />
-            )}
-            {experience.in_danger && (
-              <Tooltip title="In Danger">
-                <WarningAmberIcon sx={{ fontSize: 12, color: 'error.main' }} />
-              </Tooltip>
-            )}
-          </Box>
-          {experience.country_names?.[0] && (
-            <Typography variant="caption" color="text.secondary" noWrap sx={{ fontSize: '0.7rem' }}>
-              {experience.country_names.length > 1
-                ? `${experience.country_names[0]} +${experience.country_names.length - 1}`
-                : experience.country_names[0]}
-            </Typography>
+            />
           )}
         </Box>
-
-        {/* Actions: checkbox + curate */}
-        <Box sx={{ display: 'flex', alignItems: 'center', flexShrink: 0, gap: 0.25 }}>
-          {onCurate && (
-            <Tooltip title="Curate">
-              <IconButton
-                size="small"
-                onClick={(e) => { e.stopPropagation(); onCurate(); }}
-                sx={{ p: 0.25, opacity: 0.5, '&:hover': { opacity: 1 } }}
-              >
-                <TuneIcon sx={{ fontSize: 16 }} />
-              </IconButton>
+        <Box sx={{ display: 'flex', gap: 0.5, alignItems: 'center' }}>
+          {isRejected && (
+            <Chip
+              icon={<BlockIcon sx={{ fontSize: '0.6rem !important' }} />}
+              label="Rejected"
+              size="small"
+              color="error"
+              variant="outlined"
+              sx={{
+                height: 16,
+                fontSize: '0.55rem',
+                '& .MuiChip-label': { px: 0.5 },
+                '& .MuiChip-icon': { ml: 0.25 },
+              }}
+            />
+          )}
+          {experience.category && (
+            <Chip
+              label={experience.category}
+              size="small"
+              sx={{
+                bgcolor: catStyle.bg,
+                color: catStyle.text,
+                fontWeight: 600,
+                fontSize: '0.55rem',
+                height: 16,
+                textTransform: 'capitalize',
+                '& .MuiChip-label': { px: 0.5 },
+              }}
+            />
+          )}
+          {experience.in_danger && (
+            <Tooltip title="In Danger">
+              <WarningAmberIcon sx={{ fontSize: 12, color: 'error.main' }} />
             </Tooltip>
           )}
-          {showCheckbox && (
-            <Checkbox
-              checked={isVisited}
-              size="small"
-              onClick={(e) => {
-                e.stopPropagation();
-                onVisitedToggle?.(e);
-              }}
-              sx={{
-                p: 0.25,
-                '&.Mui-checked': { color: '#22c55e' },
-              }}
-            />
-          )}
         </Box>
+        {experience.country_names?.[0] && (
+          <Typography variant="caption" color="text.secondary" noWrap sx={{ fontSize: '0.7rem' }}>
+            {experience.country_names.length > 1
+              ? `${experience.country_names[0]} +${experience.country_names.length - 1}`
+              : experience.country_names[0]}
+          </Typography>
+        )}
       </Box>
-    );
-  },
-);
+
+      {/* Actions: checkbox + curate */}
+      <Box sx={{ display: 'flex', alignItems: 'center', flexShrink: 0, gap: 0.25 }}>
+        {onCurate && (
+          <Tooltip title="Curate">
+            <IconButton
+              size="small"
+              onClick={(e) => { e.stopPropagation(); onCurate(); }}
+              sx={{ p: 0.25, opacity: 0.5, '&:hover': { opacity: 1 } }}
+            >
+              <TuneIcon sx={{ fontSize: 16 }} />
+            </IconButton>
+          </Tooltip>
+        )}
+        {showCheckbox && (
+          <Checkbox
+            checked={isVisited}
+            size="small"
+            onClick={(e) => {
+              e.stopPropagation();
+              onVisitedToggle?.(e);
+            }}
+            sx={{
+              p: 0.25,
+              '&.Mui-checked': { color: '#22c55e' },
+            }}
+          />
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/frontend/src/components/discover/ExperienceDetailPanel.tsx
+++ b/frontend/src/components/discover/ExperienceDetailPanel.tsx
@@ -45,6 +45,7 @@ import {
 } from '../../hooks/useVisitedExperiences';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { extractImageUrl, toThumbnailUrl } from '../../hooks/useExperienceContext';
+import { subscribeToHoverTarget, useHoverActions, useHoverSelector } from '../../hooks/useHoverContext';
 
 import { CATEGORY_COLORS, VISITED_GREEN } from '../../utils/categoryColors';
 import { EmptyState } from '../shared/EmptyState';
@@ -58,15 +59,11 @@ const CONTENTS_INITIAL_SHOW = 20;
 interface ExperienceDetailPanelProps {
   experience: Experience;
   onClose: () => void;
-  /** Called when hovering a location in the location list */
-  onHoverLocation?: (coords: { lng: number; lat: number } | null) => void;
-  /** Location ID hovered on the map (for auto-scroll in location list) */
-  hoveredLocationId?: number | null;
   /** Curator: opens curation dialog */
   onCurate?: () => void;
 }
 
-export function ExperienceDetailPanel({ experience, onClose, onHoverLocation, hoveredLocationId, onCurate }: ExperienceDetailPanelProps) {
+export function ExperienceDetailPanel({ experience, onClose, onCurate }: ExperienceDetailPanelProps) {
   const { isAuthenticated } = useAuth();
 
   // Fetch full details
@@ -275,6 +272,7 @@ export function ExperienceDetailPanel({ experience, onClose, onHoverLocation, ho
         {/* Locations section */}
         {isMultiLocation && (
           <LocationsSection
+            experienceId={experience.id}
             locations={displayLocations}
             totalCount={totalLocations}
             isAuthenticated={isAuthenticated}
@@ -282,8 +280,6 @@ export function ExperienceDetailPanel({ experience, onClose, onHoverLocation, ho
             onUnmarkLocation={unmarkLocationVisited}
             onMarkAll={() => markAllLocations({ experienceId: experience.id })}
             onUnmarkAll={() => unmarkAllLocations({ experienceId: experience.id })}
-            onHoverLocation={onHoverLocation}
-            hoveredLocationId={hoveredLocationId}
           />
         )}
 
@@ -358,20 +354,30 @@ export function ExperienceDetailPanel({ experience, onClose, onHoverLocation, ho
 // Locations Section (collapsible, searchable for large lists)
 // =============================================================================
 
+/** One place the object has, as a row in the section's location list. */
+interface PanelLocation {
+  id: number;
+  name: string | null;
+  ordinal: number | null;
+  longitude: number;
+  latitude: number;
+  isVisited: boolean;
+}
+
 interface LocationsSectionProps {
-  locations: { id: number; name: string | null; ordinal: number | null; longitude: number; latitude: number; isVisited: boolean }[];
+  /** Whose places these are — a row hover names the object and the place. */
+  experienceId: number;
+  locations: PanelLocation[];
   totalCount: number;
   isAuthenticated: boolean;
   onMarkLocation: (id: number) => void;
   onUnmarkLocation: (id: number) => void;
   onMarkAll: () => void;
   onUnmarkAll: () => void;
-  onHoverLocation?: (coords: { lng: number; lat: number } | null) => void;
-  /** Location ID hovered on the map — triggers auto-scroll + highlight */
-  hoveredLocationId?: number | null;
 }
 
 function LocationsSection({
+  experienceId,
   locations,
   totalCount,
   isAuthenticated,
@@ -379,13 +385,12 @@ function LocationsSection({
   onUnmarkLocation,
   onMarkAll,
   onUnmarkAll,
-  onHoverLocation,
-  hoveredLocationId,
 }: LocationsSectionProps) {
   const shouldCollapse = totalCount > LOCATIONS_COLLAPSE_THRESHOLD;
   const [expanded, setExpanded] = useState(!shouldCollapse);
   const [searchText, setSearchText] = useState('');
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const { store } = useHoverActions();
 
   const visitedCount = locations.filter((l) => l.isVisited).length;
 
@@ -402,16 +407,27 @@ function LocationsSection({
     overscan: 5,
   });
 
-  // Auto-scroll to hovered location (from map highlight dot hover)
-  useEffect(() => {
-    if (hoveredLocationId == null) return;
-    const idx = filteredLocations.findIndex(l => l.id === hoveredLocationId);
+  // Auto-scroll to hovered location (from map highlight dot hover) — from a
+  // subscription, so a pointer crossing the dots does not re-render this
+  // section per move; the hover used to arrive as page state, which did (#573).
+  // Only a hover from the map: a row hover can only have come from a row
+  // already on the page. Through refs, because the subscription is registered
+  // once and a hover is not the moment to re-register it because the rows or
+  // the fold changed.
+  const filteredRef = useRef(filteredLocations);
+  filteredRef.current = filteredLocations;
+  const expandedRef = useRef(expanded);
+  expandedRef.current = expanded;
+  useEffect(() => subscribeToHoverTarget(store, ({ hoveredLocationId, hoverSource }) => {
+    if (hoverSource !== 'marker' || hoveredLocationId == null) return;
+    const idx = filteredRef.current.findIndex(l => l.id === hoveredLocationId);
     if (idx >= 0) {
-      if (!expanded) setExpanded(true);
+      if (!expandedRef.current) setExpanded(true);
+      // Smooth stays: these rows are fixed-height estimates with no
+      // `measureElement`, which is the case TanStack supports it for.
       virtualizer.scrollToIndex(idx, { align: 'center', behavior: 'smooth' });
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- only respond to hover changes; depending on filteredLocations/expanded/virtualizer would re-scroll on unrelated re-renders
-  }, [hoveredLocationId]);
+  }), [store, virtualizer]);
 
   return (
     <Box sx={{ mb: 2 }}>
@@ -503,55 +519,17 @@ function LocationsSection({
             >
               {virtualizer.getVirtualItems().map((virtualRow) => {
                 const loc = filteredLocations[virtualRow.index];
-                const isHovered = hoveredLocationId === loc.id;
                 return (
-                  <Box
+                  <PanelLocationRow
                     key={loc.id}
-                    onMouseEnter={() => onHoverLocation?.({ lng: loc.longitude, lat: loc.latitude })}
-                    onMouseLeave={() => onHoverLocation?.(null)}
-                    sx={{
-                      position: 'absolute',
-                      top: 0,
-                      left: 0,
-                      width: '100%',
-                      height: `${virtualRow.size}px`,
-                      transform: `translateY(${virtualRow.start}px)`,
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: 0.5,
-                      px: 1,
-                      borderBottom: '1px solid',
-                      borderColor: 'divider',
-                      '&:hover': { bgcolor: 'action.hover' },
-                      cursor: 'default',
-                      ...(isHovered && {
-                        bgcolor: 'action.selected',
-                        borderLeft: '3px solid',
-                        borderLeftColor: '#f97316',
-                      }),
-                    }}
-                  >
-                    <LocationOnIcon fontSize="small" color={loc.isVisited ? 'success' : 'action'} sx={{ flexShrink: 0 }} />
-                    <Typography
-                      variant="body2"
-                      noWrap
-                      sx={{
-                        flex: 1,
-                        textDecoration: loc.isVisited ? 'line-through' : 'none',
-                        color: loc.isVisited ? 'text.secondary' : 'text.primary',
-                      }}
-                    >
-                      {locationLabel(loc)}
-                    </Typography>
-                    {isAuthenticated && (
-                      <Checkbox
-                        checked={loc.isVisited}
-                        size="small"
-                        onChange={() => loc.isVisited ? onUnmarkLocation(loc.id) : onMarkLocation(loc.id)}
-                        sx={{ p: 0.5, '&.Mui-checked': { color: '#22c55e' } }}
-                      />
-                    )}
-                  </Box>
+                    experienceId={experienceId}
+                    loc={loc}
+                    size={virtualRow.size}
+                    start={virtualRow.start}
+                    isAuthenticated={isAuthenticated}
+                    onMarkLocation={onMarkLocation}
+                    onUnmarkLocation={onUnmarkLocation}
+                  />
                 );
               })}
             </Box>
@@ -560,6 +538,86 @@ function LocationsSection({
           )}
         </Box>
       </Collapse>
+    </Box>
+  );
+}
+
+interface PanelLocationRowProps {
+  experienceId: number;
+  loc: PanelLocation;
+  size: number;
+  start: number;
+  isAuthenticated: boolean;
+  onMarkLocation: (id: number) => void;
+  onUnmarkLocation: (id: number) => void;
+}
+
+/**
+ * One place in the panel's location list, subscribed to its own "is the map
+ * pointing at me" boolean — a dot hover highlights this row and this row alone,
+ * where the id as page state re-rendered the whole page per pointer move. Its
+ * own hover writes the store, and the ring on the map is drawn from that by
+ * `useDiscoverHover`'s subscription, which holds the coordinates. Only a hover
+ * from the *map* highlights: the row's own pointer case is the `&:hover` CSS.
+ */
+function PanelLocationRow({
+  experienceId,
+  loc,
+  size,
+  start,
+  isAuthenticated,
+  onMarkLocation,
+  onUnmarkLocation,
+}: PanelLocationRowProps) {
+  const { setHoveredFromList } = useHoverActions();
+  const isHovered = useHoverSelector(
+    s => s.hoverSource === 'marker' && s.hoveredLocationId === loc.id);
+  return (
+    <Box
+      onMouseEnter={() => setHoveredFromList(experienceId, loc.id)}
+      onMouseLeave={() => setHoveredFromList(null, null)}
+      sx={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        width: '100%',
+        height: `${size}px`,
+        transform: `translateY(${start}px)`,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 0.5,
+        px: 1,
+        borderBottom: '1px solid',
+        borderColor: 'divider',
+        '&:hover': { bgcolor: 'action.hover' },
+        cursor: 'default',
+        ...(isHovered && {
+          bgcolor: 'action.selected',
+          borderLeft: '3px solid',
+          borderLeftColor: '#f97316',
+        }),
+      }}
+    >
+      <LocationOnIcon fontSize="small" color={loc.isVisited ? 'success' : 'action'} sx={{ flexShrink: 0 }} />
+      <Typography
+        variant="body2"
+        noWrap
+        sx={{
+          flex: 1,
+          textDecoration: loc.isVisited ? 'line-through' : 'none',
+          color: loc.isVisited ? 'text.secondary' : 'text.primary',
+        }}
+      >
+        {locationLabel(loc)}
+      </Typography>
+      {isAuthenticated && (
+        <Checkbox
+          checked={loc.isVisited}
+          size="small"
+          onChange={() => loc.isVisited ? onUnmarkLocation(loc.id) : onMarkLocation(loc.id)}
+          sx={{ p: 0.5, '&.Mui-checked': { color: '#22c55e' } }}
+        />
+      )}
     </Box>
   );
 }

--- a/frontend/src/components/discover/discoverListWindow.test.tsx
+++ b/frontend/src/components/discover/discoverListWindow.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * What windowing and the hover store must hold for Discover's card list.
+ *
+ * Two failures are being pinned. The unwindowed list mounted every card the
+ * response held — up to 683 `ExperienceCard`s, each with an image, a chip row
+ * and a control — so opening a large region froze the tab. And hover as state
+ * in the view re-rendered the map's owner and every card per pointer move;
+ * `hoverStore.test.tsx` states the invariant generically, this pins it on the
+ * surface: a hover re-renders the row it names and the row it left, and no
+ * other, while the list component itself renders no more for it.
+ *
+ * The card is mocked to a counter: what is being asserted is who re-renders,
+ * not what a card looks like — and the fast version and the slow one render
+ * identical output, which is exactly how the slow one went unnoticed.
+ */
+
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import { act, render, screen } from '@testing-library/react';
+import type { Experience } from '../../api/experiences';
+import { HoverProvider, useHoverActions } from '../../hooks/useHoverContext';
+import { DiscoverExperienceList, DiscoverExperienceRow } from './DiscoverExperienceList';
+
+// jsdom has no layout and no ResizeObserver, so without these the virtualiser
+// reads a 0-height scroll container (`offsetHeight`, via its `getRect`) and
+// mounts nothing — which would let every assertion below pass vacuously
+// against an empty list. A `li` is a row (84 px, the row estimate); anything
+// else is the 600 px scroll container.
+const realOffsetHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetHeight');
+const realOffsetWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetWidth');
+const realResizeObserver = globalThis.ResizeObserver;
+const realRequestAnimationFrame = globalThis.requestAnimationFrame;
+const realCancelAnimationFrame = globalThis.cancelAnimationFrame;
+beforeAll(() => {
+  Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+    configurable: true,
+    get(this: HTMLElement) { return this.tagName === 'LI' ? 84 : 600; },
+  });
+  Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+    configurable: true,
+    get() { return 400; },
+  });
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+  // Synchronous, so the virtualiser's scroll-verify chain (`scrollToIndex`
+  // re-checks the offset over up to ten animation frames) runs to completion
+  // inside the act() that triggered it. Left asynchronous, jsdom fires the
+  // leftover frames after the test has unmounted the list, where virtual-core
+  // dereferences its nulled `targetWindow` — an unhandled error that failed
+  // the CI run while every test in it passed, and raced too tightly to show
+  // locally.
+  globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => { cb(performance.now()); return 0; }) as typeof requestAnimationFrame;
+  globalThis.cancelAnimationFrame = (() => {}) as typeof cancelAnimationFrame;
+});
+afterAll(() => {
+  if (realOffsetHeight) Object.defineProperty(HTMLElement.prototype, 'offsetHeight', realOffsetHeight);
+  if (realOffsetWidth) Object.defineProperty(HTMLElement.prototype, 'offsetWidth', realOffsetWidth);
+  globalThis.ResizeObserver = realResizeObserver;
+  globalThis.requestAnimationFrame = realRequestAnimationFrame;
+  globalThis.cancelAnimationFrame = realCancelAnimationFrame;
+});
+
+vi.mock('../../hooks/useAuth', () => ({
+  useAuth: () => ({ user: undefined }),
+}));
+
+const cardRenders: Record<number, number> = {};
+
+vi.mock('./ExperienceCard', () => ({
+  ExperienceCard: ({ experience, isHovered }: { experience: Experience; isHovered?: boolean }) => {
+    cardRenders[experience.id] = (cardRenders[experience.id] ?? 0) + 1;
+    return <span data-testid={`card-${experience.id}`}>{isHovered ? 'on' : 'off'}</span>;
+  },
+}));
+
+const experienceOf = (id: number): Experience => ({
+  id,
+  name: `Experience ${id}`,
+  longitude: 0,
+  latitude: 0,
+} as Experience);
+
+let actions: ReturnType<typeof useHoverActions>;
+function GrabActions() {
+  actions = useHoverActions();
+  return null;
+}
+
+function renderList(count: number) {
+  for (const key of Object.keys(cardRenders)) delete cardRenders[Number(key)];
+  const experiences = Array.from({ length: count }, (_, i) => experienceOf(i + 1));
+  const noop = () => {};
+  return render(
+    <HoverProvider>
+      <GrabActions />
+      <DiscoverExperienceList
+        activeView={{ regionId: 1, regionName: 'Europe', categoryId: 1, categoryName: 'UNESCO World Heritage Sites' }}
+        experiences={experiences}
+        filteredExperiences={experiences}
+        isLoading={false}
+        search=""
+        setSearch={noop}
+        shortSourceName="UNESCO"
+        rejectedCount={0}
+        hasCuratorScope={false}
+        isAuthenticated={false}
+        visitedIds={new Set()}
+        selectedExperienceId={null}
+        onBack={noop}
+        onSelectExperience={noop}
+        onCardMouseEnter={noop}
+        onCardMouseLeave={noop}
+        onVisitedToggle={noop}
+        onCurate={noop}
+        onAdd={noop}
+      />
+    </HoverProvider>,
+  );
+}
+
+describe('the windowed Discover card list', () => {
+  it('mounts the window, not the region: 683 experiences, a handful of rows', () => {
+    // 683 is the largest region on the live database. Before windowing every
+    // one of them mounted; the window plus `overscan` is what may now.
+    const { container } = renderList(683);
+    const rows = container.querySelectorAll('li');
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows.length).toBeLessThanOrEqual(30);
+  });
+
+  it('memoises the row, so a hover elsewhere cannot re-render it', () => {
+    // The subscription makes a hover cheap; the memo is what keeps the list's
+    // own renders from reaching every mounted row's card. Unwrap it and every
+    // test here still passes while the hover reaches everything again — which
+    // is how the map-mode list regressed once (`hoverIsolation.test.tsx`).
+    const isMemo = (component: unknown) =>
+      (component as { $$typeof: symbol }).$$typeof === Symbol.for('react.memo');
+    expect(isMemo(DiscoverExperienceRow)).toBe(true);
+  });
+
+  it('re-renders only the row a marker hover names, and the row it leaves', () => {
+    renderList(20);
+    const first = screen.getByTestId('card-1');
+    expect(first.textContent).toBe('off');
+    const before = { ...cardRenders };
+
+    act(() => { actions.setHoveredFromMarker(1); });
+    expect(screen.getByTestId('card-1').textContent).toBe('on');
+    expect(cardRenders[1]).toBe(before[1] + 1);
+    expect(cardRenders[2]).toBe(before[2]);
+
+    // The pointer moves on: the row left and the row entered, and no other.
+    act(() => { actions.setHoveredFromMarker(2); });
+    expect(screen.getByTestId('card-1').textContent).toBe('off');
+    expect(screen.getByTestId('card-2').textContent).toBe('on');
+    expect(cardRenders[1]).toBe(before[1] + 2);
+    expect(cardRenders[2]).toBe(before[2] + 1);
+    expect(cardRenders[3]).toBe(before[3]);
+  });
+});

--- a/frontend/src/components/discover/useDiscoverHover.test.tsx
+++ b/frontend/src/components/discover/useDiscoverHover.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * The dot→pin hand-over, which one store made breakable.
+ *
+ * The selected object's highlight dots overlap other objects' pins in pixels,
+ * and MapLibre delivers one mouse move to the pin's `mousemove` first and the
+ * dot's `mouseleave` after (`useDiscoverMap`'s registration order). Before the
+ * store, the dot's leave only cleared a *location* id that lived apart from the
+ * marker hover; unified, an unconditional clear wiped the pin hover the same
+ * gesture had just set — and the marker handler's dedupe key kept it from ever
+ * being re-set while the pointer stayed on the pin. The guard under test:
+ * a dot's leave clears only a hover that still names a place, because a dot's
+ * own hover always does and a pin's never does.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import maplibregl from 'maplibre-gl';
+import { HoverProvider, useHoverActions } from '../../hooks/useHoverContext';
+import { useDiscoverHover } from './useDiscoverHover';
+
+let actions: ReturnType<typeof useHoverActions>;
+function GrabActions() {
+  actions = useHoverActions();
+  return null;
+}
+
+function renderDiscoverHover() {
+  const wiring = {
+    // No map: every ring path declines to act without one, which is exactly
+    // what lets the store logic be tested on its own.
+    mapRef: { current: null as maplibregl.Map | null },
+    experiences: [],
+    drawnCoordsRef: { current: () => [] as [number, number][] },
+    selectedExpIdRef: { current: 5 as number | null },
+    selectedLocsRef: { current: null },
+  };
+  return renderHook(() => useDiscoverHover(wiring), {
+    wrapper: ({ children }: { children: ReactNode }) => (
+      <HoverProvider><GrabActions />{children}</HoverProvider>
+    ),
+  });
+}
+
+describe("useDiscoverHover's highlight-dot callback", () => {
+  it('names the selected object and the place on a dot hover, and clears its own hover on leave', () => {
+    const { result } = renderDiscoverHover();
+
+    act(() => { result.current.highlightHoverCallbackRef.current(42); });
+    expect(actions.store.getState()).toMatchObject({
+      hoveredExperienceId: 5, hoveredLocationId: 42, hoverSource: 'marker',
+    });
+
+    // Leaving the dot to empty map: the hover still names the dot's place,
+    // so it is the dot's to take down.
+    act(() => { result.current.highlightHoverCallbackRef.current(null); });
+    expect(actions.store.getState().hoveredExperienceId).toBeNull();
+  });
+
+  it('does not wipe a pin hover the same mouse move has already set', () => {
+    const { result } = renderDiscoverHover();
+
+    // The pointer crosses from a dot onto another object's pin: the pin's
+    // mousemove runs first and names its object, with no place …
+    act(() => { actions.setHoveredFromMarker(10); });
+    // … and the dot's leave runs after, in the same DOM move.
+    act(() => { result.current.highlightHoverCallbackRef.current(null); });
+
+    // The hover belongs to the pin now; clearing it here would also stick,
+    // because the marker handler's dedupe key already holds this pin.
+    expect(actions.store.getState()).toMatchObject({
+      hoveredExperienceId: 10, hoverSource: 'marker',
+    });
+  });
+});

--- a/frontend/src/components/discover/useDiscoverHover.ts
+++ b/frontend/src/components/discover/useDiscoverHover.ts
@@ -5,9 +5,10 @@
  * `docs/tech/development-guide.md`. It is not a slice of that component's state
  * so much as the join between its two halves: a row hovered rings every point
  * the object is drawn at, and a marker hovered scrolls the row into view and
- * shows its picture. Both directions share one source of truth — which surface
- * the hover came from — so they cannot live apart without that flag becoming
- * two.
+ * shows its picture. Both directions share one source of truth — the shared
+ * hover store's `hoverSource` (#573) — so they cannot live apart without that
+ * flag becoming two. This hook writes the store and draws the rings; what a
+ * hover changes on screen is read from the store where it is drawn.
  *
  * The rules it carries were each a defect once: a ring covers *every* pin of an
  * object rather than the first (a serial site is its parts); the places inside
@@ -17,13 +18,13 @@
  * because `getClusterLeaves` resolves after the pointer has moved on.
  */
 
-import { useState, useRef, useEffect, useCallback } from 'react';
+import { useRef, useEffect, useCallback } from 'react';
 import maplibregl from 'maplibre-gl';
 import type { Experience } from '../../api/experiences';
 import { extractImageUrl, toThumbnailUrl } from '../../hooks/useExperienceContext';
+import { subscribeToHoverTarget, useHoverActions, type HoverPreview } from '../../hooks/useHoverContext';
 import { clusterRadiusFor, SOURCE_ID, HOVER_SOURCE_ID } from './discoverMapLayers';
 import { pointInView } from '../../utils/viewBounds';
-import type { ImageCredit } from '../../api/experiences';
 
 /**
  * Rings for the places of an object that the map is currently drawing as pins.
@@ -76,25 +77,36 @@ export interface DiscoverHoverWiring {
   drawnCoordsRef: React.MutableRefObject<(expId: number) => [number, number][]>;
   /** The current selection, which the marker source deliberately does not hold. */
   selectedExpIdRef: React.MutableRefObject<number | null>;
-  /** A hover from the detail panel's location list, which rings one place. */
-  externalHoverCoords?: { lng: number; lat: number } | null;
-  /** Reported back when a highlight dot is hovered, so the panel can follow. */
-  onHoverHighlightLocation?: (locationId: number | null) => void;
+  /**
+   * The selected object's places, for the ring a panel-row hover asks for: the
+   * row names a location id, and these are the only coordinates it has here.
+   */
+  selectedLocsRef: React.MutableRefObject<{ id?: number; lng: number; lat: number }[] | null>;
 }
 
-/** What the view renders with, and what it hands the map's own listeners. */
+/** What the view hands the map's own listeners. */
 export interface DiscoverHover {
-  hoveredExperienceId: number | null;
-  hoverPreview: {
-    name: string; imageUrl: string | null; categoryName: string;
-    imageCredit: ImageCredit | null;
-  } | null;
-  cardRefsMap: React.MutableRefObject<Map<number, HTMLDivElement>>;
-  listContainerRef: React.RefObject<HTMLDivElement | null>;
   mapHoverCallbackRef: React.MutableRefObject<(id: number | null) => void>;
   highlightHoverCallbackRef: React.MutableRefObject<(locationId: number | null) => void>;
   onCardMouseEnter: (expId: number) => void;
   onCardMouseLeave: () => void;
+}
+
+/** The preview the overlay card shows for a hovered marker. */
+function previewOf(exp: Experience): HoverPreview {
+  const rawImg = extractImageUrl(exp.image_url);
+  return {
+    experienceId: exp.id,
+    experienceName: exp.name,
+    locationId: null,
+    locationName: null,
+    categoryName: exp.category_name || '',
+    category: exp.category ?? null,
+    imageUrl: rawImg ? toThumbnailUrl(rawImg, 250) : null,
+    imageCredit: exp.image_credit ?? null,
+    longitude: exp.longitude,
+    latitude: exp.latitude,
+  };
 }
 
 export function useDiscoverHover({
@@ -102,101 +114,96 @@ export function useDiscoverHover({
   experiences,
   drawnCoordsRef,
   selectedExpIdRef,
-  externalHoverCoords,
-  onHoverHighlightLocation,
+  selectedLocsRef,
 }: DiscoverHoverWiring): DiscoverHover {
-  // ── Hover sync state ──
-  const [hoveredExperienceId, setHoveredExperienceId] = useState<number | null>(null);
-  const [hoverPreview, setHoverPreview] = useState<{
-    name: string; imageUrl: string | null; categoryName: string;
-    /** Whose photograph it is: this overlay shows one, so it has to say. */
-    imageCredit: ImageCredit | null;
-  } | null>(null);
-  const hoverSourceRef = useRef<'list' | 'map' | null>(null);
-  const isAutoScrollingRef = useRef(false);
-  const cardRefsMap = useRef<Map<number, HTMLDivElement>>(new Map());
-  const listContainerRef = useRef<HTMLDivElement>(null);
+  // Hover lives in the shared store, not in state here: as `useState` in this
+  // hook, every pointer move over a marker or a card re-rendered the view that
+  // owns the map and every card in the list — the cost the store exists to
+  // remove (#573). This hook only *writes* it; what a hover changes is read
+  // where it is drawn (`DiscoverExperienceRow`, `DiscoverHoverCard`) and
+  // reacted to in subscriptions where it moves something (the list's scroll
+  // anchor, the panel's location list, the ring below).
+  const { store, setHoveredFromMarker, setHoveredFromList, setHoverPreview } = useHoverActions();
   /** Which card-hover fan-out is current, so a late cluster answer stands down. */
   const hoverGenerationRef = useRef(0);
   const experiencesRef = useRef(experiences);
   experiencesRef.current = experiences;
 
-  // Map hover → React state. A ref because the map's listeners are registered
+  // Map hover → the store. A ref because the map's listeners are registered
   // once, on mount, by `useDiscoverMap` — they must see this render's callback.
   const mapHoverCallbackRef = useRef<(id: number | null) => void>(() => {});
   mapHoverCallbackRef.current = (id: number | null) => {
-    hoverSourceRef.current = id != null ? 'map' : null;
-    setHoveredExperienceId(id);
+    setHoveredFromMarker(id);
     if (id != null) {
       const exp = experiencesRef.current.find(e => e.id === id);
-      if (exp) {
-        const rawImg = extractImageUrl(exp.image_url);
-        setHoverPreview({
-          name: exp.name,
-          imageUrl: rawImg ? toThumbnailUrl(rawImg, 250) : null,
-          categoryName: exp.category_name || '',
-          imageCredit: exp.image_credit ?? null,
-        });
-      }
-    } else {
-      setHoverPreview(null);
+      if (exp) setHoverPreview(previewOf(exp));
     }
+    // Leaving needs no explicit preview clear: the store drops the preview with
+    // the hover, exactly as the map-mode marker path relies on.
   };
 
-  // Hover on a highlight dot → the panel's location list, the same way round.
+  // Hover on a highlight dot → the store, with the place named so the panel's
+  // location list can highlight and scroll to its row. The dots belong to the
+  // selected object, which is the experience the hover therefore names.
   const highlightHoverCallbackRef = useRef<(locationId: number | null) => void>(() => {});
   highlightHoverCallbackRef.current = (locationId: number | null) => {
-    onHoverHighlightLocation?.(locationId);
+    if (locationId == null) {
+      // Only clear a hover this dot still owns. The dots overlap other
+      // objects' pins in pixels, and the pin's `mousemove` is registered ahead
+      // of the dot's `mouseleave` (`useDiscoverMap`) — so by the time the
+      // leave runs, the same mouse move may already have named the pin's
+      // object, with no place. Clearing then would wipe that hover in the
+      // gesture that set it, and the marker handler's dedupe key would keep it
+      // from being re-set while the pointer stays on the pin. A dot's own
+      // hover always names a place, which is what the guard reads.
+      const { hoverSource, hoveredLocationId } = store.getState();
+      if (hoverSource !== 'marker' || hoveredLocationId == null) return;
+      setHoveredFromMarker(null, null);
+      return;
+    }
+    setHoveredFromMarker(selectedExpIdRef.current, locationId);
   };
 
-  // ── Map hover → auto-scroll list ──
-  useEffect(() => {
-    if (hoverSourceRef.current !== 'map' || hoveredExperienceId == null) return;
-    const card = cardRefsMap.current.get(hoveredExperienceId);
-    if (card && listContainerRef.current) {
-      isAutoScrollingRef.current = true;
-      card.scrollIntoView({ behavior: 'smooth', block: 'center' });
-      // Clear auto-scroll flag after animation
-      const timer = setTimeout(() => { isAutoScrollingRef.current = false; }, 500);
-      return () => clearTimeout(timer);
-    }
-  }, [hoveredExperienceId]);
-
-  // ── External hover (from detail panel location list) → update map hover ring ──
-  useEffect(() => {
-    // This hook is called before `useDiscoverMap` — it hands that one the two
-    // callback refs above — so on the first commit this effect runs before the
-    // map is built, where it used to run after. It makes no difference: the map's
-    // sources are added on `load`, so this asked for a source that did not exist
-    // yet either way, and both paths out of that are this early return.
+  // ── Panel location-row hover → one ring on that place ──
+  //
+  // The panel names a place by hovering its row (`setHoveredFromList` with a
+  // location id); the coordinates live here, in the selected object's fetch, so
+  // the ring is drawn from a subscription rather than by the panel. Only the
+  // location case: a plain card hover draws its own rings in the handler below,
+  // in the same gesture, and the map's own hovers keep their imperative writes.
+  useEffect(() => subscribeToHoverTarget(store, ({ hoveredExperienceId, hoveredLocationId, hoverSource }) => {
     const map = mapRef.current;
     if (!map) return;
-    const hoverSource = map.getSource(HOVER_SOURCE_ID) as maplibregl.GeoJSONSource | undefined;
-    if (!hoverSource) return;
+    const hoverSource_ = map.getSource(HOVER_SOURCE_ID) as maplibregl.GeoJSONSource | undefined;
+    if (!hoverSource_) return;
 
-    if (externalHoverCoords) {
-      hoverSource.setData({
-        type: 'FeatureCollection',
-        features: [{
-          type: 'Feature',
-          geometry: { type: 'Point', coordinates: [externalHoverCoords.lng, externalHoverCoords.lat] },
-          properties: {},
-        }],
-      });
-    } else if (hoverSourceRef.current !== 'list' && hoverSourceRef.current !== 'map') {
-      // Only clear if no internal hover is active
-      hoverSource.setData({ type: 'FeatureCollection', features: [] });
+    if (hoverSource === 'list' && hoveredLocationId != null) {
+      const loc = selectedLocsRef.current?.find(l => l.id === hoveredLocationId);
+      if (loc) {
+        hoverSource_.setData({
+          type: 'FeatureCollection',
+          features: [{
+            type: 'Feature',
+            geometry: { type: 'Point', coordinates: [loc.lng, loc.lat] },
+            properties: {},
+          }],
+        });
+      }
+    } else if (hoveredExperienceId == null) {
+      // Nothing hovered anywhere: the ring comes down. Idempotent beside the
+      // imperative clears in the leave handlers, and what takes the ring down
+      // after the pointer leaves the panel's rows.
+      hoverSource_.setData({ type: 'FeatureCollection', features: [] });
     }
-    // The refs below are arguments now rather than locals, so the exhaustive-deps
-    // rule cannot tell they are stable — they are listed to keep it quiet, and a
-    // ref object never changes identity, so nothing re-runs because of them.
-  }, [externalHoverCoords, mapRef]);
+    // `mapRef`/`selectedLocsRef` are refs — stable identities, listed only for
+    // the exhaustive-deps rule.
+  }), [store, mapRef, selectedLocsRef]);
 
   // ── List hover → update map hover ring (cluster-aware) ──
   const handleCardMouseEnter = useCallback((expId: number) => {
-    if (hoverSourceRef.current === 'map' || isAutoScrollingRef.current) return;
-    hoverSourceRef.current = 'list';
-    setHoveredExperienceId(expId);
+    // A marker hover owns the gesture: it is what scrolled the list here.
+    if (store.getState().hoverSource === 'marker') return;
+    setHoveredFromList(expId);
 
     const map = mapRef.current;
     if (!map) return;
@@ -316,13 +323,12 @@ export function useDiscoverHover({
           }
         });
     }
-  }, [mapRef, drawnCoordsRef, selectedExpIdRef]);
+  }, [mapRef, drawnCoordsRef, selectedExpIdRef, store, setHoveredFromList]);
 
   const handleCardMouseLeave = useCallback(() => {
-    if (hoverSourceRef.current !== 'list') return;
+    if (store.getState().hoverSource !== 'list') return;
     hoverGenerationRef.current++;
-    hoverSourceRef.current = null;
-    setHoveredExperienceId(null);
+    setHoveredFromList(null);
 
     const map = mapRef.current;
     if (!map) return;
@@ -330,13 +336,9 @@ export function useDiscoverHover({
     if (hoverSource) {
       hoverSource.setData({ type: 'FeatureCollection', features: [] });
     }
-  }, [mapRef]);
+  }, [mapRef, store, setHoveredFromList]);
 
   return {
-    hoveredExperienceId,
-    hoverPreview,
-    cardRefsMap,
-    listContainerRef,
     mapHoverCallbackRef,
     highlightHoverCallbackRef,
     onCardMouseEnter: handleCardMouseEnter,

--- a/frontend/src/components/discover/useDiscoverMap.ts
+++ b/frontend/src/components/discover/useDiscoverMap.ts
@@ -256,14 +256,27 @@ export function useDiscoverMap({
         // `mousemove` dedupes on a dot that has not changed, so leaving the ring
         // as it is would leave it on the pin the pointer has just left.
         const dot = fromAMove ? highlightDotAt(e.point) : null;
-        if (dot) {
-          // The ring, and not the dot's key: `mapCurrentHighlightLocId` is what
-          // the dot's own `mousemove` dedupes on, and that delegate is
-          // registered after this leave, so it runs later in the same move.
-          // Writing the key here would leave the hand-over half done — ring on
-          // the dot, and the panel never told which place it is, because the
-          // move that would have said so found nothing to do.
+        // Only a dot that names a place can hold the hand-over: the fold dot
+        // is the one highlight feature with `locationId: null`, and the
+        // `mousemove` that would re-announce below is gated on the id — a ring
+        // handed to it would be wiped by the store clear and never redrawn,
+        // flashing once per crossing. For it the ring simply comes down, as it
+        // does over empty map.
+        const dotLocId = dot?.properties?.locationId as number | null | undefined;
+        if (dot && dotLocId != null) {
           setHoverRing(pointOf(dot));
+          // And *release* the dot's dedupe key — never write the dot's id into
+          // it: `mapCurrentHighlightLocId` is what the dot's own `mousemove`
+          // dedupes on, and that delegate is registered after this leave, so it
+          // runs next in this same move. With the key released it re-announces
+          // the place, which is what restores the store the clear below empties
+          // — and with it the ring (the store's clear branch wipes the one set
+          // above) and the panel row's highlight (#573). The key could stay
+          // untouched only while ring and panel state lived apart from the
+          // marker hover and survived that clear on their own; writing the
+          // dot's id instead would leave the hand-over half done, with the
+          // re-announcing move finding nothing to do.
+          mapCurrentHighlightLocId = null;
         } else {
           if (!fromAMove || !onACluster(e.point)) map.getCanvas().style.cursor = '';
           setHoverRing(null);
@@ -319,16 +332,25 @@ export function useDiscoverMap({
         const fromAMove = e.originalEvent?.type === 'mousemove';
         const pin = fromAMove ? markerAt(e.point) : null;
         if (pin) {
-          // The ring, and not the pin's key, for the reason the mirror above
-          // gives: `mapCurrentHoveredKey` belongs to the marker `mousemove`,
-          // which is registered ahead of this leave and has already set it in
-          // this same move. Writing it here is dead today and the same trap
-          // tomorrow, the moment those registrations change order.
           setHoverRing(pointOf(pin));
-        } else {
-          if (!fromAMove || !onACluster(e.point)) map.getCanvas().style.cursor = '';
-          setHoverRing(null);
+          // …and say so, because the marker `mousemove` will not: it is
+          // registered ahead of this leave, and when the pointer was on this
+          // pin *before* it touched the dot, it deduped on a key it still
+          // holds — nothing re-announced the pin in this move. Reporting the
+          // dot's end instead would clear the store (the standing hover
+          // genuinely is the dot's, so the callback's own guard cannot help),
+          // taking the ring above, the card highlight and the preview card
+          // with it, and the marker dedupe would keep every later move over
+          // the pin from putting them back (#573). For a pin entered in this
+          // same move the announcement is a duplicate the store's equality
+          // check absorbs. The hover is the pin's now, so there is nothing of
+          // the dot's left to clear — hence no `highlightHoverCallbackRef`.
+          mapCurrentHoveredKey = keyOf(pin);
+          mapHoverCallbackRef.current?.(pin.properties?.id as number);
+          return;
         }
+        if (!fromAMove || !onACluster(e.point)) map.getCanvas().style.cursor = '';
+        setHoverRing(null);
 
         highlightHoverCallbackRef.current?.(null);
       });

--- a/frontend/src/components/regionMap/HoveredRegionTooltip.tsx
+++ b/frontend/src/components/regionMap/HoveredRegionTooltip.tsx
@@ -1,0 +1,94 @@
+/**
+ * Names the region under the pointer, over the map.
+ *
+ * Its own component and its own subscriber to the region hover store, the same
+ * shape as `HoverPreviewCard`: the hovered id changes on every mouse move, and
+ * when `RegionMapVT` read it to render this inline, each move re-rendered the
+ * map — every source and layer react-map-gl holds (#573). Here a move
+ * re-renders one small box.
+ *
+ * The name resolution moved with it from `useMapInteractions`: metadata first,
+ * then the loaded tiles — `metadataById` only holds the current level's
+ * children, so an ancestor or sibling from a context layer is answered by
+ * querying the tile features it was drawn from.
+ */
+
+import { useMemo } from 'react';
+import { Box, Typography } from '@mui/material';
+import type { MapRef } from 'react-map-gl/maplibre';
+import { useRegionHoverSelector } from '../../hooks/useRegionHover';
+
+const REGIONS_SOURCE_LAYER = 'regions';
+
+interface HoveredRegionTooltipProps {
+  mapRef: React.RefObject<MapRef | null>;
+  metadataById: Record<number, { name: string }>;
+  sourceLayerName: string;
+  contextLayerCount: number;
+}
+
+export function HoveredRegionTooltip({
+  mapRef,
+  metadataById,
+  sourceLayerName,
+  contextLayerCount,
+}: HoveredRegionTooltipProps) {
+  const hoveredRegionId = useRegionHoverSelector(id => id);
+
+  // Get hovered region name from metadata, falling back to tile feature
+  // properties (for siblings not in current-level metadata)
+  const hoveredRegionName = useMemo(() => {
+    if (!hoveredRegionId) return null;
+    if (metadataById[hoveredRegionId]?.name) return metadataById[hoveredRegionId].name;
+    // Fall back: query tile features for the name
+    if (mapRef.current) {
+      const map = mapRef.current.getMap();
+      // Check context sources, main source, and root overlay
+      const sourceIds = [
+        ...Array.from({ length: contextLayerCount }, (_, i) => `context-${i}-vt`),
+        'regions-vt',
+        'root-regions-vt',
+      ];
+      for (const sourceId of sourceIds) {
+        if (!map.getSource(sourceId)) continue;
+        const sourceLayer = sourceId === 'regions-vt' ? sourceLayerName : REGIONS_SOURCE_LAYER;
+        // Filter by promoted feature ID to avoid scanning all loaded tile features
+        const features = map.querySourceFeatures(sourceId, {
+          sourceLayer,
+          filter: ['==', ['id'], hoveredRegionId],
+        });
+        if (features.length > 0 && features[0].properties?.name) {
+          return features[0].properties.name as string;
+        }
+      }
+    }
+    return null;
+  }, [hoveredRegionId, metadataById, mapRef, sourceLayerName, contextLayerCount]);
+
+  if (!hoveredRegionId || !hoveredRegionName) return null;
+
+  return (
+    <Box
+      sx={{
+        position: 'absolute',
+        bottom: 16,
+        left: 16,
+        backgroundColor: 'rgba(255,255,255,0.98)',
+        backdropFilter: 'blur(8px)',
+        p: 1.5,
+        px: 2,
+        borderRadius: 2,
+        maxWidth: 300,
+        boxShadow: '0 4px 12px rgba(0,0,0,0.08)',
+        border: '1px solid rgba(0,0,0,0.06)',
+      }}
+    >
+      <Typography variant="subtitle2" sx={{ fontWeight: 500 }}>
+        {hoveredRegionName}
+      </Typography>
+      <Typography variant="caption" color="text.secondary">
+        Click to explore
+      </Typography>
+    </Box>
+  );
+}

--- a/frontend/src/components/regionMap/useMapFeatureState.test.ts
+++ b/frontend/src/components/regionMap/useMapFeatureState.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
 import type { MapRef } from 'react-map-gl/maplibre';
 
 import { useMapFeatureState } from './useMapFeatureState';
+import { RegionHoverProvider, useRegionHoverActions } from '../../hooks/useRegionHover';
 
 /**
  * The blocking overlay is raised on every tile URL change and lowered only by an
@@ -38,25 +40,40 @@ function makeMap() {
   return { map, emit, handlers };
 }
 
+/** The store's setter, for the hover tests below; null between renders. */
+let hoverActions: ReturnType<typeof useRegionHoverActions> | null = null;
+function GrabHoverActions() {
+  hoverActions = useRegionHoverActions();
+  return null;
+}
+
 function renderState(
   map: ReturnType<typeof makeMap>['map'],
   mapLoaded = true,
   tileUrl: string | null = 'http://martin.test/tiles/{z}/{x}/{y}',
 ) {
+  hoverActions = null;
   const mapRef = { current: { getMap: () => map } as unknown as MapRef };
-  return renderHook(() =>
-    useMapFeatureState({
-      mapRef: mapRef as React.RefObject<MapRef | null>,
-      mapLoaded,
-      isCustomWorldView: true,
-      isExploring: false,
-      visitedRegionIds: undefined,
-      hoveredRegionId: null,
-      sourceLayerName: 'regions',
-      tileUrl,
-      viewingRegionId: 'all-leaf',
-      contextLayerCount: 0,
-    }),
+  return renderHook(
+    ({ url }: { url: string | null }) =>
+      useMapFeatureState({
+        mapRef: mapRef as React.RefObject<MapRef | null>,
+        mapLoaded,
+        isCustomWorldView: true,
+        isExploring: false,
+        visitedRegionIds: undefined,
+        sourceLayerName: 'regions',
+        tileUrl: url,
+        viewingRegionId: 'all-leaf',
+        contextLayerCount: 0,
+      }),
+    {
+      initialProps: { url: tileUrl },
+      // The hover arrives from the region hover store's subscription now, so
+      // the hook needs the provider even where a test never hovers anything.
+      wrapper: ({ children }: { children: ReactNode }) =>
+        createElement(RegionHoverProvider, null, createElement(GrabHoverActions), children),
+    },
   );
 }
 
@@ -146,5 +163,53 @@ describe('useMapFeatureState tile readiness', () => {
 
     expect(result.current.tilesReady).toBe(true);
     expect(result.current.tilesStalled).toBe(false);
+  });
+});
+
+/**
+ * The hover half: painted from a store subscription now, which has no retry of
+ * its own — the pre-store effect re-ran on every pointer move, so a source that
+ * appeared late or was replaced was healed by the next hover. These pin the two
+ * substitutes for that retry: the per-event source check, and the re-subscribe
+ * on `tileUrl` whose call-once repaints the hover that was already standing.
+ */
+describe('useMapFeatureState hover painting', () => {
+  it('paints a hover that arrived before the source, once the source lands', () => {
+    const { map, emit } = makeMap();
+    renderState(map);
+
+    // Sources are added by react-map-gl after `load`: at subscribe time there
+    // is nothing to paint on, and that must not end the story — the pointer
+    // has not moved, so no later hover event will carry this id.
+    act(() => { hoverActions!.setHoveredRegionId(7); });
+    expect(map.setFeatureState).not.toHaveBeenCalled();
+
+    map.getSource.mockReturnValue({} as never);
+    act(() => { emit('sourcedata', { sourceId: 'regions-vt', isSourceLoaded: true }); });
+    expect(map.setFeatureState).toHaveBeenCalledWith(
+      { source: 'regions-vt', sourceLayer: 'regions', id: 7 },
+      { hovered: true },
+    );
+  });
+
+  it('repaints the standing hover when the tile source is replaced', () => {
+    const { map } = makeMap();
+    map.getSource.mockReturnValue({} as never);
+    const { rerender } = renderState(map);
+
+    act(() => { hoverActions!.setHoveredRegionId(42); });
+    expect(map.setFeatureState).toHaveBeenCalledWith(
+      { source: 'regions-vt', sourceLayer: 'regions', id: 42 },
+      { hovered: true },
+    );
+
+    // Replacing the source wipes its feature state; the pointer has not moved,
+    // so only the re-subscription's call-once can put the hover back.
+    map.setFeatureState.mockClear();
+    rerender({ url: 'http://martin.test/v2/{z}/{x}/{y}' });
+    expect(map.setFeatureState).toHaveBeenCalledWith(
+      { source: 'regions-vt', sourceLayer: 'regions', id: 42 },
+      { hovered: true },
+    );
   });
 });

--- a/frontend/src/components/regionMap/useMapFeatureState.ts
+++ b/frontend/src/components/regionMap/useMapFeatureState.ts
@@ -5,6 +5,7 @@
 import { useEffect, useRef, useState } from 'react';
 import type { MapRef } from 'react-map-gl/maplibre';
 import type { Map as MapLibreMap, MapSourceDataEvent } from 'maplibre-gl';
+import { subscribeToRegionHover, useRegionHoverActions } from '../../hooks/useRegionHover';
 
 const REGIONS_SOURCE_LAYER = 'regions';
 
@@ -71,7 +72,6 @@ interface UseMapFeatureStateOptions {
   isCustomWorldView: boolean;
   isExploring: boolean;
   visitedRegionIds: Set<number> | undefined;
-  hoveredRegionId: number | null;
   sourceLayerName: string;
   tileUrl: string | null;
   viewingRegionId: 'all-leaf' | number;
@@ -84,7 +84,6 @@ export function useMapFeatureState({
   isCustomWorldView,
   isExploring,
   visitedRegionIds,
-  hoveredRegionId,
   sourceLayerName,
   tileUrl,
   viewingRegionId,
@@ -251,31 +250,71 @@ export function useMapFeatureState({
     return stopWaiting;
   }, [mapLoaded, tileUrl, mapRef]);
 
-  // Apply hover state to features using setFeatureState
+  // Apply hover state to features using setFeatureState — from a subscription,
+  // not a render: the hovered id changes on every mouse move over the map, and
+  // as a prop of this hook it re-rendered the component that *is* the map's
+  // sources and layers for each one (#573). Answering it here costs two
+  // `setFeatureState` calls and no render at all.
   const prevHoveredIdRef = useRef<number | null>(null);
+  const { store: regionHoverStore } = useRegionHoverActions();
 
   useEffect(() => {
     if (!mapLoaded || !mapRef.current) return;
 
     const map = mapRef.current.getMap();
-    if (!map.getSource('regions-vt')) return;
 
+    // The root overlay is in the list only while it is mounted: `setHoverState`
+    // checks `getSource` per overlay anyway, but the gate is also what makes
+    // `rootOverlayEnabled` a dependency — the overlay appearing re-subscribes,
+    // and the call-once below paints the standing hover onto it.
     const overlaySources = [
-      'root-regions-vt',
+      ...(rootOverlayEnabled ? ['root-regions-vt'] : []),
       ...Array.from({ length: contextLayerCount }, (_, i) => `context-${i}-vt`),
     ];
 
-    if (prevHoveredIdRef.current !== null) {
-      clearHoverState(map, sourceLayerName, overlaySources, prevHoveredIdRef.current);
-    }
+    // Called once on subscribe with the standing value — a hover set before
+    // this effect re-ran (the tiles arriving, an overlay appearing, the source
+    // replaced under it) is painted rather than lost until the pointer moves
+    // again. `tileUrl` is a dependency for exactly that: replacing `regions-vt`
+    // wipes its feature state, and re-subscribing is what repaints the standing
+    // hover onto the new source — the visited effect above lists it for the
+    // same reason.
+    const paint = (hoveredRegionId: number | null) => {
+      // Checked per event, not once at subscribe: the sources are added by
+      // react-map-gl's own `<Source>` components after `load`, so a check that
+      // gated the subscription concluded "no source" once and never looked
+      // again — the pre-store effect self-healed because hover state re-ran it
+      // on every pointer move, and this subscription has no such retry.
+      if (!map.getSource('regions-vt')) return;
+      if (prevHoveredIdRef.current !== null) {
+        clearHoverState(map, sourceLayerName, overlaySources, prevHoveredIdRef.current);
+      }
 
-    if (hoveredRegionId !== null && !isExploring) {
-      setHoverState(map, sourceLayerName, overlaySources, hoveredRegionId);
-      prevHoveredIdRef.current = hoveredRegionId;
-    } else {
-      prevHoveredIdRef.current = null;
-    }
-  }, [mapLoaded, hoveredRegionId, sourceLayerName, isExploring, contextLayerCount, mapRef]);
+      if (hoveredRegionId !== null && !isExploring) {
+        setHoverState(map, sourceLayerName, overlaySources, hoveredRegionId);
+        prevHoveredIdRef.current = hoveredRegionId;
+      } else {
+        prevHoveredIdRef.current = null;
+      }
+    };
+    const unsubscribe = subscribeToRegionHover(regionHoverStore, paint);
+
+    // The retry for a paint the guard above skipped: a hover set in the window
+    // between this effect running and the source landing has no later event to
+    // carry it — the deps cover the *replacement* of a source, not its first
+    // arrival. Same shape as the visited effect's listener; gated on the
+    // painted id already matching so routine tile loads cost nothing.
+    const handleSourceData = (e: MapSourceDataEvent) => {
+      if (e.sourceId !== 'regions-vt' || !e.isSourceLoaded) return;
+      if (prevHoveredIdRef.current === regionHoverStore.getState()) return;
+      paint(regionHoverStore.getState());
+    };
+    map.on('sourcedata', handleSourceData);
+    return () => {
+      unsubscribe();
+      map.off('sourcedata', handleSourceData);
+    };
+  }, [mapLoaded, regionHoverStore, sourceLayerName, isExploring, contextLayerCount, rootOverlayEnabled, tileUrl, mapRef]);
 
   // Hide region layers when exploring
   useEffect(() => {

--- a/frontend/src/components/regionMap/useMapInteractions.ts
+++ b/frontend/src/components/regionMap/useMapInteractions.ts
@@ -6,12 +6,11 @@ import { useRef, useEffect, useCallback, useMemo } from 'react';
 import type { MapRef, MapLayerMouseEvent } from 'react-map-gl/maplibre';
 import * as turf from '@turf/turf';
 import { useNavigation } from '../../hooks/useNavigation';
+import { useRegionHoverActions } from '../../hooks/useRegionHover';
 import { useExperienceContext } from '../../hooks/useExperienceContext';
 import { fetchDivision, fetchDivisionGeometry } from '../../api';
 import { smartFitBounds } from '../../utils/mapUtils';
 import type { Region } from '../../types';
-
-const REGIONS_SOURCE_LAYER = 'regions';
 
 interface ClickMeta {
   name?: string;
@@ -114,13 +113,15 @@ export function useMapInteractions({
     selectedDivision,
     selectedWorldView,
     setSelectedDivision,
-    hoveredRegionId,
-    setHoveredRegionId,
     isCustomWorldView,
     selectedRegion,
     setSelectedRegion,
     regionBreadcrumbs,
   } = useNavigation();
+  // The setter only. What is hovered is rendered by `HoveredRegionTooltip` and
+  // painted by `useMapFeatureState`'s subscription — reading it here would put
+  // this hook's owner, the map, back on the every-mouse-move render path.
+  const { setHoveredRegionId } = useRegionHoverActions();
 
   const { isExploring } = useExperienceContext();
 
@@ -387,36 +388,6 @@ export function useMapInteractions({
     }
   }, [selectedDivision, selectedWorldView, setSelectedDivision, isCustomWorldView, selectedRegion, setSelectedRegion, regionBreadcrumbs]);
 
-  // Get hovered region name from metadata, falling back to tile feature properties
-  // (for siblings not in current-level metadata)
-  const hoveredRegionName = useMemo(() => {
-    if (!hoveredRegionId) return null;
-    if (metadataById[hoveredRegionId]?.name) return metadataById[hoveredRegionId].name;
-    // Fall back: query tile features for the name
-    if (mapRef.current) {
-      const map = mapRef.current.getMap();
-      // Check context sources, main source, and root overlay
-      const sourceIds = [
-        ...Array.from({ length: contextLayerCount }, (_, i) => `context-${i}-vt`),
-        'regions-vt',
-        'root-regions-vt',
-      ];
-      for (const sourceId of sourceIds) {
-        if (!map.getSource(sourceId)) continue;
-        const sourceLayer = sourceId === 'regions-vt' ? sourceLayerName : REGIONS_SOURCE_LAYER;
-        // Filter by promoted feature ID to avoid scanning all loaded tile features
-        const features = map.querySourceFeatures(sourceId, {
-          sourceLayer,
-          filter: ['==', ['id'], hoveredRegionId],
-        });
-        if (features.length > 0 && features[0].properties?.name) {
-          return features[0].properties.name as string;
-        }
-      }
-    }
-    return null;
-  }, [hoveredRegionId, metadataById, mapRef, sourceLayerName, contextLayerCount]);
-
   // Interactive layer IDs
   const interactiveLayerIds = useMemo(() => {
     const layers = ['region-fill', 'region-hull'];
@@ -434,12 +405,10 @@ export function useMapInteractions({
     handleMouseMove,
     handleMouseLeave,
     handleGoToParent,
-    hoveredRegionName,
     interactiveLayerIds,
     selectedRegion,
     selectedDivision,
     isCustomWorldView,
     isExploring,
-    hoveredRegionId,
   };
 }

--- a/frontend/src/components/shared/VirtualRow.tsx
+++ b/frontend/src/components/shared/VirtualRow.tsx
@@ -1,5 +1,7 @@
 /**
- * One row of the windowed experience list, placed where the virtualiser says.
+ * One row of a windowed list, placed where the virtualiser says. Shared by the
+ * map-mode experience list and Discover's — each owns its virtualiser and hands
+ * this the placement.
  *
  * Measurement is the library's: the ref reports the element, and a `ResizeObserver`
  * reports changes. That observer runs *after* layout, which is one frame too late

--- a/frontend/src/hooks/regionHoverStore.test.tsx
+++ b/frontend/src/hooks/regionHoverStore.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * What a region hover is allowed to re-render.
+ *
+ * The region lists and the region map share one hovered id, and it used to be
+ * React state in `NavigationContext` — so every mouse move over a region row or
+ * a region polygon re-rendered all twelve consumers of that context, the map
+ * with all of its sources among them. This pins the shape that fixes it, the
+ * same one `hoverStore.test.tsx` pins for experiences: the store notifies, and
+ * only the components whose own selected value changed re-render.
+ *
+ * Counting renders is the only way to assert this: the rendered output of the
+ * fast version and the slow one is identical, which is exactly how the slow one
+ * went unnoticed.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { act, render } from '@testing-library/react';
+import { useRef } from 'react';
+import {
+  RegionHoverProvider,
+  subscribeToRegionHover,
+  useRegionHoverActions,
+  useRegionHoverSelector,
+} from './useRegionHover';
+
+/** Counts its own renders and shows nothing; one per thing we want to watch. */
+function useRenderCount(): number {
+  const count = useRef(0);
+  count.current += 1;
+  return count.current;
+}
+
+const renders: Record<string, number> = {};
+
+function RegionRow({ id }: { id: number }) {
+  const hovered = useRegionHoverSelector(hoveredId => hoveredId === id);
+  renders[`region-${id}`] = useRenderCount();
+  return <span data-testid={`region-${id}`}>{hovered ? 'on' : 'off'}</span>;
+}
+
+/** Stands in for the map's interaction hook: reads the setter, draws nothing. */
+function ActionsOnly() {
+  useRegionHoverActions();
+  renders.actionsOnly = useRenderCount();
+  return null;
+}
+
+let setHovered: (id: number | null) => void;
+
+function Harness() {
+  const { setHoveredRegionId } = useRegionHoverActions();
+  setHovered = setHoveredRegionId;
+  return (
+    <>
+      <ActionsOnly />
+      <RegionRow id={1} />
+      <RegionRow id={2} />
+      <RegionRow id={3} />
+    </>
+  );
+}
+
+function renderHarness() {
+  for (const key of Object.keys(renders)) delete renders[key];
+  return render(<RegionHoverProvider><Harness /></RegionHoverProvider>);
+}
+
+describe('region hover store', () => {
+  it('re-renders only the region the pointer arrived at', () => {
+    const { getByTestId } = renderHarness();
+    expect(renders['region-1']).toBe(1);
+
+    act(() => { setHovered(2); });
+
+    expect(getByTestId('region-2').textContent).toBe('on');
+    expect(renders['region-2']).toBe(2);
+    expect(renders['region-1']).toBe(1);
+    expect(renders['region-3']).toBe(1);
+  });
+
+  it('re-renders the region left behind and the one arrived at, and no others', () => {
+    const { getByTestId } = renderHarness();
+    act(() => { setHovered(1); });
+    act(() => { setHovered(3); });
+
+    expect(getByTestId('region-1').textContent).toBe('off');
+    expect(getByTestId('region-3').textContent).toBe('on');
+    expect(renders['region-1']).toBe(3);
+    expect(renders['region-3']).toBe(2);
+    expect(renders['region-2']).toBe(1);
+  });
+
+  it('never re-renders a component that only holds the setter', () => {
+    renderHarness();
+    act(() => { setHovered(1); });
+    act(() => { setHovered(2); });
+    act(() => { setHovered(null); });
+
+    // The map is this component: it answers a hover with `setFeatureState`,
+    // and rendering it reconciles every source and layer react-map-gl holds.
+    expect(renders.actionsOnly).toBe(1);
+  });
+
+  it('does not notify when the same id is set again', () => {
+    renderHarness();
+    act(() => { setHovered(2); });
+    const after = renders['region-2'];
+    // The map fires mousemove continuously over one polygon; each move sets
+    // the id it already holds, and every one of those must cost nothing.
+    act(() => { setHovered(2); });
+    expect(renders['region-2']).toBe(after);
+  });
+
+  it('hands a subscriber the standing value on subscribe, then only changes', () => {
+    // The feature-state effect subscribes when the map loads, which can be
+    // after a hover is already standing — called once on subscribe, it paints
+    // that hover rather than waiting for the pointer to move again.
+    let actions: ReturnType<typeof useRegionHoverActions>;
+    function Grab() {
+      actions = useRegionHoverActions();
+      return null;
+    }
+    render(<RegionHoverProvider><Grab /></RegionHoverProvider>);
+    act(() => { actions.setHoveredRegionId(7); });
+
+    const seen: (number | null)[] = [];
+    let unsubscribe: () => void;
+    act(() => {
+      unsubscribe = subscribeToRegionHover(actions.store, id => { seen.push(id); });
+    });
+    expect(seen).toEqual([7]);
+
+    act(() => { actions.setHoveredRegionId(9); });
+    act(() => { actions.setHoveredRegionId(null); });
+    expect(seen).toEqual([7, 9, null]);
+    unsubscribe!();
+  });
+});

--- a/frontend/src/hooks/useNavigation.tsx
+++ b/frontend/src/hooks/useNavigation.tsx
@@ -5,6 +5,7 @@ import { useQuery } from '@tanstack/react-query';
 import type { AdministrativeDivision, WorldView, Region } from '../types';
 import { fetchWorldViews, fetchDivisionAncestors, fetchRootRegions, fetchRegionAncestors } from '../api';
 import { useAuth } from './useAuth';
+import { RegionHoverProvider } from './useRegionHover';
 
 interface NavigationContextType {
   // World View
@@ -22,10 +23,6 @@ interface NavigationContextType {
   selectedRegion: Region | null;
   setSelectedRegion: (region: Region | null) => void;
   rootRegions: Region[];
-
-  // Hovered item (shared between list and map)
-  hoveredRegionId: number | null;
-  setHoveredRegionId: (id: number | null) => void;
 
   // Breadcrumbs (works for both GADM divisions and custom regions)
   divisionBreadcrumbs: AdministrativeDivision[];
@@ -67,7 +64,6 @@ export function NavigationProvider({ children }: { children: ReactNode }) {
   const [selectedRegion, setSelectedRegion] = useState<Region | null>(null);
   const [divisionBreadcrumbs, setDivisionBreadcrumbs] = useState<AdministrativeDivision[]>([]);
   const [regionBreadcrumbs, setRegionBreadcrumbs] = useState<Region[]>([]);
-  const [hoveredRegionId, setHoveredRegionId] = useState<number | null>(null);
   const [tileVersion, setTileVersion] = useState(0);
 
   // Increment tile version to force MapLibre to reload tiles
@@ -406,8 +402,6 @@ export function NavigationProvider({ children }: { children: ReactNode }) {
     selectedRegion,
     setSelectedRegion: handleSetSelectedRegion,
     rootRegions,
-    hoveredRegionId,
-    setHoveredRegionId,
     divisionBreadcrumbs,
     regionBreadcrumbs,
     tileVersion,
@@ -425,7 +419,6 @@ export function NavigationProvider({ children }: { children: ReactNode }) {
     selectedRegion,
     handleSetSelectedRegion,
     rootRegions,
-    hoveredRegionId,
     divisionBreadcrumbs,
     regionBreadcrumbs,
     tileVersion,
@@ -434,9 +427,14 @@ export function NavigationProvider({ children }: { children: ReactNode }) {
     rootRegionsLoading,
   ]);
 
+  // The hovered region rides its own store rather than this context — it
+  // changes on every mouse move over the region map, and here it re-rendered
+  // all twelve consumers of this context per move (#573). Mounted by this
+  // provider the way `ExperienceProvider` mounts `HoverProvider`, so every
+  // surface that navigates regions can read it.
   return (
     <NavigationContext.Provider value={value}>
-      {children}
+      <RegionHoverProvider>{children}</RegionHoverProvider>
     </NavigationContext.Provider>
   );
 }

--- a/frontend/src/hooks/useRegionHover.tsx
+++ b/frontend/src/hooks/useRegionHover.tsx
@@ -1,0 +1,101 @@
+/**
+ * Which region the pointer is over, published to the few things that draw it.
+ *
+ * The experience list learned this shape first — see `useHoverContext.tsx` for
+ * the full argument. The short form: hover changes on every mouse move, so as
+ * React state in a context it re-rendered every consumer of that context per
+ * move. For regions that context was `NavigationContext`, whose twelve
+ * consumers include `RegionMapVT` — so dragging the pointer across the region
+ * map re-rendered the map itself, both lists, the breadcrumbs and the search
+ * box, at mousemove rate (#573).
+ *
+ * The state here is one primitive — the hovered region or division id — which
+ * is why this is its own small store rather than a second field on the
+ * experience hover store: the two are different domains with different
+ * providers (region hover must reach `RegionList`, which renders outside
+ * `ExperienceProvider`), and a primitive needs none of that store's
+ * preview-merging rules. The invariants are the same and are pinned the same
+ * way, in `regionHoverStore.test.tsx`: a selector re-renders only the component
+ * whose own value changed, and holding the setter costs no renders at all.
+ */
+
+import { createContext, useContext, useMemo, useRef, useSyncExternalStore, type ReactNode } from 'react';
+
+export interface RegionHoverStore {
+  getState: () => number | null;
+  /** Listeners take no arguments, so this fits `useSyncExternalStore` directly. */
+  subscribe: (listener: () => void) => () => void;
+}
+
+interface RegionHoverContextType {
+  store: RegionHoverStore;
+  setHoveredRegionId: (id: number | null) => void;
+}
+
+const RegionHoverContext = createContext<RegionHoverContextType | null>(null);
+
+export function RegionHoverProvider({ children }: { children: ReactNode }) {
+  const stateRef = useRef<number | null>(null);
+  const listenersRef = useRef<Set<() => void>>(new Set());
+
+  // Built once, so reading the context never costs a render — the whole point.
+  const value = useMemo<RegionHoverContextType>(() => ({
+    store: {
+      getState: () => stateRef.current,
+      subscribe: (listener: () => void) => {
+        listenersRef.current.add(listener);
+        return () => { listenersRef.current.delete(listener); };
+      },
+    },
+    setHoveredRegionId: (id: number | null) => {
+      // The map fires mousemove continuously over one polygon; each move
+      // re-sets the id it already holds, and must not wake anyone for it.
+      if (stateRef.current === id) return;
+      stateRef.current = id;
+      // Copied, because a listener may unsubscribe during the walk — a row
+      // unmounting is the ordinary case in a windowed list.
+      for (const listener of [...listenersRef.current]) listener();
+    },
+  }), []);
+
+  return <RegionHoverContext.Provider value={value}>{children}</RegionHoverContext.Provider>;
+}
+
+function useRegionHoverContext(): RegionHoverContextType {
+  const context = useContext(RegionHoverContext);
+  if (!context) {
+    throw new Error('useRegionHoverContext must be used within a RegionHoverProvider');
+  }
+  return context;
+}
+
+/**
+ * The setter, and the store for anything that reacts in an effect rather than
+ * in a render. Stable, so reading this never costs a re-render.
+ */
+export function useRegionHoverActions(): RegionHoverContextType {
+  return useRegionHoverContext();
+}
+
+/**
+ * One value out of the hovered id, re-rendering only when *that* value changes.
+ * A row asks "am I the one" and gets a boolean; see `useHoverContext.tsx` for
+ * why the selector must return a primitive.
+ */
+export function useRegionHoverSelector<T>(selector: (hoveredId: number | null) => T): T {
+  const { store } = useRegionHoverContext();
+  return useSyncExternalStore(store.subscribe, () => selector(store.getState()));
+}
+
+/**
+ * The hovered id for the things that answer a hover outside of a render — the
+ * map's feature-state writer and its tooltip. Called once on subscribing, so a
+ * hover already standing when the map loads is painted rather than missed.
+ */
+export function subscribeToRegionHover(
+  store: RegionHoverStore,
+  listener: (hoveredId: number | null) => void,
+): () => void {
+  listener(store.getState());
+  return store.subscribe(() => listener(store.getState()));
+}

--- a/frontend/src/hooks/useSeenWindowIds.test.ts
+++ b/frontend/src/hooks/useSeenWindowIds.test.ts
@@ -1,0 +1,71 @@
+/**
+ * What the accumulate-and-flush behind New-badge impressions must hold.
+ *
+ * The server keeps the *first* impression, so the failure being guarded is not
+ * recoverable: an id reported for a row nobody was shown spends that reader's
+ * personal week, and an id leaked across a region change reports one region's
+ * rows against another's list. The flush timer is the other half — windowing
+ * made the seen-set change on every scroll, and each change used to be a
+ * request against a shared rate limit.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useSeenWindowIds } from './useSeenWindowIds';
+
+const FLUSH_MS = 800;
+
+function renderSeen(initialIds: number[], initialKey: string | number | null) {
+  return renderHook(
+    ({ ids, key }: { ids: number[]; key: string | number | null }) => useSeenWindowIds(ids, key),
+    { initialProps: { ids: initialIds, key: initialKey } },
+  );
+}
+
+describe('useSeenWindowIds', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('accumulates what the window has held, across window movements', () => {
+    const { result, rerender } = renderSeen([1, 2], 'region-1');
+    act(() => { vi.advanceTimersByTime(FLUSH_MS); });
+    expect(result.current).toEqual(new Set([1, 2]));
+
+    // The reader scrolls on; the earlier rows are not unseen by leaving.
+    rerender({ ids: [3], key: 'region-1' });
+    act(() => { vi.advanceTimersByTime(FLUSH_MS); });
+    expect(result.current).toEqual(new Set([1, 2, 3]));
+  });
+
+  it('holds new ids back until the flush timer fires', () => {
+    // One report per interval, not one per scroll frame: the set feeds a
+    // request, and `authenticatedLimiter` counts every one of them.
+    const { result } = renderSeen([1, 2], 'region-1');
+    expect(result.current).toEqual(new Set());
+    act(() => { vi.advanceTimersByTime(FLUSH_MS - 1); });
+    expect(result.current).toEqual(new Set());
+    act(() => { vi.advanceTimersByTime(1); });
+    expect(result.current).toEqual(new Set([1, 2]));
+  });
+
+  it('resets in the render that changes the key, not an effect later', () => {
+    const { result, rerender } = renderSeen([1, 2], 'region-1');
+    act(() => { vi.advanceTimersByTime(FLUSH_MS); });
+
+    // The same render that carries region B's rows must carry an empty set: one
+    // commit of B's rows against A's seen-set reports rows nobody has seen.
+    rerender({ ids: [9], key: 'region-2' });
+    expect(result.current).toEqual(new Set());
+    act(() => { vi.advanceTimersByTime(FLUSH_MS); });
+    expect(result.current).toEqual(new Set([9]));
+  });
+
+  it('drops rows still waiting to be flushed when the key changes', () => {
+    // Ids pending from region A must not surface once the timer comes round
+    // against region B's list.
+    const { result, rerender } = renderSeen([1, 2], 'region-1');
+    rerender({ ids: [], key: 'region-2' });
+    act(() => { vi.advanceTimersByTime(FLUSH_MS * 2); });
+    expect(result.current).toEqual(new Set());
+  });
+});

--- a/frontend/src/hooks/useSeenWindowIds.ts
+++ b/frontend/src/hooks/useSeenWindowIds.ts
@@ -1,0 +1,95 @@
+/**
+ * Which experiences the reader's window has actually held, accumulated.
+ *
+ * Windowing is what makes New-badge impressions answerable, and also what makes
+ * this hook necessary wherever a list is windowed: before it, rendering a group
+ * of 467 stamped all 467 as seen while the reader had passed ten, and the
+ * server keeps the *first* impression — so those rows spent the reader's
+ * personal week unseen, which is precisely what that week exists to prevent.
+ * Accumulated rather than "in view now", because scrolling away does not unsee
+ * a row. Shared by the map-mode experience list and Discover's (#573).
+ *
+ * State rather than a ref, so callers' memos have something real to depend on:
+ * a ref mutated in place tells React nothing, and the impressions call would
+ * keep reporting the previous set.
+ *
+ * Flushed on a timer rather than per render, which is what windowing costs
+ * here: the set used to change once per region and now changes as the reader
+ * scrolls, and each change is a request. `authenticatedLimiter` allows 60 a
+ * minute per IP across every authenticated call, and a curator publishing a
+ * sync's arrivals in one go is precisely how a region comes to hold hundreds of
+ * rows carrying the mark. Ids accumulate between flushes, so this bounds how
+ * often the rows are reported, never which of them are.
+ *
+ * The reset tracker is state, not a ref, which is what makes it restart-safe:
+ * the reset key arrives through navigation, which React Router pushes in a
+ * transition — a render React may discard and replay. A ref is shared with the
+ * committed fiber, so it would keep the new key across a discard while the
+ * queued reset went with the discarded tree; state is queued on the same
+ * work-in-progress tree as the reset, so the two are discarded and replayed
+ * together. The reset runs during render for the same reason the map-mode list
+ * resets during render: one commit carrying region B's rows against region A's
+ * seen-set would report impressions for rows nobody has seen, and the server
+ * keeps the first one.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * How often, at most, the rows the window has held are reported as seen.
+ *
+ * Long enough that a scroll through a freshly published region is a handful of
+ * requests rather than one per render, short enough that a reader who glances
+ * and leaves has still been counted.
+ */
+const SEEN_FLUSH_MS = 800;
+
+/**
+ * `resetKey` is compared with `!==`, so it must be a primitive: an object or an
+ * array rebuilt per render would never equal the tracked one, and the set would
+ * reset on every render instead of ever accumulating.
+ */
+export function useSeenWindowIds(idsInWindow: number[], resetKey: string | number | null): Set<number> {
+  const [seenIds, setSeenIds] = useState<Set<number>>(() => new Set());
+  // Rows seen since the last flush, and the flush itself. Cleared by the
+  // render-phase reset below, or region A's rows would be reported once the
+  // timer came round against region B's list.
+  const pendingSeen = useRef<Set<number>>(new Set());
+  const flushTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const [trackedKey, setTrackedKey] = useState(resetKey);
+  if (resetKey !== trackedKey) {
+    setTrackedKey(resetKey);
+    setSeenIds(new Set());
+    pendingSeen.current = new Set();
+  }
+
+  useEffect(() => {
+    const fresh = idsInWindow.filter(id => !seenIds.has(id) && !pendingSeen.current.has(id));
+    for (const id of fresh) pendingSeen.current.add(id);
+    if (pendingSeen.current.size === 0 || flushTimer.current) return;
+    flushTimer.current = setTimeout(() => {
+      flushTimer.current = null;
+      const batch = pendingSeen.current;
+      pendingSeen.current = new Set();
+      // Empty when a reset cleared the pending set while this was in flight;
+      // setting state anyway would report the new list against a set that
+      // gained nothing.
+      if (batch.size === 0) return;
+      setSeenIds(prev => {
+        const next = new Set(prev);
+        for (const id of batch) next.add(id);
+        return next;
+      });
+    }, SEEN_FLUSH_MS);
+  }, [idsInWindow, seenIds]);
+
+  // A flush landing after the list is gone belongs to nobody.
+  useEffect(() => () => {
+    if (flushTimer.current) clearTimeout(flushTimer.current);
+    flushTimer.current = null;
+    pendingSeen.current = new Set();
+  }, []);
+
+  return seenIds;
+}


### PR DESCRIPTION
## Description

Every list except map mode's re-rendered whole on hover, and none of Discover's was windowed. This brings the other surfaces up to the invariant `hoverStore.test.tsx` states — *"re-renders only the place the pointer arrived at"*, *"never re-renders a component that only holds the setters"* — and windows the one unwindowed list in the app.

Commit by commit:

1. **`useSeenWindowIds`** — the map-mode list's New-badge accumulate-and-flush extracted into a shared hook (a second windowed list is about to need it), with tests pinning accumulation, the flush interval, the render-phase reset, and pending ids dying with their key.
2. **`VirtualRow` → `components/shared/`** — the windowed-row placement both lists need verbatim.
3. **Region hover gets its own store** (`useRegionHover`). `hoveredRegionId` was React state in `NavigationContext`, so every mouse move over a region row — or over the region map, which writes the same id from `mousemove` — re-rendered all twelve consumers of that context, `RegionMapVT` with every source and layer among them. Now: `RegionList` rows subscribe to their own "am I the one", the tooltip naming the hovered region is its own subscriber component (`HoveredRegionTooltip`, taking the metadata-then-tiles name fallback with it), `useMapFeatureState` paints hover from a subscription (two `setFeatureState` calls, no render), and `useMapInteractions` keeps the setter alone. `regionHoverStore.test.tsx` pins the invariants, plus the two this store adds: a same-id write wakes nobody (the map re-sets the id it already holds on every `mousemove`), and a subscriber is handed the standing value on subscribe (the map can load after a hover is already standing).
4. **Discover rides the shared hover store, and its card list is windowed.**
   - `useDiscoverHover` only writes the store now; its cluster-aware ring drawing is unchanged. Each card row subscribes to its own boolean (`DiscoverExperienceRow`, memoised); the preview card is its own subscriber (`DiscoverHoverCard`).
   - The detail panel's location hover — which was **DiscoverPage state**, re-rendering all three panels per pointer move — goes through the store in both directions: a dot hover names the selected object *and* the place, so the panel row highlights itself and auto-scrolls from a subscription; a panel-row hover writes the store and the ring is drawn by `useDiscoverHover`'s subscription, which holds the coordinates.
   - The card list mounts what the scroll window covers (up to 683 cards before — the live database's largest region). A marker hover scrolls by index from a subscription (`cardRefsMap` and the smooth `scrollIntoView` went with the windowing — TanStack documents smooth as unsupported beside dynamic measurement, and a jump cannot slide rows under a resting pointer, which is what the old `isAutoScrollingRef` guard absorbed). New-badge impressions report what the window has held via `useSeenWindowIds` — the server keeps the *first* impression, so reporting the whole filtered set was honest only while every row was mounted.
5. **Docs** — experience-map-ui.md (both surfaces on the store, the windowed Discover list, the region check the issue asked for), shared-frontend-patterns.md (VirtualRow + three use-this-not-that rows), development-guide.md (hooks table).

The issue's two "check" items: `DiscoverRegionList`'s hover is pure CSS — nothing to change; `RegionList`'s rode the navigation context and now rides the region hover store.

One deliberate behaviour nuance: hovering a location row in the detail panel now also tints the (already selected) card in the list, because one store holds one truth — the hover names that object's place. Previously the two states were separate and could not agree.

## Related Issues
Closes: #573

## How Was This Tested?

**Measured, on the worst real cases** from the live database: **Europe** (683 experiences; its UNESCO view lists **467 cards**) and **New South Wales** (**153** sibling regions). Setup: headless Chromium, dev build (StrictMode doubles renders), real pointer moves via CDP — 40 per sweep, ~25 ms apart, up and down the panel so rows enter *and* leave — metrics from `PerformanceObserver('longtask')` + an rAF frame sampler. The heavy data lives in an admin-only world view, so the API answers were captured from the live database with read-only SQL and served via request interception, **identical on both sides**; external images and the raster basemap were blocked so neither run depends on the network. Martin tiles (region polygons) are real.

| Interaction (40 pointer moves unless noted) | before | after |
|---|---|---|
| **Discover, UNESCO in Europe (467 cards): pointer across the cards** | blocked **9 483 ms**, worst frame 1 000 ms, avg frame 149.8 ms | blocked **57 ms**, worst frame 50 ms, avg frame 21.8 ms |
| Discover page DOM once that list is open | **6 419** nodes, all 467 cards mounted | **724** nodes, 14 rows mounted |
| Opening that list (pill click → settled) | blocked 1 781 ms, worst frame 1 367 ms | blocked 618 ms, worst frame 267 ms |
| **Detail panel, Rock Art of the Mediterranean Basin (758 locations): pointer across the location rows** | blocked **1 097 ms**, worst frame 217 ms | blocked **0 ms**, worst frame 50 ms |
| **Map mode, New South Wales (153 region rows): pointer across the rows** | blocked **4 749 ms** (55 long tasks), avg frame 87.2 ms | blocked **2 305 ms** (31), avg frame 40.5 ms |
| Map mode: pointer across the NSW polygons on the map | blocked 4 331 ms, avg frame 82.9 ms | blocked 2 018 ms, avg frame 38.2 ms |

The map-mode residual is MapLibre repainting 153 polygons' hover feature-state under headless software GL (SwiftShader) — identical work on both sides; what the store removed is the React half, which is the difference shown. Marker hover shares the measured store path; its ring drawing is unchanged. Functional pass on the same runs: the hovered-region tooltip follows the pointer, a card hover rings its object's pins and clusters, the panel's 758-location list highlights and scrolls for dot hovers.

**Unit tests**, each pinning what a measurement cannot:
- `regionHoverStore.test.tsx` — the store invariants, by render counts, mirroring `hoverStore.test.tsx`.
- `discoverListWindow.test.tsx` — 683 experiences mount ≤ 30 rows; the row is memoised; a hover re-renders the row it names and the row it left, and no other.
- `useSeenWindowIds.test.ts` — accumulation, flush interval, render-phase reset, pending ids dying with their key.

Full suites green: 1265 backend + 539 frontend + Python (in the pinned 3.12 container), `npm run check` green, full Semgrep (Node + Python) green, Trivy green (after an uncached rebuild — the stale local apt layer was the only red), `npm run test:e2e:smoke` 7/7.

## Checklist
- [x] Commit messages follow the standard template.
- [x] All commits are signed.
- [x] Related issues are mentioned in the description above.
- [x] Linter checks have been passed.

## Additional Comments (if any):

`docs/vision/vision.md` untouched deliberately: nothing a visitor can see or do changed — the same hovers answer the same way, without the stalls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvkBCWjCQmWKkinCTbDn7o