### PR TITLE
Pin every pooled transaction to one connection

### DIFF
--- a/backend/eslint.config.mjs
+++ b/backend/eslint.config.mjs
@@ -4,6 +4,23 @@ import tsparser from '@typescript-eslint/parser';
 import security from 'eslint-plugin-security';
 import sonarjs from 'eslint-plugin-sonarjs';
 
+/** What to do instead, said once for both spellings of the mistake below. */
+const PINNED_TRANSACTION = "pool.query() does not pin a connection. Open the transaction on one client: "
+  + "const client = await pool.connect(); await client.query('BEGIN'); ... client.release(unusable) "
+  + "— see editExperience in controllers/experience/curationController.ts.";
+
+/**
+ * The verbs that only mean anything on the connection that opened them.
+ *
+ * Postgres' synonyms are here too — `START TRANSACTION` for BEGIN, `END` and
+ * `ABORT` for COMMIT and ROLLBACK — since they open and close exactly the same
+ * stray transaction. `END` is safe to name only because the template selector
+ * below reads the opening quasi alone: this codebase writes plenty of
+ * interpolated `CASE … ${x} … END`, whose trailing quasi would otherwise be
+ * reported as a transaction.
+ */
+const TX_VERBS = '(BEGIN|START TRANSACTION|COMMIT|END|ROLLBACK|ABORT|SAVEPOINT|RELEASE)';
+
 export default [
   {
     ignores: ['dist/', 'node_modules/'],
@@ -44,6 +61,27 @@ export default [
       // Skip blank lines and single-line comments (docstrings / section banners)
       // from the count so files aren't artificially close to the limit.
       'max-lines': ['error', { max: 1000, skipBlankLines: true, skipComments: true }],
+      // A transaction has to be pinned to one client. `pool.query('BEGIN')`
+      // checks out an arbitrary idle client, runs BEGIN on it and releases it
+      // with the transaction still open: the statements that follow may land on
+      // other connections, and another request that checks out that client runs
+      // its own writes inside the stray transaction — to be rolled back with it.
+      // The rule exists because the prose form of it, written in
+      // curationController, outlived four call sites (#532).
+      'no-restricted-syntax': ['error',
+        {
+          selector: `CallExpression[callee.object.name='pool'][callee.property.name='query'] > Literal[value=/^\\s*${TX_VERBS}\\b/i]`,
+          message: PINNED_TRANSACTION,
+        },
+        {
+          // `:first-child` because only the opening quasi can be the start of
+          // the statement. Without it every quasi is read, and an interpolated
+          // `… ${x} ROLLBACK …` deep inside one string would be reported as a
+          // transaction it never opened.
+          selector: `CallExpression[callee.object.name='pool'][callee.property.name='query'] > TemplateLiteral > TemplateElement:first-child[value.raw=/^\\s*${TX_VERBS}\\b/i]`,
+          message: PINNED_TRANSACTION,
+        },
+      ],
       // SonarJS: disable genuine false positives only
       'sonarjs/pseudo-random': 'off', // Math.random is fine for non-crypto uses (e.g., jitter)
       'sonarjs/no-clear-text-protocols': 'off', // False positives on example/docs URLs

--- a/backend/src/controllers/admin/curatorController.test.ts
+++ b/backend/src/controllers/admin/curatorController.test.ts
@@ -1,0 +1,308 @@
+/**
+ * Tests for the two writes that grant and take back a curator's scope.
+ *
+ * Both are transactions for the same reason: a scope row and the role that
+ * answers for it are one fact in two tables. A `curator_assignments` row whose
+ * user is still `user` reaches no curation screen, and a `curator` role with no
+ * row left grants powers over nothing — either half alone is a state no screen
+ * in the product can explain.
+ *
+ * What is asserted here is not that the statements ran but that they ran on the
+ * one connection the handler checked out (#532). `pool.query('BEGIN')` reads as
+ * a transaction and is not one: pg.Pool hands out an arbitrary idle client per
+ * call and releases it with the transaction still open, so the promotion may
+ * land on another connection — and a *different admin's* write that checks out
+ * the leaked client is swept into the stray transaction and dies with it.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../db/index.js', () => ({
+  pool: { query: vi.fn(), connect: vi.fn() },
+  rollbackQuietly: async (c: { query: (s: string) => unknown }) => {
+    try { await c.query('ROLLBACK'); return undefined; } catch (e) { return e as Error; }
+  },
+}));
+
+import { pool } from '../../db/index.js';
+import { createCuratorAssignment, revokeCuratorAssignment } from './curatorController.js';
+
+const mockedQuery = pool.query as unknown as ReturnType<typeof vi.fn>;
+const mockedConnect = pool.connect as unknown as ReturnType<typeof vi.fn>;
+/** The same mock, in its callable shape: `vi.fn()`'s own type is not callable. */
+const answer = mockedQuery as unknown as (sql: string, params?: unknown[]) => Promise<unknown>;
+
+function makeRes() {
+  return { json: vi.fn(), status: vi.fn().mockReturnThis() };
+}
+
+/** The client the handler must pin; its statements answer from the pool's mock. */
+function pinClient() {
+  const client = {
+    query: vi.fn((sql: string, params?: unknown[]) => answer(sql, params)),
+    release: vi.fn(),
+  };
+  mockedConnect.mockResolvedValue(client);
+  return client;
+}
+
+/** What the pinned client was asked, in order. */
+function clientSql(client: ReturnType<typeof pinClient>): string[] {
+  return client.query.mock.calls.map(call => String(call[0]));
+}
+
+/** A reader being given, or losing, the curator's chair over Algeria. */
+const ALGERIA = 3;
+const CANDIDATE = 214;
+const ADMIN = { id: 1 };
+
+/**
+ * Answers each statement by what it asks for, so a handler's own order of
+ * questions — not a fixture's order — decides what comes back.
+ *
+ * `role` and `lockedRole` are separate on purpose: the first answers the
+ * reference check, which runs outside any transaction, and the second answers
+ * the read under `FOR NO KEY UPDATE`. Letting a test set them apart is how the
+ * "decided from the locked read" rule can be asserted at all.
+ */
+function answering(
+  overrides: { role?: string; lockedRole?: string; remaining?: string } = {},
+) {
+  mockedQuery.mockImplementation(async (sql: string) => {
+    const text = String(sql);
+    if (/FROM users/i.test(text) && /SELECT/i.test(text)) {
+      const role = /FOR NO KEY UPDATE/i.test(text)
+        ? overrides.lockedRole ?? overrides.role ?? 'user'
+        : overrides.role ?? 'user';
+      return { rows: [{ id: CANDIDATE, role }] };
+    }
+    if (/FROM regions/i.test(text)) return { rows: [{ id: ALGERIA }] };
+    if (/FROM curator_assignments/i.test(text) && /COUNT/i.test(text)) {
+      return { rows: [{ count: overrides.remaining ?? '0' }] };
+    }
+    if (/FROM curator_assignments/i.test(text)) {
+      return { rows: [{ id: 77, user_id: CANDIDATE }] };
+    }
+    if (/INSERT INTO curator_assignments/i.test(text)) {
+      return { rows: [{ id: 77, assigned_at: new Date('2026-08-23T10:00:00Z') }] };
+    }
+    return { rows: [], rowCount: 1 };
+  });
+}
+
+/** Make one statement of the transaction fail, leaving the rest answering. */
+function failOn(statement: RegExp, message: string) {
+  const answering = mockedQuery.getMockImplementation() as
+    (sql: string, params?: unknown[]) => Promise<unknown>;
+  mockedQuery.mockImplementation(async (sql: string, params?: unknown[]) => {
+    if (statement.test(String(sql))) throw new Error(message);
+    return answering(sql, params);
+  });
+}
+
+describe('granting a curator their scope', () => {
+  beforeEach(() => {
+    mockedQuery.mockReset();
+    mockedConnect.mockReset();
+    answering();
+  });
+
+  it('writes the scope and the promotion on one pinned client', async () => {
+    const client = pinClient();
+    const res = makeRes();
+
+    await createCuratorAssignment({
+      body: { userId: CANDIDATE, scopeType: 'region', regionId: ALGERIA },
+      user: ADMIN,
+    } as never, res as never);
+
+    const onClient = clientSql(client);
+    expect(onClient[0]).toBe('BEGIN');
+    expect(onClient.at(-1)).toBe('COMMIT');
+    expect(onClient.filter(sql => /INSERT INTO curator_assignments/i.test(sql))).toHaveLength(1);
+    expect(onClient.filter(sql => /UPDATE users SET role = 'curator'/i.test(sql))).toHaveLength(1);
+    expect(client.release).toHaveBeenCalledTimes(1);
+    expect(res.status).toHaveBeenCalledWith(201);
+  });
+
+  it('leaves the role alone for someone who already curates elsewhere', async () => {
+    answering({ role: 'curator', lockedRole: 'curator' });
+    const client = pinClient();
+
+    await createCuratorAssignment({
+      body: { userId: CANDIDATE, scopeType: 'region', regionId: ALGERIA },
+      user: ADMIN,
+    } as never, makeRes() as never);
+
+    // A second scope is not a second promotion; the row is all that is new.
+    expect(clientSql(client).filter(sql => /UPDATE users/i.test(sql))).toHaveLength(0);
+    expect(client.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('takes the user row under the lock before it writes anything', async () => {
+    const client = pinClient();
+
+    await createCuratorAssignment({
+      body: { userId: CANDIDATE, scopeType: 'region', regionId: ALGERIA },
+      user: ADMIN,
+    } as never, makeRes() as never);
+
+    // Ordering is the assertion, not the presence of the lock: a lock taken
+    // after the INSERT serialises nothing that has already happened.
+    const onClient = clientSql(client);
+    const locked = onClient.findIndex(sql => /FROM users[\s\S]*FOR NO KEY UPDATE/i.test(sql));
+    const inserted = onClient.findIndex(sql => /INSERT INTO curator_assignments/i.test(sql));
+    expect(locked).toBe(1);
+    expect(locked).toBeLessThan(inserted);
+  });
+
+  it('decides the promotion from the locked read, not the check before it', async () => {
+    // The reference check saw `user`; by the time the transaction opened, a
+    // concurrent grant had already promoted them. Deciding from the stale read
+    // would write the promotion a second time — harmless here — but the same
+    // staleness in the other direction is what demotes a live curator.
+    answering({ role: 'user', lockedRole: 'curator' });
+    const client = pinClient();
+    const res = makeRes();
+
+    await createCuratorAssignment({
+      body: { userId: CANDIDATE, scopeType: 'region', regionId: ALGERIA },
+      user: ADMIN,
+    } as never, res as never);
+
+    expect(clientSql(client).filter(sql => /UPDATE users/i.test(sql))).toHaveLength(0);
+    const [payload] = res.json.mock.calls[0] as [{ rolePromoted: boolean }];
+    expect(payload.rolePromoted).toBe(false);
+  });
+
+  it('rolls back and hands the connection back when the promotion fails', async () => {
+    const client = pinClient();
+    failOn(/UPDATE users/i, 'could not serialize access');
+
+    await expect(createCuratorAssignment({
+      body: { userId: CANDIDATE, scopeType: 'region', regionId: ALGERIA },
+      user: ADMIN,
+    } as never, makeRes() as never)).rejects.toThrow('could not serialize access');
+
+    // The scope row must not survive the promotion that failed, and the
+    // connection must not go back to the pool still inside the transaction.
+    expect(clientSql(client)).toContain('ROLLBACK');
+    expect(client.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('never opens the transaction for input the validator refuses', async () => {
+    const client = pinClient();
+    const res = makeRes();
+
+    // Region scope with no region names nothing to curate.
+    await createCuratorAssignment({
+      body: { userId: CANDIDATE, scopeType: 'region' }, user: ADMIN,
+    } as never, res as never);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(mockedConnect).not.toHaveBeenCalled();
+    expect(client.query).not.toHaveBeenCalled();
+  });
+});
+
+describe('taking a curator scope back', () => {
+  beforeEach(() => {
+    mockedQuery.mockReset();
+    mockedConnect.mockReset();
+    answering();
+  });
+
+  it('deletes the scope and demotes on one pinned client', async () => {
+    const client = pinClient();
+    const res = makeRes();
+
+    answering({ role: 'curator', lockedRole: 'curator', remaining: '0' });
+
+    await revokeCuratorAssignment(
+      { params: { assignmentId: '77' } } as never, res as never);
+
+    const onClient = clientSql(client);
+    expect(onClient[0]).toBe('BEGIN');
+    expect(onClient.at(-1)).toBe('COMMIT');
+    expect(onClient.filter(sql => /DELETE FROM curator_assignments/i.test(sql))).toHaveLength(1);
+    // The count that decides the demotion is read inside the transaction that
+    // did the delete; on a shared connection it could count rows a concurrent
+    // revoke had not committed.
+    expect(onClient.filter(sql => /COUNT\(\*\)/i.test(sql))).toHaveLength(1);
+    expect(onClient.filter(sql => /UPDATE users SET role = 'user'/i.test(sql))).toHaveLength(1);
+    expect(client.release).toHaveBeenCalledTimes(1);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      assignmentId: 77, userId: CANDIDATE, remainingAssignments: 0, roleReverted: true,
+    }));
+  });
+
+  it('keeps the role of a curator who still holds another scope', async () => {
+    answering({ role: 'curator', lockedRole: 'curator', remaining: '2' });
+    const client = pinClient();
+    const res = makeRes();
+
+    await revokeCuratorAssignment(
+      { params: { assignmentId: '77' } } as never, res as never);
+
+    expect(clientSql(client).filter(sql => /UPDATE users/i.test(sql))).toHaveLength(0);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      remainingAssignments: 2, roleReverted: false,
+    }));
+  });
+
+  it('rolls back and hands the connection back when the delete fails', async () => {
+    const client = pinClient();
+    failOn(/DELETE FROM curator_assignments/i, 'deadlock detected');
+
+    await expect(revokeCuratorAssignment(
+      { params: { assignmentId: '77' } } as never, makeRes() as never,
+    )).rejects.toThrow('deadlock detected');
+
+    expect(clientSql(client)).toContain('ROLLBACK');
+    expect(client.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('takes the user row under the lock before it deletes', async () => {
+    const client = pinClient();
+
+    await revokeCuratorAssignment(
+      { params: { assignmentId: '77' } } as never, makeRes() as never);
+
+    // The same order granting uses, which is what keeps the two from
+    // deadlocking on each other rather than merely serialising.
+    const onClient = clientSql(client);
+    const locked = onClient.findIndex(sql => /FROM users[\s\S]*FOR NO KEY UPDATE/i.test(sql));
+    const deleted = onClient.findIndex(sql => /DELETE FROM curator_assignments/i.test(sql));
+    expect(locked).toBe(1);
+    expect(locked).toBeLessThan(deleted);
+  });
+
+  it('answers 404, and touches no role, when the delete removes nothing', async () => {
+    // Another admin revoked it between the read that found it and this
+    // transaction. Reporting success for a delete that removed nothing is the
+    // misleading half; demoting on a count taken for somebody else's decision
+    // is the damaging one.
+    const client = pinClient();
+    const res = makeRes();
+    answering({ role: 'curator', lockedRole: 'curator', remaining: '0' });
+    const answers = mockedQuery.getMockImplementation() as
+      (sql: string, params?: unknown[]) => Promise<{ rows: unknown[]; rowCount?: number }>;
+    mockedQuery.mockImplementation(async (sql: string, params?: unknown[]) => (
+      /DELETE FROM curator_assignments/i.test(String(sql))
+        ? { rows: [], rowCount: 0 }
+        : answers(sql, params)
+    ));
+
+    await revokeCuratorAssignment(
+      { params: { assignmentId: '77' } } as never, res as never);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    const onClient = clientSql(client);
+    expect(onClient).toContain('ROLLBACK');
+    expect(onClient).not.toContain('COMMIT');
+    expect(onClient.filter(sql => /COUNT\(\*\)/i.test(sql))).toHaveLength(0);
+    expect(onClient.filter(sql => /UPDATE users/i.test(sql))).toHaveLength(0);
+    expect(client.release).toHaveBeenCalledTimes(1);
+    expect(res.json).not.toHaveBeenCalledWith(expect.objectContaining({ success: true }));
+  });
+});

--- a/backend/src/controllers/admin/curatorController.ts
+++ b/backend/src/controllers/admin/curatorController.ts
@@ -6,7 +6,7 @@
  */
 
 import { Response } from 'express';
-import { pool } from '../../db/index.js';
+import { pool, rollbackQuietly } from '../../db/index.js';
 import type { AuthenticatedRequest } from '../../middleware/auth.js';
 
 /**
@@ -53,6 +53,21 @@ interface AssignmentInput {
 
 type ValidationError = { status: number; error: string };
 
+/**
+ * How a writer of somebody's curator standing locks their user row.
+ *
+ * Granting a scope and taking one back both decide the role from a count of
+ * what is left, so they have to serialise on the user or two admins acting at
+ * once leave the two halves disagreeing: an assignment whose owner is back to
+ * `user` and locked out of every curation screen, or a `curator` with nothing
+ * scoped. `FOR NO KEY UPDATE` for the reason `db/locks.ts` gives for the same
+ * mode — it self-conflicts, so the two serialise, while staying compatible with
+ * the `FOR KEY SHARE` that `curator_assignments`' foreign key takes on this
+ * very row. A constant of its own rather than `OBJECT_LOCK`, which names the
+ * order and mode for an experience and its contents.
+ */
+const USER_ROLE_LOCK = 'FOR NO KEY UPDATE';
+
 function validateAssignmentInput(body: AssignmentInput): ValidationError | null {
   const { userId, scopeType, regionId, categoryId } = body;
   if (!userId || !scopeType) {
@@ -70,18 +85,23 @@ function validateAssignmentInput(body: AssignmentInput): ValidationError | null 
   return null;
 }
 
-async function verifyAssignmentReferences(
-  body: AssignmentInput,
-): Promise<{ error: ValidationError } | { userRole: string }> {
-  const userResult = await pool.query('SELECT id, role FROM users WHERE id = $1', [body.userId]);
+/**
+ * Do the three things the body names exist? Answers the error to send, or null.
+ *
+ * Existence only: the role the promotion turns on is read inside the
+ * transaction, under the lock, because a read out here is stale the moment a
+ * concurrent revoke commits.
+ */
+async function verifyAssignmentReferences(body: AssignmentInput): Promise<ValidationError | null> {
+  const userResult = await pool.query('SELECT id FROM users WHERE id = $1', [body.userId]);
   if (userResult.rows.length === 0) {
-    return { error: { status: 404, error: 'User not found' } };
+    return { status: 404, error: 'User not found' };
   }
 
   if (body.scopeType === 'region') {
     const regionResult = await pool.query('SELECT id FROM regions WHERE id = $1', [body.regionId]);
     if (regionResult.rows.length === 0) {
-      return { error: { status: 404, error: 'Region not found' } };
+      return { status: 404, error: 'Region not found' };
     }
   }
 
@@ -91,21 +111,41 @@ async function verifyAssignmentReferences(
       [body.categoryId],
     );
     if (catResult.rows.length === 0) {
-      return { error: { status: 404, error: 'Category not found' } };
+      return { status: 404, error: 'Category not found' };
     }
   }
 
-  return { userRole: userResult.rows[0].role };
+  return null;
 }
 
 async function insertAssignmentAndPromote(
   body: AssignmentInput,
   assignedBy: number,
-  currentRole: string,
 ): Promise<{ id: number; assignedAt: Date; rolePromoted: boolean }> {
-  await pool.query('BEGIN');
+  // One client, not pool.query('BEGIN') — see the note in curationController:
+  // pg.Pool hands out an arbitrary idle client per call, so a transaction has
+  // to be pinned or its statements land on different connections. The scope row
+  // and the promotion that answers for it are the pair this holds together: a
+  // curator row without the role reaches no curation screen, and the role
+  // without the row grants powers nothing scoped.
+  const client = await pool.connect();
+  let unusable: Error | undefined;
   try {
-    const insertResult = await pool.query(
+    await client.query('BEGIN');
+
+    // The role is re-read here, under the lock that revoking takes too, and not
+    // taken from the reference check above: that read is outside any
+    // transaction, so a revoke committing between the two decides this
+    // promotion on a role that no longer holds. `FOR NO KEY UPDATE` for the
+    // reason `db/locks.ts` gives — it self-conflicts, so a grant and a revoke
+    // of the same user serialise, while staying compatible with the KEY SHARE
+    // the INSERT's foreign key takes on this very row.
+    const locked = await client.query(
+      `SELECT role FROM users WHERE id = $1 ${USER_ROLE_LOCK}`,
+      [body.userId],
+    );
+
+    const insertResult = await client.query(
       `
       INSERT INTO curator_assignments (user_id, scope_type, region_id, category_id, assigned_by, notes)
       VALUES ($1, $2, $3, $4, $5, $6)
@@ -114,20 +154,27 @@ async function insertAssignmentAndPromote(
       [body.userId, body.scopeType, body.regionId || null, body.categoryId || null, assignedBy, body.notes || null],
     );
 
-    const rolePromoted = currentRole === 'user';
+    // No row means the user was deleted since the reference check; the INSERT
+    // above has already failed on its foreign key by then, so this value never
+    // reaches anybody.
+    const rolePromoted = locked.rows[0]?.role === 'user';
     if (rolePromoted) {
-      await pool.query("UPDATE users SET role = 'curator' WHERE id = $1", [body.userId]);
+      await client.query("UPDATE users SET role = 'curator' WHERE id = $1", [body.userId]);
     }
 
-    await pool.query('COMMIT');
+    await client.query('COMMIT');
     return {
       id: insertResult.rows[0].id,
       assignedAt: insertResult.rows[0].assigned_at,
       rolePromoted,
     };
   } catch (error) {
-    await pool.query('ROLLBACK');
+    // A client whose ROLLBACK also failed must be destroyed, not pooled: it
+    // would otherwise carry an open transaction into the next request.
+    unusable = await rollbackQuietly(client);
     throw error;
+  } finally {
+    client.release(unusable);
   }
 }
 
@@ -146,14 +193,14 @@ export async function createCuratorAssignment(req: AuthenticatedRequest, res: Re
     return;
   }
 
-  const refResult = await verifyAssignmentReferences(body);
-  if ('error' in refResult) {
-    res.status(refResult.error.status).json({ error: refResult.error.error });
+  const refError = await verifyAssignmentReferences(body);
+  if (refError) {
+    res.status(refError.status).json({ error: refError.error });
     return;
   }
 
   try {
-    const inserted = await insertAssignmentAndPromote(body, assignedBy, refResult.userRole);
+    const inserted = await insertAssignmentAndPromote(body, assignedBy);
     res.status(201).json({
       id: inserted.id,
       userId: body.userId,
@@ -192,42 +239,70 @@ export async function revokeCuratorAssignment(req: AuthenticatedRequest, res: Re
 
   const userId = assignmentResult.rows[0].user_id;
 
-  // Delete assignment and check if role should revert, atomically
-  await pool.query('BEGIN');
+  // Delete assignment and check if role should revert, atomically — on one
+  // pinned client, as `insertAssignmentAndPromote` above. The count that
+  // decides the demotion is read here, so a statement landing outside the
+  // transaction would count assignments a concurrent revoke has not committed.
+  const client = await pool.connect();
+  let unusable: Error | undefined;
+  let remaining: number;
+  let roleReverted = false;
   try {
-    await pool.query('DELETE FROM curator_assignments WHERE id = $1', [assignmentId]);
+    await client.query('BEGIN');
+
+    // The user row first, in the mode granting takes, so the two serialise —
+    // see `USER_ROLE_LOCK`. Two revokes running side by side would otherwise
+    // each see the other's assignment still standing, and neither would demote.
+    const locked = await client.query(
+      `SELECT role FROM users WHERE id = $1 ${USER_ROLE_LOCK}`,
+      [userId],
+    );
+
+    // The read above this transaction is what found the assignment, and by now
+    // another admin may have revoked it. Deleting nothing and then reporting a
+    // successful revoke is the part that misleads: it would also demote on a
+    // count taken for somebody else's decision.
+    const deleted = await client.query(
+      'DELETE FROM curator_assignments WHERE id = $1 RETURNING user_id',
+      [assignmentId],
+    );
+    if (deleted.rowCount === 0) {
+      unusable = await rollbackQuietly(client);
+      res.status(404).json({ error: 'Assignment not found' });
+      return;
+    }
 
     // Check if user has any remaining assignments
-    const remainingResult = await pool.query(
+    const remainingResult = await client.query(
       'SELECT COUNT(*) as count FROM curator_assignments WHERE user_id = $1',
       [userId],
     );
 
-    const remaining = parseInt(remainingResult.rows[0].count);
-    let roleReverted = false;
+    remaining = parseInt(remainingResult.rows[0].count);
 
     // Revert role to 'user' if no remaining assignments (and not admin)
-    if (remaining === 0) {
-      const userResult = await pool.query('SELECT role FROM users WHERE id = $1', [userId]);
-      if (userResult.rows.length > 0 && userResult.rows[0].role === 'curator') {
-        await pool.query("UPDATE users SET role = 'user' WHERE id = $1", [userId]);
-        roleReverted = true;
-      }
+    if (remaining === 0 && locked.rows[0]?.role === 'curator') {
+      await client.query("UPDATE users SET role = 'user' WHERE id = $1", [userId]);
+      roleReverted = true;
     }
 
-    await pool.query('COMMIT');
-
-    res.json({
-      success: true,
-      assignmentId,
-      userId,
-      remainingAssignments: remaining,
-      roleReverted,
-    });
+    await client.query('COMMIT');
   } catch (error) {
-    await pool.query('ROLLBACK');
+    // A client whose ROLLBACK also failed must be destroyed, not pooled: it
+    // would otherwise carry an open transaction into the next request.
+    unusable = await rollbackQuietly(client);
     throw error;
+  } finally {
+    client.release(unusable);
   }
+
+  res.json({
+    success: true,
+    assignmentId,
+    userId,
+    remainingAssignments: remaining,
+    roleReverted,
+  });
 }
 
 /**

--- a/backend/src/controllers/admin/syncController.categories.test.ts
+++ b/backend/src/controllers/admin/syncController.categories.test.ts
@@ -11,7 +11,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('../../db/index.js', () => ({
-  pool: { query: vi.fn() },
+  pool: { query: vi.fn(), connect: vi.fn() },
+  rollbackQuietly: async (c: { query: (s: string) => unknown }) => {
+    try { await c.query('ROLLBACK'); return undefined; } catch (e) { return e as Error; }
+  },
 }));
 
 vi.mock('../experience/waitingCounts.js', () => ({
@@ -20,9 +23,12 @@ vi.mock('../experience/waitingCounts.js', () => ({
 
 import { pool } from '../../db/index.js';
 import { waitingCountsByCategory } from '../experience/waitingCounts.js';
-import { getCategories } from './syncController.js';
+import { getCategories, reorderCategories } from './syncController.js';
 
 const mockedQuery = pool.query as unknown as ReturnType<typeof vi.fn>;
+const mockedConnect = pool.connect as unknown as ReturnType<typeof vi.fn>;
+/** The same mock, in its callable shape: `vi.fn()`'s own type is not callable. */
+const answer = mockedQuery as unknown as (sql: string, params?: unknown[]) => Promise<unknown>;
 const mockedCounts = waitingCountsByCategory as unknown as ReturnType<typeof vi.fn>;
 
 const SOURCES = [
@@ -89,5 +95,75 @@ describe('getCategories', () => {
     expect(payload[1].waiting).toBeNull();
     expect(errorSpy).toHaveBeenCalled();
     errorSpy.mockRestore();
+  });
+});
+
+/**
+ * The order the panel writes is one transaction, and it has to hold one
+ * connection for its whole length — #532.
+ *
+ * `pool.query('BEGIN')` reads as a transaction and is not one: pg.Pool checks
+ * out an arbitrary idle client, runs the BEGIN on it and releases it with the
+ * transaction still open. Here the order is written one row at a time, so a run
+ * that half-applied would leave two sources sharing a `display_priority` and one
+ * with none — and the stray transaction on the released client would take a
+ * different request's writes down with it when something eventually rolls back.
+ */
+describe('reorderCategories', () => {
+  beforeEach(() => {
+    mockedQuery.mockReset();
+    mockedConnect.mockReset();
+    mockedQuery.mockResolvedValue({ rows: [], rowCount: 1 });
+  });
+
+  /** The client the handler must pin; its statements answer from the pool's mock. */
+  function pinClient() {
+    const client = {
+      query: vi.fn((sql: string, params?: unknown[]) => answer(sql, params)),
+      release: vi.fn(),
+    };
+    mockedConnect.mockResolvedValue(client);
+    return client;
+  }
+
+  it('writes every position on the pinned client, BEGIN through COMMIT', async () => {
+    const client = pinClient();
+    const res = makeRes();
+
+    // Public Art & Monuments first, then UNESCO, then the museums.
+    await reorderCategories({ body: { categoryIds: [3, 1, 2] } } as never, res as never);
+
+    const onClient = client.query.mock.calls.map(call => String(call[0]));
+    expect(onClient[0]).toBe('BEGIN');
+    expect(onClient.at(-1)).toBe('COMMIT');
+    expect(onClient.filter(sql => /UPDATE experience_categories/i.test(sql))).toHaveLength(3);
+    expect(client.release).toHaveBeenCalledTimes(1);
+    expect(res.json).toHaveBeenCalledWith({ success: true, order: [3, 1, 2] });
+  });
+
+  it('rolls back and hands the connection back when a position fails', async () => {
+    const client = pinClient();
+    mockedQuery
+      .mockResolvedValueOnce({ rows: [] })  // BEGIN
+      .mockRejectedValueOnce(new Error('deadlock detected'));
+
+    await expect(reorderCategories(
+      { body: { categoryIds: [3, 1, 2] } } as never, makeRes() as never,
+    )).rejects.toThrow('deadlock detected');
+
+    const onClient = client.query.mock.calls.map(call => String(call[0]));
+    expect(onClient).toContain('ROLLBACK');
+    expect(client.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('never opens the transaction before the input is known to be a list', async () => {
+    const client = pinClient();
+    const res = makeRes();
+
+    await reorderCategories({ body: {} } as never, res as never);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(mockedConnect).not.toHaveBeenCalled();
+    expect(client.query).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/controllers/admin/syncController.ts
+++ b/backend/src/controllers/admin/syncController.ts
@@ -7,7 +7,7 @@
 import { Request, Response } from 'express';
 import { isTerminalSyncStatus } from '../../services/sync/types.js';
 import { isCancellable } from '../../services/sync/syncOrchestrator.js';
-import { pool } from '../../db/index.js';
+import { pool, rollbackQuietly } from '../../db/index.js';
 import { waitingCountsByCategory } from '../experience/waitingCounts.js';
 import {
   syncUnescoSites,
@@ -646,18 +646,29 @@ export async function reorderCategories(req: Request, res: Response): Promise<vo
     return;
   }
 
-  await pool.query('BEGIN');
+  // One client, not pool.query('BEGIN') — see the note in curationController:
+  // pg.Pool hands out an arbitrary idle client per call, so a transaction has
+  // to be pinned or its statements land on different connections. The order is
+  // written one row at a time, so a half-applied run leaves two sources sharing
+  // a display_priority and one with none.
+  const client = await pool.connect();
+  let unusable: Error | undefined;
   try {
+    await client.query('BEGIN');
     for (let i = 0; i < categoryIds.length; i++) {
-      await pool.query(
+      await client.query(
         'UPDATE experience_categories SET display_priority = $1 WHERE id = $2',
         [i + 1, categoryIds[i]]
       );
     }
-    await pool.query('COMMIT');
+    await client.query('COMMIT');
   } catch (err) {
-    await pool.query('ROLLBACK');
+    // A client whose ROLLBACK also failed must be destroyed, not pooled: it
+    // would otherwise carry an open transaction into the next request.
+    unusable = await rollbackQuietly(client);
     throw err;
+  } finally {
+    client.release(unusable);
   }
 
   res.json({ success: true, order: categoryIds });

--- a/backend/src/controllers/experience/experienceLocationController.test.ts
+++ b/backend/src/controllers/experience/experienceLocationController.test.ts
@@ -27,7 +27,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('../../db/index.js', () => ({
-  pool: { query: vi.fn() },
+  pool: { query: vi.fn(), connect: vi.fn() },
+  rollbackQuietly: async (c: { query: (s: string) => unknown }) => {
+    try { await c.query('ROLLBACK'); return undefined; } catch (e) { return e as Error; }
+  },
 }));
 
 import { pool } from '../../db/index.js';
@@ -44,14 +47,41 @@ import {
 import { offeredToReaderSql } from './experienceLifecycle.js';
 
 const mockedQuery = pool.query as unknown as ReturnType<typeof vi.fn>;
+const mockedConnect = pool.connect as unknown as ReturnType<typeof vi.fn>;
+/** The same mock, in its callable shape: `vi.fn()`'s own type is not callable. */
+const answer = mockedQuery as unknown as (sql: string, params?: unknown[]) => Promise<unknown>;
 
 function makeRes() {
   return { json: vi.fn(), status: vi.fn().mockReturnThis() };
 }
 
+/**
+ * The client a handler pins for its transaction (#532).
+ *
+ * Its statements are answered by the pool's mock, so a test that stubs a row
+ * stubs it for both and `sentSql()` below still sees everything the handler
+ * sent. What separates them is the client's own call list, which is what
+ * `clientSql()` reads: a statement is there only if it was addressed to this
+ * one connection.
+ */
+function pinClient() {
+  const client = {
+    query: vi.fn((sql: string, params?: unknown[]) => answer(sql, params)),
+    release: vi.fn(),
+  };
+  mockedConnect.mockReset();
+  mockedConnect.mockResolvedValue(client);
+  return client;
+}
+
 /** Every statement the handler sent, in order. */
 function sentSql(): string[] {
   return mockedQuery.mock.calls.map(call => String(call[0]));
+}
+
+/** What the pinned client was asked, in order. */
+function clientSql(client: ReturnType<typeof pinClient>): string[] {
+  return client.query.mock.calls.map(call => String(call[0]));
 }
 
 /** The one statement that reads the location table. */
@@ -130,6 +160,7 @@ describe('a visit outlives the point', () => {
   beforeEach(() => {
     mockedQuery.mockReset();
     mockedQuery.mockResolvedValue({ rows: [{ location_id: 1, visit_id: 3 }], rowCount: 1 });
+    pinClient();
   });
 
   it('counts a reader progress over the points still on offer', async () => {
@@ -224,6 +255,76 @@ describe('a visit outlives the point', () => {
     const counts = sentSql().filter(sql => /COUNT\(\*\) as count/i.test(sql));
     expect(counts).toHaveLength(1);
     expect(counts[0]).toMatch(/el\.missing_since IS NULL/);
+  });
+});
+
+/**
+ * A transaction has to hold one connection for its whole length — #532.
+ *
+ * `pool.query('BEGIN')` reads as a transaction and is not one: pg.Pool checks
+ * out an arbitrary idle client, runs the BEGIN on it and releases it with the
+ * transaction still open. The statements that follow may land on other
+ * connections, and a *different reader's* write that checks out the leaked
+ * client joins the stray transaction — to be rolled back with it. These two
+ * handlers write in bulk, so what a stray ROLLBACK undoes here is somebody
+ * else's tick beside a place they did visit.
+ *
+ * The assertion is therefore not "the statements ran" but "they ran on the one
+ * client the handler checked out", which a return to `pool.query('BEGIN')`
+ * fails outright: nothing is addressed to a client at all.
+ */
+describe('a transaction is pinned to one connection', () => {
+  beforeEach(() => {
+    mockedQuery.mockReset();
+    mockedQuery.mockResolvedValue({ rows: [{ id: 1, count: '0' }], rowCount: 1 });
+  });
+
+  it('marks every location on the pinned client, BEGIN through COMMIT', async () => {
+    const client = pinClient();
+
+    await markAllLocationsVisited(
+      { params: { experienceId: '42' }, query: {}, user: { id: 5 } } as never,
+      makeRes() as never);
+
+    const onClient = clientSql(client);
+    expect(onClient[0]).toBe('BEGIN');
+    expect(onClient.at(-1)).toBe('COMMIT');
+    expect(onClient.filter(sql => /INSERT INTO user_visited_locations/i.test(sql))).toHaveLength(1);
+    expect(onClient.filter(sql => /INSERT INTO user_visited_experiences/i.test(sql))).toHaveLength(1);
+    expect(client.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('takes the visits back on the pinned client, both deletes included', async () => {
+    const client = pinClient();
+
+    await unmarkAllLocationsVisited(
+      { params: { experienceId: '42' }, query: {}, user: { id: 5 } } as never,
+      makeRes() as never);
+
+    const onClient = clientSql(client);
+    expect(onClient[0]).toBe('BEGIN');
+    expect(onClient.at(-1)).toBe('COMMIT');
+    expect(onClient.filter(sql => /DELETE FROM user_visited_locations/i.test(sql))).toHaveLength(1);
+    expect(onClient.filter(sql => /DELETE FROM user_visited_experiences/i.test(sql))).toHaveLength(1);
+    expect(client.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('rolls back and hands the connection back when a statement fails', async () => {
+    const client = pinClient();
+    mockedQuery
+      .mockResolvedValueOnce({ rows: [{ id: 1 }] })  // the points on offer
+      .mockResolvedValueOnce({ rows: [] })           // BEGIN
+      .mockRejectedValueOnce(new Error('insert failed'));
+
+    await expect(markAllLocationsVisited(
+      { params: { experienceId: '42' }, query: {}, user: { id: 5 } } as never,
+      makeRes() as never)).rejects.toThrow('insert failed');
+
+    // Both halves matter: an unclosed transaction on a client nobody released
+    // is exactly the state this issue is about, and the release is what stops
+    // the next request from inheriting it.
+    expect(clientSql(client)).toContain('ROLLBACK');
+    expect(client.release).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/backend/src/controllers/experience/experienceLocationController.ts
+++ b/backend/src/controllers/experience/experienceLocationController.ts
@@ -5,7 +5,7 @@
  */
 
 import { Request, Response } from 'express';
-import { pool } from '../../db/index.js';
+import { pool, rollbackQuietly } from '../../db/index.js';
 import {
   hideLostSql,
   hideRefusedSql,
@@ -521,11 +521,17 @@ export async function markAllLocationsVisited(req: AuthenticatedRequest, res: Re
     return;
   }
 
-  // Mark locations as visited in a single transaction
-  await pool.query('BEGIN');
+  // Mark locations as visited in a single transaction, on one client — see the
+  // note in curationController: pg.Pool hands out an arbitrary idle client per
+  // call, so a transaction has to be pinned or its statements land on different
+  // connections, and the BEGIN goes back to the pool with nothing to close it.
+  const client = await pool.connect();
+  let unusable: Error | undefined;
   try {
+    await client.query('BEGIN');
+
     for (const loc of locationsResult.rows) {
-      await pool.query(`
+      await client.query(`
         INSERT INTO user_visited_locations (user_id, location_id, visited_at)
         VALUES ($1, $2, NOW())
         ON CONFLICT (user_id, location_id) DO NOTHING
@@ -533,16 +539,20 @@ export async function markAllLocationsVisited(req: AuthenticatedRequest, res: Re
     }
 
     // Also mark the experience itself as visited for backward compatibility
-    await pool.query(`
+    await client.query(`
       INSERT INTO user_visited_experiences (user_id, experience_id, visited_at)
       VALUES ($1, $2, NOW())
       ON CONFLICT (user_id, experience_id) DO NOTHING
     `, [userId, experienceId]);
 
-    await pool.query('COMMIT');
+    await client.query('COMMIT');
   } catch (error) {
-    await pool.query('ROLLBACK');
+    // A client whose ROLLBACK also failed must be destroyed, not pooled: it
+    // would otherwise carry an open transaction into the next request.
+    unusable = await rollbackQuietly(client);
     throw error;
+  } finally {
+    client.release(unusable);
   }
 
   res.json({
@@ -569,13 +579,21 @@ export async function unmarkAllLocationsVisited(req: AuthenticatedRequest, res: 
   const experienceId = parseInt(String(req.params.experienceId));
   const regionId = req.query.regionId ? parseInt(String(req.query.regionId)) : null;
 
-  await pool.query('BEGIN');
+  // One client for the whole transaction, as in `markAllLocationsVisited` above.
+  // This half is the sharper one: its body is deletes, so a ROLLBACK that
+  // reached a shared connection would resurrect visits a different reader had
+  // just cleared.
+  const client = await pool.connect();
+  let unusable: Error | undefined;
+  let locationsUnmarked: number;
   try {
+    await client.query('BEGIN');
+
     let result;
 
     if (regionId) {
       // Only unmark locations that are in the specified region
-      result = await pool.query(`
+      result = await client.query(`
         DELETE FROM user_visited_locations
         WHERE user_id = $1 AND location_id IN (
           SELECT el.id
@@ -586,7 +604,7 @@ export async function unmarkAllLocationsVisited(req: AuthenticatedRequest, res: 
       `, [userId, experienceId, regionId]);
     } else {
       // Unmark all locations
-      result = await pool.query(`
+      result = await client.query(`
         DELETE FROM user_visited_locations
         WHERE user_id = $1 AND location_id IN (
           SELECT id FROM experience_locations WHERE experience_id = $2
@@ -598,7 +616,7 @@ export async function unmarkAllLocationsVisited(req: AuthenticatedRequest, res: 
     // the note there. It matters on the region-scoped branch above, which
     // clears one region's visits and can leave a withdrawn point's visit
     // standing somewhere else.
-    const remainingResult = await pool.query(`
+    const remainingResult = await client.query(`
       SELECT COUNT(*) as count
       FROM user_visited_locations uvl
       JOIN experience_locations el ON uvl.location_id = el.id
@@ -607,24 +625,29 @@ export async function unmarkAllLocationsVisited(req: AuthenticatedRequest, res: 
     `, [userId, experienceId]);
 
     if (parseInt(remainingResult.rows[0].count) === 0) {
-      await pool.query(
+      await client.query(
         'DELETE FROM user_visited_experiences WHERE user_id = $1 AND experience_id = $2',
         [userId, experienceId]
       );
     }
 
-    await pool.query('COMMIT');
-
-    res.json({
-      success: true,
-      experienceId,
-      regionId,
-      locationsUnmarked: result.rowCount || 0,
-    });
+    await client.query('COMMIT');
+    locationsUnmarked = result.rowCount || 0;
   } catch (error) {
-    await pool.query('ROLLBACK');
+    // A client whose ROLLBACK also failed must be destroyed, not pooled: it
+    // would otherwise carry an open transaction into the next request.
+    unusable = await rollbackQuietly(client);
     throw error;
+  } finally {
+    client.release(unusable);
   }
+
+  res.json({
+    success: true,
+    experienceId,
+    regionId,
+    locationsUnmarked,
+  });
 }
 
 /**

--- a/backend/src/db/pooledTransactionLint.test.ts
+++ b/backend/src/db/pooledTransactionLint.test.ts
@@ -1,0 +1,57 @@
+/**
+ * The lint rule that keeps a transaction on one connection — #532.
+ *
+ * The rule is the only part of that fix that has to keep working without
+ * anybody thinking about it, and a selector is easy to break silently: tighten
+ * it and it stops reporting, loosen it and it reports SQL that is not a
+ * transaction at all. Both directions are asserted here, against the repo's own
+ * `eslint.config.mjs` rather than a copy of the selector — a test that restated
+ * the pattern would agree with itself while the gate let anything through.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ESLint } from 'eslint';
+
+const eslint = new ESLint();
+
+/** What the transaction rule says about one snippet, if anything. */
+async function reported(code: string): Promise<string[]> {
+  const [result] = await eslint.lintText(code, { filePath: 'src/lint-fixture.ts' });
+  return result.messages
+    .filter(message => message.ruleId === 'no-restricted-syntax')
+    .map(message => message.message);
+}
+
+const HEADER = "import { pool } from './index.js';\n";
+
+describe('a transaction opened through the pool fails the lint', () => {
+  it.each([
+    ["pool.query('BEGIN')", "await pool.query('BEGIN');"],
+    ['a template literal', 'await pool.query(`BEGIN`);'],
+    ['lower case and padding', "await pool.query('  begin ');"],
+    ['START TRANSACTION, the synonym', "await pool.query('START TRANSACTION');"],
+    ['ABORT, the other synonym', "await pool.query('ABORT');"],
+    ['COMMIT on its own', "await pool.query('COMMIT');"],
+    ['ROLLBACK on its own', "await pool.query('ROLLBACK');"],
+    ['SAVEPOINT', "await pool.query('SAVEPOINT before_the_writes');"],
+  ])('reports %s', async (_name, statement) => {
+    const messages = await reported(`${HEADER}async function f() { ${statement} }\n`);
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toContain('pool.connect()');
+  });
+
+  it.each([
+    ['an ordinary read', "await pool.query('SELECT 1');"],
+    ['the same verbs on a pinned client', 'await client.query(`BEGIN`);'],
+    // The selector reads the opening quasi only. Interpolated CASE/END is
+    // everywhere in this codebase's SQL, and its trailing quasi begins with the
+    // word Postgres also accepts for COMMIT.
+    ['CASE … END around an interpolation', 'await pool.query(`SELECT CASE WHEN a THEN ${x} END FROM t`);'],
+    ['a transaction verb quoted inside a value', "await pool.query(`SELECT ${x}, 'ROLLBACK' AS word`);"],
+    ['a word that merely starts the same way', 'await pool.query(`SELECT ${x} FROM begin_of_year`);'],
+  ])('leaves %s alone', async (_name, statement) => {
+    const code = `${HEADER}declare const client: { query: (s: string) => Promise<void> };\n`
+      + `declare const x: number;\nasync function f() { ${statement} }\n`;
+    expect(await reported(code)).toEqual([]);
+  });
+});

--- a/docs/tech/authentication.md
+++ b/docs/tech/authentication.md
@@ -201,6 +201,30 @@ docker exec -i tyr-ng-db psql -U postgres -d track_regions \
         AND email_verified = true;"
 ```
 
+### The curator role follows the assignments
+
+Nobody sets `role = 'curator'` by hand. An admin granting the first
+scope in `curator_assignments` promotes the account, and revoking the
+last one takes the role back — the role is a summary of the rows, and
+each half of the pair is useless alone: an assignment whose owner is
+back to `user` is locked out of every curation screen by
+`requireCurator`, and a `curator` with no rows left has authority over
+nothing.
+
+Both writes therefore take `SELECT role FROM users WHERE id = $1 FOR NO
+KEY UPDATE` as the first statement of their transaction
+(`USER_ROLE_LOCK` in `controllers/admin/curatorController.ts`), and
+decide the promotion from *that* read rather than from the reference
+check before it. Two admins acting on one account at the same moment
+otherwise leave the halves disagreeing: two revokes each counting the
+other's assignment as still standing and neither demoting, or a grant
+deciding "already a curator" against a role a concurrent revoke has
+just taken away. The mode is the one `db/locks.ts` argues for — it
+self-conflicts, so the two serialise, and it stays compatible with the
+key share `curator_assignments`' foreign key takes on the same row.
+Granting and revoking lock in the same order, which is what keeps them
+from deadlocking rather than merely serialising.
+
 ## API Endpoints
 
 ### Authentication

--- a/docs/tech/development-guide.md
+++ b/docs/tech/development-guide.md
@@ -140,6 +140,25 @@ services/
 - Use raw `pool.query()` with parameterized SQL for PostGIS geometry operations.
 - **Never** concatenate user input into SQL strings.
 - When you need `SET`/`RESET` to apply to the same connection as your query, use `const client = await pool.connect()` + `client.query()` + `client.release()`. `pool.query()` grabs a random connection each time.
+- **A transaction is pinned to one client, always.** `pool.query('BEGIN')` is not a transaction: pg.Pool checks out an arbitrary idle client, runs the BEGIN on it and releases it with the transaction still open. The statements that follow may land on other connections, and a *different request* that checks out the leaked client runs its own writes inside that stray transaction — to be rolled back with it. The shape, as in `curationController.ts`'s `editExperience`:
+
+  ```ts
+  const client = await pool.connect();
+  let unusable: Error | undefined;
+  try {
+    await client.query('BEGIN');
+    // ... every statement of the transaction on `client`
+    await client.query('COMMIT');
+  } catch (error) {
+    // A client whose ROLLBACK also failed must be destroyed, not pooled.
+    unusable = await rollbackQuietly(client);
+    throw error;
+  } finally {
+    client.release(unusable);
+  }
+  ```
+
+  Respond *after* the `finally`, not inside the `try` — a `res.json()` before the release leaves the connection out on any path that throws between the two. `rollbackQuietly` (`db/index.ts`) is what keeps a failing ROLLBACK from replacing the error the caller needs to see, and its return value is the argument `release()` needs to destroy a client that can no longer be trusted. The rule is enforced: `no-restricted-syntax` in `backend/eslint.config.mjs` fails the lint on `pool.query('BEGIN' | 'COMMIT' | 'ROLLBACK' | 'SAVEPOINT' | 'RELEASE' …)`, because the prose form of it lived in a comment for months while four call sites went on doing it (#532).
 
 ### Backend Gotchas
 


### PR DESCRIPTION
## Description

Five handlers opened a transaction with `pool.query('BEGIN')`. That call checks out an arbitrary idle client from `pg.Pool`, runs `BEGIN` on it and releases it **with the transaction still open** — `pg-pool` does not reset a released client. The statements that follow each check out whatever client is free, so they may or may not be inside that transaction, and a *different request* that checks out the leaked client runs its own writes inside it, to be undone when something eventually rolls back.

The damaging direction is not "the handler is not atomic" — it is that somebody else's writes join the stray transaction and die with it. A reader who unticks their visit to the Classical Gardens of Suzhou sees it confirmed and finds the tick back after the next refetch, because another reader's "mark all visited" on the Dolomites hit an error on the connection they shared.

Fixed in all five, in the shape three sibling controllers already use — one client held for the whole transaction, `rollbackQuietly`'s verdict handed to `release()` so a client whose ROLLBACK also failed is destroyed rather than pooled, and the response sent after the `finally`:

| file | handler | what the transaction holds together |
|---|---|---|
| `experienceLocationController.ts` | `markAllLocationsVisited` | the per-location visits and the experience-level row |
| `experienceLocationController.ts` | `unmarkAllLocationsVisited` | the deletes, and the count that decides whether the experience-level row goes |
| `curatorController.ts` | `insertAssignmentAndPromote` | the scope row and the promotion that answers for it |
| `curatorController.ts` | `revokeCuratorAssignment` | the delete, the remaining-scope count, and the demotion |
| `syncController.ts` | `reorderCategories` | one `display_priority` per source, written one row at a time |

The issue's fourth scope item asked for a guard so the pattern cannot come back: `no-restricted-syntax` in `backend/eslint.config.mjs` now fails the lint on `pool.query()` given any verb that only means something on the connection that opened it — `BEGIN`, `COMMIT`, `ROLLBACK`, `SAVEPOINT`, `RELEASE` and Postgres' synonyms `START TRANSACTION`, `END` and `ABORT` — in both the string and template-literal spellings. The template selector reads the opening quasi alone, so an interpolated `CASE … ${x} … END` is not mistaken for a transaction. `client.query('BEGIN')` and every non-transactional `pool.query()` are untouched, which is what makes an AST selector worth having over a grep. The rule exists because the prose form of it, written in `curationController.ts`, had been true for months while four call sites went on ignoring it.

### What the review round added

Both bot reviewers found that pinning the connection was necessary and not sufficient for the curator pair, and they were right — the fix grew to match the invariant this PR claims for it:

- **The `users` row is locked.** Granting and revoking a scope both decide the role from a count of what is left, and neither locked anything, so two admins acting on one account left the halves disagreeing — two revokes each counting the other's assignment as still standing and neither demoting, or a grant reading `curator` while a revoke committed the demotion, leaving a live assignment behind a `user` role that `requireCurator` turns away. `SELECT role FROM users WHERE id = $1 FOR NO KEY UPDATE` is now the first statement of both transactions, and the promotion is decided from that read rather than from the reference check outside it. Both lock in the same order, so they serialise rather than deadlock; the mode is the one `db/locks.ts` argues for.
- **A revoke that deletes nothing says so.** The read that finds the assignment runs before the transaction, so a concurrent revoke could leave this one deleting zero rows and still reporting success — and demoting on a count taken for somebody else's decision. The delete now carries `RETURNING user_id` and answers 404 when it removed nothing.
- **The lint rule covers Postgres' synonyms**, and reads the opening quasi only (both above).

## Related Issues

Fixes: #532

## How Was This Tested?

- **New tests** covering the invariant rather than the statements — that every write of the transaction is addressed to the one client the handler checked out, and that the client comes back on the failing path too: 3 in `experienceLocationController.test.ts`, 11 in a new `curatorController.test.ts` (including the lock's ordering on both handlers, the promotion following the locked read when it disagrees with the check before it, and the 404 on a delete that removed nothing), 3 in `syncController.categories.test.ts`. Each was run against the unfixed code first and fails there — 13 for the pinning, 4 more for the locking — so none of them is vacuous.
- **The lint rule has a test of its own**, `src/db/pooledTransactionLint.test.ts`: it lints snippets against the repo's own `eslint.config.mjs` rather than a restatement of the selector — eight spellings that must be reported, five that must not. Dropping `:first-child` from the config makes the `CASE … END` case fail.
- **The locking claims were checked against the development database**, not reasoned about: two `SELECT … FOR NO KEY UPDATE` on one `users` row conflict (the second, with `NOWAIT`, fails `55P03`), while the `FOR KEY SHARE` that `curator_assignments`' foreign key takes on that row is not blocked by it. Both probes ran inside rolled-back transactions.
- Existing coverage of the two visit handlers keeps passing unchanged: the mocked client answers from the pool's mock, so what a test stubs is still what the handler reads.
- `npm run check` — green (its Python gates run in the pinned `python:3.12-slim` container on this host, which has no 3.12).
- `TEST_REPORT_LOCAL=1 npm test` — 1295 backend + 543 frontend passing. `pytest` green in the same container.
- `npm run security:all` — Semgrep (Node and Python) 0 findings, Trivy clean, dependency audits clean. Node Semgrep re-run after the review round; the Python and image scans were not, since neither `cv-python` nor any dependency changed.
- `npm run test:e2e:smoke` — 7 passed, before and after the review round.

## Checklist
Before submitting your PR, please review the following:
- [x] Commit messages follow the standard template.
- [x] All commits are signed.
- [x] Related issues are mentioned in the description above.
- [x] Linter checks have been passed.

## Additional Comments (if any):

Two behaviours change slightly beyond the fix itself, both deliberate. The responses in `unmarkAllLocationsVisited` and `revokeCuratorAssignment` move out of the `try` block: a `res.json()` before the release would leave the connection checked out on any path that throws between the two. And each handler now holds one connection for the length of its transaction rather than borrowing one per statement — the same number of round trips, and the pool's 20 clients are not a new constraint at these volumes.

`verifyAssignmentReferences` loses its `role` column and its `userRole` return: with the promotion decided under the lock, an unlocked read of the role has no remaining caller, and leaving it would be an invitation to use it again.

Not in scope, and unchanged: the other reads that happen *before* each transaction — the locations on offer, the assignment being revoked — stay on the pool, as they do in the sibling controllers. They decide a 404 before there is a transaction to be in, and where that answer can go stale the statement inside the transaction now re-checks it.